### PR TITLE
Sql Params standardized names

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle.Tests/OracleParamTests.cs
+++ b/src/ServiceStack.OrmLite.Oracle.Tests/OracleParamTests.cs
@@ -28,15 +28,15 @@ namespace ServiceStack.OrmLite.Oracle.Tests
                 DropAndCreateTables(db);
                 var dateTimeNow =new DateTime( DateTime.Now.Year,  DateTime.Now.Month,  DateTime.Now.Day);
 
-                db.InsertParameterized(new ParamTestBO() { Id = 1, Double = 0.001, Int = 100, Info = "One", NullableBool = null, DateTime = dateTimeNow });
-                db.InsertParameterized(new ParamTestBO() { Id = 2, Double = 0.002, Int = 200, Info = "Two", NullableBool = true, DateTime = dateTimeNow });
-                db.InsertParameterized(new ParamTestBO() { Id = 3, Double = 0.003, Int = 300, Info = "Three", NullableBool = false, DateTime = dateTimeNow.AddDays(23) });
-                db.InsertParameterized(new ParamTestBO() { Id = 4, Double = 0.004, Int = 400, Info = "Four", NullableBool = null });
+                db.InsertParam(new ParamTestBO() { Id = 1, Double = 0.001, Int = 100, Info = "One", NullableBool = null, DateTime = dateTimeNow });
+                db.InsertParam(new ParamTestBO() { Id = 2, Double = 0.002, Int = 200, Info = "Two", NullableBool = true, DateTime = dateTimeNow });
+                db.InsertParam(new ParamTestBO() { Id = 3, Double = 0.003, Int = 300, Info = "Three", NullableBool = false, DateTime = dateTimeNow.AddDays(23) });
+                db.InsertParam(new ParamTestBO() { Id = 4, Double = 0.004, Int = 400, Info = "Four", NullableBool = null });
 
-                var bo1 = db.SelectParameterized<ParamTestBO>(q => q.Id == 1).Single();
-                var bo2 = db.SelectParameterized<ParamTestBO>(q => q.Id == 2).Single();
-                var bo3 = db.SelectParameterized<ParamTestBO>(q => q.Id == 3).Single();
-                var bo4 = db.SelectParameterized<ParamTestBO>(q => q.Id == 4).Single();
+                var bo1 = db.SelectParam<ParamTestBO>(q => q.Id == 1).Single();
+                var bo2 = db.SelectParam<ParamTestBO>(q => q.Id == 2).Single();
+                var bo3 = db.SelectParam<ParamTestBO>(q => q.Id == 3).Single();
+                var bo4 = db.SelectParam<ParamTestBO>(q => q.Id == 4).Single();
 
                 Assert.AreEqual(1, bo1.Id);
                 Assert.AreEqual(2, bo2.Id);
@@ -78,7 +78,9 @@ namespace ServiceStack.OrmLite.Oracle.Tests
                 DropAndCreateTables(db);
 
                 var bo1 = new ParamTestBO() { Id = 1, Double = 0.001, Int = 100, Info = "One", NullableBool = true };
-                db.InsertParameterized(bo1);
+                var bo2 = new ParamTestBO() { Id = 2, Double = 0.002, Int = 200, Info = "Two", NullableBool = true, DateTime = DateTime.Now };
+                db.InsertParam(bo1);
+                db.InsertParam(bo2);
 
                 bo1.Double = 0.01;
                 bo1.Int = 10000;
@@ -86,7 +88,7 @@ namespace ServiceStack.OrmLite.Oracle.Tests
                 bo1.NullableBool = null;
                 bo1.DateTime = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day);
 
-                db.UpdateParameterized(bo1);
+                db.UpdateParam(bo1);
 
                 var bo1Check = db.GetById<ParamTestBO>(1);
 
@@ -94,6 +96,23 @@ namespace ServiceStack.OrmLite.Oracle.Tests
                 Assert.AreEqual(bo1.Int, bo1Check.Int);
                 Assert.AreEqual(bo1.Info, bo1Check.Info);
                 Assert.AreEqual(bo1.DateTime, bo1Check.DateTime);
