### PR TITLE
Adds failing test for ReadExtensions and Naming Strategy.

### DIFF
--- a/src/ServiceStack.OrmLite/Expressions/ReadExtensions.cs
+++ b/src/ServiceStack.OrmLite/Expressions/ReadExtensions.cs
@@ -120,7 +120,8 @@ namespace ServiceStack.OrmLite
 				{
 					var row = new T();					
 					for (int i = 0; i<dataReader.FieldCount; i++)
-					{						
+					{
+						//Bug: Not respecting the dialect's naming strategy
 						var fieldDef = fieldDefs.FirstOrDefault(
 							x => x.FieldName.ToUpper() == dataReader.GetName(i).ToUpper());
 
@@ -153,6 +154,7 @@ namespace ServiceStack.OrmLite
 						FieldDefinition fieldDef;
 						if (!fieldDefCache.TryGetValue(i, out fieldDef))
 						{
+							//Bug: Not respecting the dialect's naming strategy
 						 	fieldDef = fieldDefs.FirstOrDefault(
 								x => x.FieldName.ToUpper() == dataReader.GetName(i).ToUpper());
 							fieldDefCache[i] = fieldDef;

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableWithNamingStrategyTest.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableWithNamingStrategyTest.cs
@@ -101,6 +101,26 @@ namespace ServiceStack.OrmLite.Tests
 			OrmLiteConfig.DialectProvider.NamingStrategy= new OrmLiteNamingStrategyBase();
 		}
 		
+		[Test]
+		public void Can_get_data_from_TableWithUnderscoreSeparatedCompoundNamingStrategy_with_ReadConnectionExtension()
+		{
+			OrmLiteConfig.DialectProvider.NamingStrategy = new UnderscoreSeparatedCompoundNamingStrategy();
+
+			using (var db = ConnectionString.OpenDbConnection())
+			{
+				db.CreateTable<ModelWithOnlyStringFields>(true);
+				var m = new ModelWithOnlyStringFields
+							{
+								Id = "997",
+								AlbumId = "112",
+								AlbumName = "ElectroShip",
+								Name = "ReadConnectionExtensionFirst"
+							};
+				db.Save(m);
+				var modelFromDb = db.First<ModelWithOnlyStringFields>(x => x.Name == "ReadConnectionExtensionFirst");
+				Assert.AreEqual(m.AlbumName, modelFromDb.AlbumName);
+			}
+		}
 		
 		[Test]
 		public void Can_get_data_from_TableWithNamigStrategy_AfterChangingNamingStrategy()


### PR DESCRIPTION
I've written a failing test to show that this read extension will not deserialize correctly because it does not use the dialect's naming strategy. I suspect this is not the only extension method with this issue.
