### PR TITLE
Update tests/ServiceStack.OrmLite.Tests/ForeignKeyAttributeTests.cs

### DIFF
--- a/tests/ServiceStack.OrmLite.Tests/ForeignKeyAttributeTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/ForeignKeyAttributeTests.cs
@@ -100,7 +100,7 @@ namespace ServiceStack.OrmLite.Tests
         }
 
         [TestFixtureTearDown]
-        public void TearDwon()
+        public void TearDown()
         {
             using (var dbConn = ConnectionString.OpenDbConnection())
             {


### PR DESCRIPTION
Fixed typo on method:
[TestFixtureTearDown]
public void TearDwon() => TearDown()
