### PR TITLE
Fixed Byte[] issue

### DIFF
--- a/src/ServiceStack.OrmLite.MySql.Tests/ServiceStack.OrmLite.MySql.Tests.csproj
+++ b/src/ServiceStack.OrmLite.MySql.Tests/ServiceStack.OrmLite.MySql.Tests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ShippersExample.cs" />
     <Compile Include="SqlMapperTests.cs" />
+    <Compile Include="TypeWithByteArrayFieldTests.cs" />
     <Compile Include="UseCase\CustomerOrdersUseCase.cs" />
     <Compile Include="UseCase\SimpleUseCase.cs" />
     <Compile Include="OrmLiteGetScalarTests.cs" />

--- a/src/ServiceStack.OrmLite.MySql.Tests/TypeWithByteArrayFieldTests.cs
+++ b/src/ServiceStack.OrmLite.MySql.Tests/TypeWithByteArrayFieldTests.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+
+namespace ServiceStack.OrmLite.MySql.Tests
+{
+    public class TypeWithByteArrayFieldTests : OrmLiteTestBase
+    {
+        [Test]
+        public void CanInsertAndSelectByteArray()
+        {
+            var orig = new TypeWithByteArrayField { Id = 1, Content = new byte[] { 0, 17, 0, 17, 0, 7 } };
+
+            using (var db = ConnectionString.OpenDbConnection())
+            {
+                db.CreateTable<TypeWithByteArrayField>(true);
+
+                db.Save(orig);
+
+                var target = db.GetById<TypeWithByteArrayField>(orig.Id);
+
+                Assert.AreEqual(orig.Id, target.Id);
+                Assert.AreEqual(orig.Content, target.Content);
+            }
+        }
+    }
+
+    class TypeWithByteArrayField
+    {
+        public int Id { get; set; }
+        public byte[] Content { get; set; }
+    }
+}

--- a/src/ServiceStack.OrmLite.MySql/MySqlDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.MySql/MySqlDialectProvider.cs
@@ -59,6 +59,11 @@ namespace ServiceStack.OrmLite.MySql
                 return base.GetQuotedValue(guidValue.ToString("N"), typeof(string));
             }
 
+            if (fieldType == typeof(byte[]))
+            {
+                return "0x" + BitConverter.ToString((byte[])value).Replace("-", "");
+            }
+
             return base.GetQuotedValue(value, fieldType);
         }
 
@@ -73,6 +78,9 @@ namespace ServiceStack.OrmLite.MySql
                         ? value
                         : (int.Parse(value.ToString()) != 0); //backward compatibility (prev version mapped bool as bit(1))
             }
+
+            if (type == typeof(byte[]))
+                return value;
 
             return base.ConvertDbValue(value, type);
         }

--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/ServiceStack.OrmLite.PostgreSQL.Tests.csproj
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/ServiceStack.OrmLite.PostgreSQL.Tests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="OrmLiteTestBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="OrmLiteGetScalarTests.cs" />
+    <Compile Include="TypeWithByteArrayFieldTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config">

--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/TypeWithByteArrayFieldTests.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/TypeWithByteArrayFieldTests.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using ServiceStack.OrmLite.Tests;
+
+namespace ServiceStack.OrmLite.PostgreSQL.Tests
+{
+    public class TypeWithByteArrayFieldTests : OrmLiteTestBase
+    {
+        [Test]
+        public void CanInsertAndSelectByteArray()
+        {
+            var orig = new TypeWithByteArrayField { Id = 1, Content = new byte[] { 0, 17, 0, 17, 0, 7 } };
+
+            using (var db = ConnectionString.OpenDbConnection())
+            {
+                db.CreateTable<TypeWithByteArrayField>(true);
+
+                db.Save(orig);
+
+                var target = db.GetById<TypeWithByteArrayField>(orig.Id);
+
+                Assert.AreEqual(orig.Id, target.Id);
+                Assert.AreEqual(orig.Content, target.Content);
+            }
+        }
+    }
+
+    class TypeWithByteArrayField
+    {
+        public int Id { get; set; }
+        public byte[] Content { get; set; }
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
@@ -98,6 +98,9 @@ namespace ServiceStack.OrmLite.SqlServer
 					return dateTimeValue - timeSpanOffset;
 				}
 
+                if (type == typeof(byte[]))
+                    return value;
+
 				return base.ConvertDbValue(value, type);
 			}
 			catch (Exception ex)
@@ -130,6 +133,7 @@ namespace ServiceStack.OrmLite.SqlServer
 			if(fieldType == typeof(string)) {
                 return GetQuotedParam(value.ToString());
 			}