+
+
+                Assert.GreaterOrEqual(DateTime.Now, bo2.DateTime);
+
+                bo2.Info = "TwoUpdated";
+                bo2.Int = 9923;
+                bo2.NullableBool = false;
+                bo2.DateTime = DateTime.Now.AddDays(10);
+
+                db.UpdateParam(bo2);
+
+                var bo2Check = db.GetById<ParamTestBO>(2);
+
+                Assert.Less(DateTime.Now, bo2.DateTime);
+                Assert.AreEqual("TwoUpdated", bo2Check.Info);
+                Assert.AreEqual(9923, bo2Check.Int);
+                Assert.AreEqual(false, bo2Check.NullableBool);
             }
         }
 
@@ -112,9 +131,9 @@ namespace ServiceStack.OrmLite.Oracle.Tests
                 Assert.IsNotNull(db.Select<ParamTestBO>(q => q.Id == 2).FirstOrDefault());
                 Assert.IsNotNull(db.Select<ParamTestBO>(q => q.Id == 3).FirstOrDefault());
 
-                db.DeleteByIdParametized<ParamTestBO>(1);
-                db.DeleteByIdParametized<ParamTestBO>(2);
-                db.DeleteByIdParametized<ParamTestBO>(3);
+                db.DeleteByIdParam<ParamTestBO>(1);
+                db.DeleteByIdParam<ParamTestBO>(2);
+                db.DeleteByIdParam<ParamTestBO>(3);
 
                 Assert.IsNull(db.Select<ParamTestBO>(q => q.Id == 1).FirstOrDefault());
                 Assert.IsNull(db.Select<ParamTestBO>(q => q.Id == 2).FirstOrDefault());
@@ -133,9 +152,9 @@ namespace ServiceStack.OrmLite.Oracle.Tests
                 db.Insert(new ParamTestBO() { Id = 2, Info = "Item2" });
                 db.Insert(new ParamTestBO() { Id = 3, Info = "Item3" });
 
-                Assert.AreEqual("Item1", db.GetByIdParameterized<ParamTestBO>(1).Info);
-                Assert.AreEqual("Item2", db.GetByIdParameterized<ParamTestBO>(2).Info);
-                Assert.AreEqual("Item3", db.GetByIdParameterized<ParamTestBO>(3).Info);
+                Assert.AreEqual("Item1", db.GetByIdParam<ParamTestBO>(1).Info);
+                Assert.AreEqual("Item2", db.GetByIdParam<ParamTestBO>(2).Info);
+                Assert.AreEqual("Item3", db.GetByIdParam<ParamTestBO>(3).Info);
             }
         }
 
