### PR TITLE
Exposing the ExecuteSql function

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteWriteExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteWriteExtensions.cs
@@ -143,7 +143,7 @@ namespace ServiceStack.OrmLite
             }
         }
 
-        internal static int ExecuteSql(this IDbCommand dbCmd, string sql)
+        public static int ExecuteSql(this IDbCommand dbCmd, string sql)
         {
             LogDebug(sql);
 


### PR DESCRIPTION
A simple helper function that is used internally but would be useful as a public extension.

I did not add any tests since that function is already well tested due to all of the write extensions using it.
