### PR TITLE
Update NuGet packages for SQLite to match available 1.0.84.0 version.

### DIFF
--- a/src/ServiceStack.OrmLite.Sqlite32/packages.config
+++ b/src/ServiceStack.OrmLite.Sqlite32/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Data.SQLite" version="1.0.83.0" targetFramework="net35" />
+  <package id="System.Data.SQLite" version="1.0.84.0" targetFramework="net35" />
 </packages>

--- a/src/ServiceStack.OrmLite.Sqlite64/packages.config
+++ b/src/ServiceStack.OrmLite.Sqlite64/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Data.SQLite.x64" version="1.0.83.0" targetFramework="net35" />
+  <package id="System.Data.SQLite.x64" version="1.0.84.0" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
This is once again the only version available on NuGet.
