### PR TITLE
Expression NullReferenceException fix.

### DIFF
--- a/src/ServiceStack.OrmLite/Expressions/SqlExpressionVisitor.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpressionVisitor.cs
@@ -838,8 +838,8 @@ namespace ServiceStack.OrmLite
             var exp = m.Object as MemberExpression;
             return exp != null 
                 && exp.Expression != null 
-                && (m.Object as MemberExpression).Expression.Type == typeof(T)
-                && (m.Object as MemberExpression).Expression.NodeType == ExpressionType.Parameter;
+                && exp.Expression.Type == typeof(T)
+                && exp.Expression.NodeType == ExpressionType.Parameter;
         }
 
         protected virtual object VisitMethodCall(MethodCallExpression m)


### PR DESCRIPTION
When performing a method call in a Select statement, the
SqlExpressionVisitor checks if it is a Sql, Array or Column method call.
However a NullReferenceException is thrown when trying to do this:
db.Select(q=>q.DateStamp < DateTime.Now.AddMonths(-1));

Now the above call is properly expressed.
