### PR TITLE
testing new SqlExpressions overloads

### DIFF
--- a/src/FirebirdTests/TestExpressions/Main.cs
+++ b/src/FirebirdTests/TestExpressions/Main.cs
@@ -84,6 +84,11 @@ namespace TestExpressions
 				List<Author> result=dbCmd.Select(ev);
 				Console.WriteLine(ev.WhereExpression);
 				Console.WriteLine("Expected:{0} ; Selected:{1}, OK? {2}", expected, result.Count, expected==result.Count);
+				result = dbCmd.Select<Author>(qry => qry.Where(rn => rn.Birthday >= new DateTime(year, 1, 1) && rn.Birthday <= new DateTime(year, 12, 31)));
+				Console.WriteLine("Expected:{0} ; Selected:{1}, OK? {2}", expected, result.Count, expected == result.Count);
+				result = dbCmd.Select<Author>(rn => rn.Birthday >= new DateTime(year, 1, 1) && rn.Birthday <= new DateTime(year, 12, 31));
+				Console.WriteLine("Expected:{0} ; Selected:{1}, OK? {2}", expected, result.Count, expected == result.Count);
+
 				
 				// select authors from London, Berlin and Madrid : 6
 				expected=6;

--- a/src/PostgreSQLExpressionsTest/Main.cs
+++ b/src/PostgreSQLExpressionsTest/Main.cs
@@ -48,7 +48,7 @@ namespace PostgreSQLExpressionsTest
 			SqlExpressionVisitor<Author> ev = OrmLiteConfig.DialectProvider.ExpressionVisitor<Author>();
 									
 			using (IDbConnection db =
-			       "Server=localhost;Port=5432;User Id=postgres; Password=postgres; Database=jasperserver".OpenDbConnection())
+			       "Server=localhost;Port=5432;User Id=postgres; Password=postgres; Database=ormlite".OpenDbConnection())
 			using ( IDbCommand dbCmd = db.CreateCommand())
 			{
 				dbCmd.DropTable<Author>();

--- a/src/PostgreSQLExpressionsTest/PostgreSQLExpressionsTest.csproj
+++ b/src/PostgreSQLExpressionsTest/PostgreSQLExpressionsTest.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -18,7 +18,7 @@
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <Externalconsole>true</Externalconsole>
+    <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -49,7 +49,7 @@
     <Reference Include="ServiceStack.Text">
       <HintPath>..\..\lib\ServiceStack.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.XML" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />


### PR DESCRIPTION
thanks to Demis we now have two new overloads to select:

1.
result = dbCmd.Select<Author>(qry => qry.Where(rn => rn.Birthday >= new  DateTime(year, 1, 1) && rn.Birthday  new DateTime(year, 12, 31))); 

2.
result = dbCmd.Select<Author>(rn => rn.Birthday >= new DateTime(year, 1, 1)  && rn.Birthday <= new DateTime(year, 12, 31)); 