@@ -146,20 +165,20 @@ namespace ServiceStack.OrmLite.Oracle.Tests
             {
                 DropAndCreateTables(db);
 
-                db.InsertParameterized(new ParamTestBO() { Id = 1, Double = 0.001, Int = 100, Info = "One", NullableBool = null });
-                db.InsertParameterized(new ParamTestBO() { Id = 2, Double = 0.002, Int = 200, Info = "Two", NullableBool = true });
-                db.InsertParameterized(new ParamTestBO() { Id = 3, Double = 0.003, Int = 300, Info = "Three", NullableBool = false });
-                db.InsertParameterized(new ParamTestBO() { Id = 4, Double = 0.004, Int = 400, Info = "Four", NullableBool = null });
+                db.InsertParam(new ParamTestBO() { Id = 1, Double = 0.001, Int = 100, Info = "One", NullableBool = null });
+                db.InsertParam(new ParamTestBO() { Id = 2, Double = 0.002, Int = 200, Info = "Two", NullableBool = true });
+                db.InsertParam(new ParamTestBO() { Id = 3, Double = 0.003, Int = 300, Info = "Three", NullableBool = false });
+                db.InsertParam(new ParamTestBO() { Id = 4, Double = 0.004, Int = 400, Info = "Four", NullableBool = null });
 
                 //select multiple items
                 Assert.AreEqual(2, db.Select<ParamTestBO>(q => q.NullableBool == null).Count);
-                Assert.AreEqual(2, db.SelectParameterized<ParamTestBO>(q => q.NullableBool == null).Count);
-                Assert.AreEqual(1, db.SelectParameterized<ParamTestBO>(q => q.NullableBool == true).Count);
-                Assert.AreEqual(1, db.SelectParameterized<ParamTestBO>(q => q.NullableBool == false).Count);
+                Assert.AreEqual(2, db.SelectParam<ParamTestBO>(q => q.NullableBool == null).Count);
+                Assert.AreEqual(1, db.SelectParam<ParamTestBO>(q => q.NullableBool == true).Count);
+                Assert.AreEqual(1, db.SelectParam<ParamTestBO>(q => q.NullableBool == false).Count);
 
-                Assert.AreEqual(1, db.SelectParameterized<ParamTestBO>(q => q.Info == "Two").Count);
-                Assert.AreEqual(1, db.SelectParameterized<ParamTestBO>(q => q.Int == 300).Count);
-                Assert.AreEqual(1, db.SelectParameterized<ParamTestBO>(q => q.Double == 0.003).Count);
+                Assert.AreEqual(1, db.SelectParam<ParamTestBO>(q => q.Info == "Two").Count);
+                Assert.AreEqual(1, db.SelectParam<ParamTestBO>(q => q.Int == 300).Count);
+                Assert.AreEqual(1, db.SelectParam<ParamTestBO>(q => q.Double == 0.003).Count);
             }
         }
 
@@ -170,26 +189,26 @@ namespace ServiceStack.OrmLite.Oracle.Tests
             {
                 DropAndCreateTables(db);
 
-                db.InsertParameterized(new ParamTestBO() { Id = 1, Double = 0.001, Int = 100, Info = "One", NullableBool = null });
-                db.InsertParameterized(new ParamTestBO() { Id = 2, Double = 0.002, Int = 200, Info = "Two", NullableBool = true });
-                db.InsertParameterized(new ParamTestBO() { Id = 3, Double = 0.003, Int = 300, Info = "Three", NullableBool = false });
-                db.InsertParameterized(new ParamTestBO() { Id = 4, Double = 0.004, Int = 400, Info = "Four", NullableBool = null });
+                db.InsertParam(new ParamTestBO() { Id = 1, Double = 0.001, Int = 100, Info = "One", NullableBool = null });
+                db.InsertParam(new ParamTestBO() { Id = 2, Double = 0.002, Int = 200, Info = "Two", NullableBool = true });
+                db.InsertParam(new ParamTestBO() { Id = 3, Double = 0.003, Int = 300, Info = "Three", NullableBool = false });
+                db.InsertParam(new ParamTestBO() { Id = 4, Double = 0.004, Int = 400, Info = "Four", NullableBool = null });
 
-                db.InsertParameterized(new ParamRelBO() { PTId = 1, Info = "T1" });
-                db.InsertParameterized(new ParamRelBO() { PTId = 1, Info = "T1" });
-                db.InsertParameterized(new ParamRelBO() { PTId = 1, Info = "T1" });
-                db.InsertParameterized(new ParamRelBO() { PTId = 1, Info = "T1" });
-                db.InsertParameterized(new ParamRelBO() { PTId = 2, Info = "T1" });
-                db.InsertParameterized(new ParamRelBO() { PTId = 2, Info = "T1" });
-                db.InsertParameterized(new ParamRelBO() { PTId = 3, Info = "T1" });
-                db.InsertParameterized(new ParamRelBO() { PTId = 4, Info = "T1" });
-                db.InsertParameterized(new ParamRelBO() { PTId = 3, Info = "T2" });
-                db.InsertParameterized(new ParamRelBO() { PTId = 4, Info = "T2" });
+                db.InsertParam(new ParamRelBO() { PTId = 1, Info = "T1" });
+                db.InsertParam(new ParamRelBO() { PTId = 1, Info = "T1" });
+                db.InsertParam(new ParamRelBO() { PTId = 1, Info = "T1" });
+                db.InsertParam(new ParamRelBO() { PTId = 1, Info = "T1" });
+                db.InsertParam(new ParamRelBO() { PTId = 2, Info = "T1" });
+                db.InsertParam(new ParamRelBO() { PTId = 2, Info = "T1" });
+                db.InsertParam(new ParamRelBO() { PTId = 3, Info = "T1" });
+                db.InsertParam(new ParamRelBO() { PTId = 4, Info = "T1" });
+                db.InsertParam(new ParamRelBO() { PTId = 3, Info = "T2" });
+                db.InsertParam(new ParamRelBO() { PTId = 4, Info = "T2" });
 
-                Assert.AreEqual(8, db.SelectParameterized<ParamRelBO>(q => q.Info == "T1").Count);
-                Assert.AreEqual(2, db.SelectParameterized<ParamRelBO>(q => q.Info == "T2").Count);
-
-                Assert.AreEqual(3, db.SelectParameterized<ParamRelBO>(q => q.Info == "T1" && (q.PTId == 2 || q.PTId == 3) ).Count);
+                Assert.AreEqual(8, db.SelectParam<ParamRelBO>(q => q.Info == "T1").Count);
+                Assert.AreEqual(2, db.SelectParam<ParamRelBO>(q => q.Info == "T2").Count);
+               
+                Assert.AreEqual(3, db.SelectParam<ParamRelBO>(q => q.Info == "T1" && (q.PTId == 2 || q.PTId == 3) ).Count);
             }
         }
 

