### PR TITLE
Miniprofiler + multiple db types == confused DialectProvider

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteConnection.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConnection.cs
@@ -87,6 +87,8 @@ namespace ServiceStack.OrmLite
 			if (isOpen) return;
 			
 			DbConnection.Open();
+            //so the internal connection is wrapped for example by miniprofiler
+            if(Factory.ConnectionFilter != null) { dbConnection = Factory.ConnectionFilter(dbConnection); }
 			isOpen = true;
 		}
 

--- a/src/ServiceStack.OrmLite/OrmLiteConnectionFactory.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConnectionFactory.cs
@@ -99,7 +99,9 @@ namespace ServiceStack.OrmLite
                 ? new OrmLiteConnection(this)
                 : OrmLiteConnection;
 
-            return ConnectionFilter(connection);
+            //moved setting up the ConnectionFilter to OrmLiteConnection.Open
+            //return ConnectionFilter(connection);
+            return connection;
         }
 
         public IDbConnection OpenDbConnection(string connectionKey)
@@ -112,7 +114,8 @@ namespace ServiceStack.OrmLite
                 ? new OrmLiteConnection(factory)
                 : factory.OrmLiteConnection;
 
-            connection = factory.ConnectionFilter(connection);
+            //moved setting up the ConnectionFilter to OrmLiteConnection.Open
+            //connection = factory.ConnectionFilter(connection);
             connection.Open();
 
             return connection;


### PR DESCRIPTION
Found another edge case:

The OrmLiteConnections created by OrmLiteConnectionFactory are wrapped by the factory's ConnectionFilter, if it's present. Therefore the return type from the factory isn't a OrmLiteConnection, and read/write extensions can't access the connection's DialectProvider.

This is a problem, when using multiple database types simultaneously, and using Miniprofiler at the same time. The last connection's dialect stays in the static DialectProvider attribute, therefore OrmLite won't be able to generate the right SQL for the rest of the connections.

Here is a repro: https://github.com/AkosLukacs/OrmLite_MiniProfiler_multiple_db_types
Just launch it, and go to /hello. 
Use the official OrmLite dll to make it fail, and the dll from the "@modifiedDlls" folder.

This commit solves this problem by wrapping the OrmLiteConnection's dbConnection property, not the OrmLiteConnection. Therefore the DialecProvider can be extracted from the OrmLiteConnection even when using Miniprofiler.
