### PR TITLE
Replace EscapeParam by GetQuotedParam

### DIFF
--- a/src/ServiceStack.OrmLite.MySql/MySqlDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.MySql/MySqlDialectProvider.cs
@@ -27,9 +27,9 @@ namespace ServiceStack.OrmLite.MySql
     	    base.DefaultValueFormat = " DEFAULT '{0}'";
         }
 
-        public override string EscapeParam(object paramValue)
+        public override string GetQuotedParam(string paramValue)
         {
-            return paramValue.ToString().Replace("\\", "\\\\").Replace("'", @"\'");
+            return "'" + paramValue.Replace("\\", "\\\\").Replace("'", @"\'") + "'";
         }
 
         public override IDbConnection CreateConnection(string connectionString, Dictionary<string, string> options)

--- a/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
@@ -95,10 +95,10 @@ namespace ServiceStack.OrmLite.PostgreSQL
 			return sql.ToString();
 		}		
 
-		public override string EscapeParam(object paramValue)
-		{
-			return paramValue.ToString().Replace("'", @"''");
-		}
+        public override string GetQuotedParam(string paramValue)
+        {
+            return "'" + paramValue.Replace("'", @"''") + "'";
+        }
 
 		public override IDbConnection CreateConnection(string connectionString, Dictionary<string, string> options)
 		{

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
@@ -27,6 +27,11 @@ namespace ServiceStack.OrmLite.SqlServer
 			base.InitColumnTypeMap();
 		}
 
+        public override string GetQuotedParam(string paramValue)
+        {
+            return (UseUnicode ? "N'" : "'") + paramValue.Replace("'", "''") + "'";
+        }
+
 		public override IDbConnection CreateConnection(string connectionString, Dictionary<string, string> options)
 		{
 			var isFullConnectionString = connectionString.Contains(";");
@@ -101,20 +106,10 @@ namespace ServiceStack.OrmLite.SqlServer
 			}
 		}
 
+
 		public override string GetQuotedValue(object value, Type fieldType)
 		{
 			if (value == null) return "NULL";
-
-            if (!fieldType.UnderlyingSystemType.IsValueType && fieldType != typeof(string))
-            {
-                if (TypeSerializer.CanCreateFromString(fieldType))
-                {
-                    return (UseUnicode ? "N'" : "'") + EscapeParam(TypeSerializer.SerializeToString(value)) + "'";
-                }
-
-                throw new NotSupportedException(
-                    string.Format("Property of type: {0} is not supported", fieldType.FullName));
-            }
 
 			if (fieldType == typeof(Guid))
 			{
@@ -133,7 +128,7 @@ namespace ServiceStack.OrmLite.SqlServer
 				return base.GetQuotedValue(boolValue ? 1 : 0, typeof(int));
 			}
 			if(fieldType == typeof(string)) {
-				return (UseUnicode ? "N'" : "'") + EscapeParam(value) + "'";
+                return GetQuotedParam(value.ToString());
 			}
             if (fieldType == typeof(byte[]))
             {

--- a/src/ServiceStack.OrmLite/Expressions/SqlExpressionVisitor.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpressionVisitor.cs
@@ -1168,13 +1168,13 @@ namespace ServiceStack.OrmLite
                     statement = string.Format("lower({0})", quotedColName);
                     break;
                 case "StartsWith":
-                    statement = string.Format("upper({0}) like '{1}%' ", quotedColName, OrmLiteConfig.DialectProvider.EscapeParam(args[0]).ToUpper());
+                    statement = string.Format("upper({0}) like {1} ", quotedColName, OrmLiteConfig.DialectProvider.GetQuotedParam(args[0].ToString().ToUpper() + "%"));
                     break;
                 case "EndsWith":
-                    statement = string.Format("upper({0}) like '%{1}'", quotedColName, OrmLiteConfig.DialectProvider.EscapeParam(args[0]).ToUpper());
+                    statement = string.Format("upper({0}) like {1}", quotedColName, OrmLiteConfig.DialectProvider.GetQuotedParam("%" + args[0].ToString().ToUpper()));
                     break;
                 case "Contains":
-                    statement = string.Format("upper({0}) like '%{1}%'", quotedColName, OrmLiteConfig.DialectProvider.EscapeParam(args[0]).ToUpper());
+                    statement = string.Format("upper({0}) like {1}", quotedColName, OrmLiteConfig.DialectProvider.GetQuotedParam("%" + args[0].ToString().ToUpper() + "%"));
                     break;
                 case "Substring":
                     var startIndex = Int32.Parse(args[0].ToString()) + 1;

--- a/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
@@ -25,7 +25,13 @@ namespace ServiceStack.OrmLite
 
         INamingStrategy NamingStrategy { get; set; }
 
-        string EscapeParam(object paramValue);
+        /// <summary>
+        /// Quote the string so that it can be used inside an SQL-expression
+        /// Escape quotes inside the string
+        /// </summary>
+        /// <param name="paramValue"></param>
+        /// <returns></returns>
+        string GetQuotedParam(string paramValue);
 
         object ConvertDbValue(object value, Type type);
 

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -301,7 +301,7 @@ namespace ServiceStack.OrmLite
             {
                 if (TypeSerializer.CanCreateFromString(fieldType))
                 {
-                    return "'" + EscapeParam(TypeSerializer.SerializeToString(value)) + "'";
+                    return OrmLiteConfig.DialectProvider.GetQuotedParam(TypeSerializer.SerializeToString(value));
                 }
 
                 throw new NotSupportedException(
@@ -318,15 +318,15 @@ namespace ServiceStack.OrmLite
                 return ((decimal)value).ToString(CultureInfo.InvariantCulture);
 
             return ShouldQuoteValue(fieldType)
-                    ? "'" + EscapeParam(value) + "'"
+                    ? OrmLiteConfig.DialectProvider.GetQuotedParam(value.ToString())
                     : value.ToString();
         }
 
         public abstract IDbConnection CreateConnection(string filePath, Dictionary<string, string> options);
 
-        public virtual string EscapeParam(object paramValue)
+        public virtual string GetQuotedParam(string paramValue)
         {
-            return paramValue.ToString().Replace("'", "''");
+            return "'" + paramValue.Replace("'", "''") + "'";
         }
 
         public virtual string GetQuotedTableName(ModelDefinition modelDef)


### PR DESCRIPTION
The reason I changed object to string argument was since needed to be used by 'like' and then string is more logical.

I deleted EscapeParam since not used anymore.