--- a/src/ServiceStack.OrmLite/Expressions/ReadConnectionExtensions.cs
+++ b/src/ServiceStack.OrmLite/Expressions/ReadConnectionExtensions.cs
@@ -130,10 +130,14 @@ namespace ServiceStack.OrmLite
             return dbConn.Exec(dbCmd => dbCmd.Select(expression));
         }
 
-        public static List<T> SelectParameterized<T>(this IDbConnection dbConn, Expression<Func<T, bool>> predicate)
+        /// <summary>
+        /// Performs the same function as Select() except arguments are passed as parameters to the generated SQL.
+        /// Currently does not support complex SQL.## ,  .StartsWith(), EndsWith() and Contains() operators
+        /// </summary>
+        public static List<T> SelectParam<T>(this IDbConnection dbConn, Expression<Func<T, bool>> predicate)
             where T : new ()
         {
-            return dbConn.Exec(dbCmd => dbCmd.SelectParametized(predicate));
+            return dbConn.Exec(dbCmd => dbCmd.SelectParam(predicate));
         }
 
         public static T First<T>(this IDbConnection dbConn, Expression<Func<T, bool>> predicate)

--- a/src/ServiceStack.OrmLite/Expressions/ReadExtensions.cs
+++ b/src/ServiceStack.OrmLite/Expressions/ReadExtensions.cs
@@ -45,7 +45,7 @@ namespace ServiceStack.OrmLite
 			}
 		}
 
-        public static List<T> SelectParametized<T>(this IDbCommand dbCmd, Expression<Func<T, bool>> predicate)
+        public static List<T> SelectParam<T>(this IDbCommand dbCmd, Expression<Func<T, bool>> predicate)
     where T : new()
         {
             var ev = OrmLiteConfig.DialectProvider.ExpressionVisitor<T>();

--- a/src/ServiceStack.OrmLite/OrmLiteReadConnectionExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadConnectionExtensions.cs
@@ -108,10 +108,13 @@ namespace ServiceStack.OrmLite
             return dbConn.Exec(dbCmd => dbCmd.GetById<T>(idValue));
         }
 
