### PR TITLE
Column index cache

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteUtilExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteUtilExtensions.cs
@@ -46,11 +46,6 @@ namespace ServiceStack.OrmLite
 			{
                 // Create index cache
                 Dictionary<string, int> indexCache = new Dictionary<string, int>();
-                foreach (var fieldDef in fieldDefs)
-                {
-                    var index = dataReader.GetColumnIndex(fieldDef.FieldName);
-                    indexCache.Add(fieldDef.Name, index);
-                }
 				while (dataReader.Read())
 				{
 					var row = new T();

--- a/src/ServiceStack.OrmLite/OrmLiteWriteExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteWriteExtensions.cs
@@ -238,8 +238,21 @@ namespace ServiceStack.OrmLite
 			{
 				foreach (var fieldDef in fieldDefs)
 				{
-                    // [EDIT] Parameter indexCache and checking if is set, then use them else ask for every fielname.
-                    var index = indexCache == null ? dataReader.GetColumnIndex(fieldDef.FieldName) : indexCache[fieldDef.Name];
+                    // If index cache is set then try get value. If not present then get and store it.
+                    int index = NotFound;
+                    if (indexCache != null)
+                    {
+                        if (!indexCache.TryGetValue(fieldDef.Name, out index))
+                        {
+                            index = dataReader.GetColumnIndex(fieldDef.FieldName);
+                            indexCache.Add(fieldDef.Name, index);
+                        }
+                    }
+                    else
+                    {
+                        index = dataReader.GetColumnIndex(fieldDef.FieldName);
+                    }
+                       
 					if (index == NotFound) continue;
 					var value = dataReader.GetValue(index);
 					fieldDef.SetValue(objWithProperties, value);


### PR DESCRIPTION
Add index cache. We ask for column index only once, now.
Example:

class Type {
// many fields
}

Db.Select("Select field1 from ..."); // Take about 4000 ms
Or
Db.Select("Select field1, ... fieldN from ..."); // Take about 20 ms
With index cache
Db.Select("Select field1 from ..."); // take about 150ms

On 25 records.
