### PR TITLE
Allow an empty or NULL list to generate valid SQL for SqlInValues

### DIFF
--- a/src/ServiceStack.OrmLite/SqlInValues.cs
+++ b/src/ServiceStack.OrmLite/SqlInValues.cs
@@ -1,4 +1,6 @@
 using System.Collections;
+using System.Linq;
+using System.Linq.Expressions;
 
 namespace ServiceStack.OrmLite
 {
@@ -6,13 +8,23 @@ namespace ServiceStack.OrmLite
 	{
 		private readonly IEnumerable values;
 
+        public int Count { get; private set; }
+
 		public SqlInValues(IEnumerable values)
 		{
 			this.values = values;
+
+            if(values != null)
+
+            foreach (var value in values)
+                ++Count;
 		}
 
 		public string ToSqlInString()
 		{
+            if(Count == 0)
+                return "NULL";
+
 			return OrmLiteUtilExtensions.SqlJoin(values);
 		}
 	}

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteUtilExtensionsTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteUtilExtensionsTests.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using ServiceStack.OrmLite;
+
+namespace ServiceStack.OrmLite.Tests
+{
+    public class OrmLiteUtilExtensionsTests : OrmLiteTestBase
+    {
+        [Test]
+        public void CanCreateStringInStatement()
+        {
+            var list = new string[] { "A", "B", "C" };
+
+            var sql = "IN ({0})".Params(list.SqlInValues());
+
+            Assert.AreEqual("IN ('A','B','C')", sql);
+        }
+
+        [Test]
+        public void CanCreateIntInStatement()
+        {
+            var list = new int[] { 1, 2, 3 };
+
+            var sql = "IN ({0})".Params(list.SqlInValues());
+
+            Assert.AreEqual("IN (1,2,3)", sql);
+        }
+
+        [Test]
+        public void CanCreateNullInStatementFromEmptyList()
+        {
+            var list = new string[] {};
+
+            var sql = "IN ({0})".Params(list.SqlInValues());
+
+            Assert.AreEqual("IN (NULL)", sql);
+        }
+    }
+}

--- a/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
+++ b/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
@@ -118,6 +118,7 @@
     <Compile Include="OrmLiteQueryTests.cs" />
     <Compile Include="LocalizationTests.cs" />
     <Compile Include="OrmLiteConnectionFactoryTests.cs" />
+    <Compile Include="OrmLiteUtilExtensionsTests.cs" />
     <Compile Include="ShippersExample.cs" />
     <Compile Include="NorthwindPerfTests.cs" />
     <Compile Include="OrmLiteComplexTypesTests.cs" />


### PR DESCRIPTION
Previously, an empty or null list would generate "IN ()" and now it
generates "IN (NULL)"  This is particular useful when generating an IN
list dynamically and you cannot be assured that the list will contain
any elements