+
             if (fieldType == typeof(byte[]))
             {
                 return "0x" + BitConverter.ToString((byte[])value).Replace("-", "");

--- a/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
+++ b/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="OrmLiteTestBase.cs" />
     <Compile Include="SqlServerExpressionVisitorQueryTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TypeWithByteArrayFieldTests.cs" />
     <Compile Include="UnicodeTests.cs" />
     <Compile Include="UpdateTests.cs" />
     <Compile Include="UseCase\SimpleUseCase.cs" />

--- a/src/ServiceStack.OrmLite.SqlServerTests/TypeWithByteArrayFieldTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/TypeWithByteArrayFieldTests.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+
+namespace ServiceStack.OrmLite.SqlServerTests
+{
+    public class TypeWithByteArrayFieldTests : OrmLiteTestBase
+    {
+        [Test]
+        public void CanInsertAndSelectByteArray()
+        {
+            var orig = new TypeWithByteArrayField { Id = 1, Content = new byte[] { 0, 17, 0, 17, 0, 7 } };
+
+            using (var db = ConnectionString.OpenDbConnection())
+            {
+                db.CreateTable<TypeWithByteArrayField>(true);
+
+                db.Save(orig);
+
+                var target = db.GetById<TypeWithByteArrayField>(orig.Id);
+
+                Assert.AreEqual(orig.Id, target.Id);
+                Assert.AreEqual(orig.Content, target.Content);
+            }
+        }
+    }
+
+    class TypeWithByteArrayField
+    {
+        public int Id { get; set; }
+        public byte[] Content { get; set; }
+    }
+}

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -18,6 +18,7 @@ using ServiceStack.Logging;
 using ServiceStack.Text;
 using System.Diagnostics;
 using ServiceStack.Common.Extensions;
+using System.IO;
 
 namespace ServiceStack.OrmLite
 {
@@ -257,6 +258,9 @@ namespace ServiceStack.OrmLite
 
             if (value.GetType() == type)
             {
+                if (type == typeof(byte[]))
+                    return TypeSerializer.DeserializeFromStream<byte[]>(new MemoryStream((byte[])value));
+
                 return value;
             }
 

--- a/tests/ServiceStack.OrmLite.FirebirdTests/ServiceStack.OrmLite.FirebirdTests.csproj
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/ServiceStack.OrmLite.FirebirdTests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Expressions\StringFunctionTests.cs" />
     <Compile Include="Expressions\TestType.cs" />
     <Compile Include="Expressions\UnaryExpressionsTest.cs" />
+    <Compile Include="TypeWithByteArrayFieldTests.cs" />
     <Compile Include="UseCase\SimpleUseCase.cs" />
     <Compile Include="UseCase\CustomerOrdersUseCase.cs" />
     <Compile Include="UseCase\SchemaUseCase.cs" />

--- a/tests/ServiceStack.OrmLite.FirebirdTests/TypeWithByteArrayFieldTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/TypeWithByteArrayFieldTests.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+
+namespace ServiceStack.OrmLite.FirebirdTests
+{
+    public class TypeWithByteArrayFieldTests : OrmLiteTestBase
+    {
+        [Test]
+        public void CanInsertAndSelectByteArray()
+        {
+            var orig = new TypeWithByteArrayField { Id = 1, Content = new byte[] { 0, 17, 0, 17, 0, 7 } };
+
+            using (var db = ConnectionString.OpenDbConnection())
+            {
+                db.CreateTable<TypeWithByteArrayField>(true);
+
+                db.Save(orig);
+
+                var target = db.GetById<TypeWithByteArrayField>(orig.Id);
+
+                Assert.AreEqual(orig.Id, target.Id);
+                Assert.AreEqual(orig.Content, target.Content);
+            }
+        }
+    }
+
+    class TypeWithByteArrayField
+    {
+        public int Id { get; set; }
+        public byte[] Content { get; set; }
+    }
+}

--- a/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
+++ b/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SqlBuilderTests.cs" />
     <Compile Include="SqlServerProviderTests.cs" />
+    <Compile Include="TypeWithByteArrayFieldTests.cs" />
     <Compile Include="UseCase\CustomerOrdersUseCase.cs" />
     <Compile Include="UseCase\SchemaUseCase.cs" />
     <Compile Include="UseCase\ShardingUseCase.cs" />

--- a/tests/ServiceStack.OrmLite.Tests/TypeWithByteArrayFieldTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/TypeWithByteArrayFieldTests.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+
+namespace ServiceStack.OrmLite.Tests
+{
+    public class TypeWithByteArrayFieldTests : OrmLiteTestBase
+    {
+        [Test]
+        public void CanInsertAndSelectByteArray()
+        {
+            var orig = new TypeWithByteArrayField { Id = 1, Content = new byte[] { 0, 17, 0, 17, 0, 7 } };
+
+            using (var db = ConnectionString.OpenDbConnection())
+            {
+                db.CreateTable<TypeWithByteArrayField>(true);
+
+                db.Save(orig);
+
+                var target = db.GetById<TypeWithByteArrayField>(orig.Id);
+
+                Assert.AreEqual(orig.Id, target.Id);
+                Assert.AreEqual(orig.Content, target.Content);
+            }
+        }
+    }
+
+    class TypeWithByteArrayField
+    {
+        public int Id { get; set; }
+        public byte[] Content { get; set; }
+    }
+}


### PR DESCRIPTION
With this commit the issue regarding byte arrays is fixed (issues #107 and #109). I added tests for the following dialects: SQL Server, SQLite, MySql, PostgreSQL and Firefird

By default (see OrmLiteDialectProviderBase methods GetQuotedValue and ConvertDBValue) fields with the type byte[] are converted to base64 when stored and converted back from base64 when read (using the TypeSerializer). The last step was missing and so the value read was not equal to the original value.

In the existing implementation of the SQL Server dialect, this behavior was already overwritten (the original byte array is stored, no conversion is needed). I implemented the same behavior for the MySql dialect.