-        public static T GetByIdParameterized<T>(this IDbConnection dbConn, object idValue)
+        /// <summary>
+        /// Performs an GetById() except argument is passed as a parameter to the generated SQL
+        /// </summary>
+        public static T GetByIdParam<T>(this IDbConnection dbConn, object idValue)
             where T: new()
         {
-            return dbConn.Exec(dbCmd => dbCmd.GetByIdParameterized<T>(idValue));
+            return dbConn.Exec(dbCmd => dbCmd.GetByIdParam<T>(idValue));
         }
 
         /// <summary>

--- a/src/ServiceStack.OrmLite/OrmLiteReadExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadExtensions.cs
@@ -508,7 +508,7 @@ namespace ServiceStack.OrmLite
 		}
 
         [Obsolete(UseDbConnectionExtensions)]
-        public static T GetByIdParameterized<T>(this IDbCommand dbCmd, object id)
+        public static T GetByIdParam<T>(this IDbCommand dbCmd, object id)
             where T : new()
         {
             var modelDef = ModelDefinition<T>.Definition;

--- a/src/ServiceStack.OrmLite/OrmLiteWriteConnectionExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteWriteConnectionExtensions.cs
@@ -107,7 +107,10 @@ namespace ServiceStack.OrmLite
             dbConn.Exec(dbCmd => dbCmd.UpdateAll(objs));
         }
 
-        public static void UpdateParameterized<T>(this IDbConnection dbConn, T obj)
+        /// <summary>
+        /// Performs an Update<T>() except arguments are passed as parameters to the generated SQL
+        /// </summary>
+        public static void UpdateParam<T>(this IDbConnection dbConn, T obj)
             where T : new()
         {
             dbConn.Exec(dbCmd =>
@@ -147,10 +150,13 @@ namespace ServiceStack.OrmLite
             dbConn.Exec(dbCmd => dbCmd.DeleteById<T>(id));
         }
 
-        public static void DeleteByIdParametized<T>(this IDbConnection dbConn, object id)
+        /// <summary>
+        /// Performs a DeleteById() except argument is passed as a parameter to the generated SQL
+        /// </summary>
+        public static void DeleteByIdParam<T>(this IDbConnection dbConn, object id)
 where T : new()
         {
-            dbConn.Exec(dbCmd => dbCmd.DeleteByIdParameterized<T>(id));
+            dbConn.Exec(dbCmd => dbCmd.DeleteByIdParam<T>(id));
         }
 
         public static void DeleteByIds<T>(this IDbConnection dbConn, IEnumerable idValues)
@@ -198,7 +204,10 @@ where T : new()
             dbConn.Exec(dbCmd => dbCmd.InsertAll(objs));
         }
 
-        public static void InsertParameterized<T>(this IDbConnection dbConn, T obj)
+        /// <summary>
+        /// Performs an Insert() except arguments are passed as parameters to the generated SQL
+        /// </summary>
+        public static void InsertParam<T>(this IDbConnection dbConn, T obj)
     where T : new()
         {
             dbConn.Exec(dbCmd =>

--- a/src/ServiceStack.OrmLite/OrmLiteWriteExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteWriteExtensions.cs
@@ -344,7 +344,7 @@ namespace ServiceStack.OrmLite
         }
 
         [Obsolete(UseDbConnectionExtensions)]
-        public static void DeleteByIdParameterized<T>(this IDbCommand dbCmd, object id)
+        public static void DeleteByIdParam<T>(this IDbCommand dbCmd, object id)
         {
             var modelDef = ModelDefinition<T>.Definition;
             var idParamString = OrmLiteConfig.DialectProvider.ParamString+"0";


### PR DESCRIPTION
I have renamed the methods to fit with what we agreed. I have opted for Param rather than Params as getById and deletebyId only use a single parameter and it seems best to keep it consistent and logical where possible. I have also added in some intellisense comments to these methods so it is clear to an end user exactly why the call is different.

Just to clarify I have also rerun all the param specific oracle unit tests and all is working again after the table create issue fix. 
