### PR TITLE
Fixed problem that SqlServer-unicode fix changed DefaultStringLength for Oracle

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
@@ -164,5 +164,23 @@ namespace ServiceStack.OrmLite.SqlServer
 			
 			return result > 0;
 		}
+
+        public override bool UseUnicode
+        {
+            get
+            {
+                return useUnicode;
+            }
+            set
+            {
+                useUnicode = value;
+                if (useUnicode && this.DefaultStringLength > 4000)
+                {
+                    this.DefaultStringLength = 4000;
+                }
+
+                // UpdateStringColumnDefinitions(); is called by changing DefaultStringLength 
+            }
+        }
 	}
 }

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -149,7 +149,7 @@ namespace ServiceStack.OrmLite
             set { paramString = value; }
         }
 
-        private bool useUnicode;
+        protected bool useUnicode;
         public virtual bool UseUnicode
         {
             get
@@ -181,11 +181,6 @@ namespace ServiceStack.OrmLite
             this.StringLengthColumnDefinitionFormat = useUnicode
                 ? StringLengthUnicodeColumnDefinitionFormat
                 : StringLengthNonUnicodeColumnDefinitionFormat;
-
-
-            this.defaultStringLength = useUnicode
-                ? 4000
-                : 8000;
 
             this.StringColumnDefinition = string.Format(
                 this.StringLengthColumnDefinitionFormat, DefaultStringLength);


### PR DESCRIPTION
Had to make useUnicode protected, is this ok?
