### PR TITLE
Enum Handling

### DIFF
--- a/src/ServiceStack.OrmLite.MySql.Tests/EnumTests.cs
+++ b/src/ServiceStack.OrmLite.MySql.Tests/EnumTests.cs
@@ -42,12 +42,21 @@ namespace ServiceStack.OrmLite.MySql.Tests
             {
                 con.CreateTable<TypeWithEnum>(true);
                 con.Save(new TypeWithEnum { Id = 1, EnumValue = SomeEnum.Value1 });
-                con.Save(new TypeWithEnum { Id = 2, EnumValue = SomeEnum.Value1});
+                con.Save(new TypeWithEnum { Id = 2, EnumValue = SomeEnum.Value1 });
                 con.Save(new TypeWithEnum { Id = 3, EnumValue = SomeEnum.Value2 });
+                con.Save(new TypeWithEnum { Id = 4, EnumValue = SomeEnum.Value3 });
 
                 var target = con.Select<TypeWithEnum>(q => q.EnumValue == SomeEnum.Value1);
-
                 Assert.AreEqual(2, target.Count());
+
+                target = con.Select<TypeWithEnum>(q => SomeEnum.Value1 == q.EnumValue);
+                Assert.AreEqual(2, target.Count());
+
+                target = con.Select<TypeWithEnum>(q => q.EnumValue != SomeEnum.Value2 && q.EnumValue != SomeEnum.Value3);
+                Assert.AreEqual(2, target.Count());
+
+                target = con.Select<TypeWithEnum>(q => q.EnumValue != SomeEnum.Value2);
+                Assert.AreEqual(3, target.Count());
             }
         }
 

--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/EnumTests.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/EnumTests.cs
@@ -45,10 +45,19 @@ namespace ServiceStack.OrmLite.PostgreSQL.Tests
                 con.Save(new TypeWithEnum { Id = 1, EnumValue = SomeEnum.Value1 });
                 con.Save(new TypeWithEnum { Id = 2, EnumValue = SomeEnum.Value1 });
                 con.Save(new TypeWithEnum { Id = 3, EnumValue = SomeEnum.Value2 });
+                con.Save(new TypeWithEnum { Id = 4, EnumValue = SomeEnum.Value3 });
 
                 var target = con.Select<TypeWithEnum>(q => q.EnumValue == SomeEnum.Value1);
-
                 Assert.AreEqual(2, target.Count());
+
+                target = con.Select<TypeWithEnum>(q => SomeEnum.Value1 == q.EnumValue);
+                Assert.AreEqual(2, target.Count());
+
+                target = con.Select<TypeWithEnum>(q => q.EnumValue != SomeEnum.Value2 && q.EnumValue != SomeEnum.Value3);
+                Assert.AreEqual(2, target.Count());
+
+                target = con.Select<TypeWithEnum>(q => q.EnumValue != SomeEnum.Value2);
+                Assert.AreEqual(3, target.Count());
             }
         }
 
@@ -95,6 +104,7 @@ namespace ServiceStack.OrmLite.PostgreSQL.Tests
     public class TypeWithEnum
     {
         public int Id { get; set; }
-        public SomeEnum EnumValue { get; set; } 
+        public SomeEnum EnumValue { get; set; }
+        public string TextCol { get; set; }
     }
 }

--- a/src/ServiceStack.OrmLite.SqlServerTests/EnumTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/EnumTests.cs
@@ -44,10 +44,19 @@ namespace ServiceStack.OrmLite.SqlServerTests
                 con.Save(new TypeWithEnum { Id = 1, EnumValue = SomeEnum.Value1 });
                 con.Save(new TypeWithEnum { Id = 2, EnumValue = SomeEnum.Value1 });
                 con.Save(new TypeWithEnum { Id = 3, EnumValue = SomeEnum.Value2 });
+                con.Save(new TypeWithEnum { Id = 4, EnumValue = SomeEnum.Value3 });
 
                 var target = con.Select<TypeWithEnum>(q => q.EnumValue == SomeEnum.Value1);
-
                 Assert.AreEqual(2, target.Count());
+
+                target = con.Select<TypeWithEnum>(q => SomeEnum.Value1 == q.EnumValue);
+                Assert.AreEqual(2, target.Count());
+
+                target = con.Select<TypeWithEnum>(q => q.EnumValue != SomeEnum.Value2 && q.EnumValue != SomeEnum.Value3);
+                Assert.AreEqual(2, target.Count());
+
+                target = con.Select<TypeWithEnum>(q => q.EnumValue != SomeEnum.Value2);
+                Assert.AreEqual(3, target.Count());
             }
         }
 

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -798,6 +798,9 @@ namespace ServiceStack.OrmLite
 
         public virtual DbType GetColumnDbType(Type valueType)
         {
+            if (valueType.IsEnum)
+                return DbTypeMap.ColumnDbTypeMap[typeof (string)];
+
             return DbTypeMap.ColumnDbTypeMap[valueType];
         }
 

--- a/tests/ServiceStack.OrmLite.Tests/EnumTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/EnumTests.cs
@@ -44,10 +44,19 @@ namespace ServiceStack.OrmLite.Tests
                 con.Save(new TypeWithEnum { Id = 1, EnumValue = SomeEnum.Value1 });
                 con.Save(new TypeWithEnum { Id = 2, EnumValue = SomeEnum.Value1 });
                 con.Save(new TypeWithEnum { Id = 3, EnumValue = SomeEnum.Value2 });
+                con.Save(new TypeWithEnum { Id = 4, EnumValue = SomeEnum.Value3 });
 
                 var target = con.Select<TypeWithEnum>(q => q.EnumValue == SomeEnum.Value1);
-
                 Assert.AreEqual(2, target.Count());
+
+                target = con.Select<TypeWithEnum>(q => SomeEnum.Value1 == q.EnumValue);
+                Assert.AreEqual(2, target.Count());
+
+                target = con.Select<TypeWithEnum>(q => q.EnumValue != SomeEnum.Value2 && q.EnumValue != SomeEnum.Value3);
+                Assert.AreEqual(2, target.Count());
+
+                target = con.Select<TypeWithEnum>(q => q.EnumValue != SomeEnum.Value2);
+                Assert.AreEqual(3, target.Count());
             }
         }
 


### PR DESCRIPTION
I modified the classes SqlExpressionVisitor and OrmLiteDialectProviderBase to be able to cope with enum values in select queries. All enum values are stored as and queried by string values. @angelcolmenares and @mythz: could you please review the changes I've made in the expression visitor. 

If you are OK with the changes I am going to merge the pull request and also close the issues #86 and #85 which are related to this pull request.
