### PR TITLE
SQL Server Update Bug

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServer/ServiceStack.OrmLite.SqlServer.csproj
+++ b/src/ServiceStack.OrmLite.SqlServer/ServiceStack.OrmLite.SqlServer.csproj
@@ -52,6 +52,10 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ServiceStack.Text, Version=3.9.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\ServiceStack.OrmLite.Firebird\bin\Debug\ServiceStack.Text.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerExpressionVisitor.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerExpressionVisitor.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Text;
+using ServiceStack.Text;
 
 namespace ServiceStack.OrmLite.SqlServer
 {
@@ -50,6 +52,30 @@ namespace ServiceStack.OrmLite.SqlServer
 	            skip + take);
 
 	        return retVal;
+        }
+
+        public override string ToUpdateStatement(T item, bool excludeDefaults = false)
+        {
+
+            var setFields = new StringBuilder();
+            var dialectProvider = OrmLiteConfig.DialectProvider;
+
+            foreach (var fieldDef in ModelDef.FieldDefinitions)
+            {
+                if (UpdateFields.Count > 0 && !UpdateFields.Contains(fieldDef.Name) || fieldDef.AutoIncrement) continue; // added
+                var value = fieldDef.GetValue(item);
+                if (excludeDefaults && (value == null || value.Equals(value.GetType().GetDefaultValue()))) continue; //GetDefaultValue?
+
+                fieldDef.GetQuotedValue(item);
+
+                if (setFields.Length > 0) setFields.Append(",");
+                setFields.AppendFormat("{0} = {1}",
+                    dialectProvider.GetQuotedColumnName(fieldDef.FieldName),
+                    dialectProvider.GetQuotedValue(value, fieldDef.FieldType));
+            }
+
+            return string.Format("UPDATE {0} SET {1} {2}",
+                                                dialectProvider.GetQuotedTableName(ModelDef), setFields, WhereExpression);
         }
 
         protected virtual void AssertValidSkipRowValues()

--- a/src/ServiceStack.OrmLite.SqlServerTests/UpdateTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/UpdateTests.cs
@@ -27,6 +27,31 @@ namespace ServiceStack.OrmLite.SqlServerTests
             }
         }
 
+        [Test]
+        public void Can_execute_update_only()
+        {
+            using (var con = ConnectionString.OpenDbConnection())
+            {
+                con.CreateTable<SimpleType>(true);
+                var obj = new SimpleType { Name = "Somename" };
+                con.Save(obj);
+                var storedObj = con.GetById<SimpleType>(con.GetLastInsertId());
+
+                Assert.AreEqual(obj.Name, storedObj.Name);
+
+                var ev = OrmLiteConfig.DialectProvider.ExpressionVisitor<SimpleType>();
+                ev.Update();
+                ev.Where(q => q.Id == storedObj.Id); 
+                storedObj.Name = "Someothername";
+
+                con.UpdateOnly(storedObj, ev);
+
+                var target = con.GetById<SimpleType>(storedObj.Id);
+
+                Assert.AreEqual("Someothername", target.Name);
+            }
+        }
+
 
         [Test]
         public void Can_execute_update()

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -605,7 +605,7 @@ namespace ServiceStack.OrmLite
                         continue;
                     }
 
-                    if (updateFields.Count > 0 && !updateFields.Contains(fieldDef.Name)) continue;
+                    if (updateFields.Count > 0 && !updateFields.Contains(fieldDef.Name) || fieldDef.AutoIncrement) continue;
                     if (sql.Length > 0) sql.Append(",");
                     sql.AppendFormat("{0} = {1}", GetQuotedColumnName(fieldDef.FieldName), fieldDef.GetQuotedValue(objWithProperties));
                 }


### PR DESCRIPTION
SQL Server does not allow identity columns to be updated. Any field that has the AutoIncrementAttribute set is now ignored when building the update statement in the SQL Server dialect.

@mythz Are you OK with the proposed solution?
