### PR TITLE
linq support for object[].Contains

### DIFF
--- a/tests/ServiceStack.OrmLite.Tests/ExpressionVisitorTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/ExpressionVisitorTests.cs
@@ -117,6 +117,22 @@ namespace ServiceStack.OrmLite.Tests
             Assert.AreEqual(2, target.Count);
         }
 
+        [Test]
+        public void Can_Select_using_Array_Contains()
+        {
+            var vals = new object[]{ TestEnum.Val0, TestEnum.Val1 };
+
+            var visitor1 = OrmLiteConfig.DialectProvider.ExpressionVisitor<TestType>();
+            visitor1.Where(q => vals.Contains(q.EnumCol));
+            var sql1 = visitor1.ToSelectStatement();
+
+            var visitor2 = OrmLiteConfig.DialectProvider.ExpressionVisitor<TestType>();
+            visitor2.Where(q => Sql.In(q.EnumCol, vals));
+            var sql2 = visitor2.ToSelectStatement();
+
+            Assert.AreEqual(sql1, sql2);
+        }
+
         private int MethodReturningInt(int val)
         {
             return val;


### PR DESCRIPTION
It would be nice to not have to expose the Sql class in every case.  In the case of the IN statement, object[].Contains seems just as functional as the Sql.In method.
