### PR TITLE
Changed column definition for strings to text from VARCHAR.

### DIFF
--- a/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
@@ -40,10 +40,18 @@ namespace ServiceStack.OrmLite.PostgreSQL
 			string defaultValue)
 		{
 			string fieldDefinition = null;
-
 			if (fieldType == typeof(string))
 			{
-				fieldDefinition = string.Format(StringLengthColumnDefinitionFormat, fieldLength.GetValueOrDefault(DefaultStringLength));
+				if (fieldLength != null)
+				{
+					fieldDefinition = UseUnicode
+						? string.Format(base.StringLengthUnicodeColumnDefinitionFormat, fieldLength)
+						: string.Format(base.StringLengthNonUnicodeColumnDefinitionFormat, fieldLength);
+				}
+				else
+				{
+					fieldDefinition = StringLengthColumnDefinitionFormat;
+				}
 			}
 			else
 			{


### PR DESCRIPTION
From PostgreSQL documentation:
Tip: There is no performance difference among these three types (variable-length with limit, fixed-length -blank padded, variable unlimited length), apart from increased storage space when using the blank-padded type, and a few extra CPU cycles to check the length when storing into a length-constrained column. While character(n) has performance advantages in some other database systems, there is no such advantage in PostgreSQL; in fact character(n) is usually the slowest of the three because of its additional storage costs. In most situations text or character varying should be used instead.
