### PR TITLE
Parameterized QuerySingle breaks on multiple sql statements now

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServerTests/QueryTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/QueryTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using ServiceStack.Common.Tests.Models;
+
+namespace ServiceStack.OrmLite.SqlServerTests
+{
+	public class QueryTests : OrmLiteTestBase
+	{
+        [Test]
+        public void Can_GetSingle_with_multiple_sql_statements()
+        {
+            using (var db = ConnectionString.OpenDbConnection())
+            {
+                db.CreateTable<ModelWithOnlyStringFields>(true);
+
+                var rowIds = new List<string>(new[] { "id-1", "id-2", "id-3" });
+
+                rowIds.ForEach(x => db.Insert(ModelWithOnlyStringFields.Create(x)));
+
+                var filterRow = ModelWithOnlyStringFields.Create("id-4");
+                filterRow.AlbumName = "FilteredName";
+
+                db.Insert(filterRow);
+
+				var sql = "update [ModelWithOnlyStringFields] set AlbumName = @AlbumName + 'test' from [ModelWithOnlyStringFields] where AlbumName=@AlbumName;select * from [ModelWithOnlyStringFields] where AlbumName=@AlbumName + 'test'";
+
+                var row = db.QuerySingle<ModelWithOnlyStringFields>(sql, new { filterRow.AlbumName });
+                Assert.That(row.Id, Is.EqualTo(filterRow.Id));
+            }
+        }
+	}
+}

--- a/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
+++ b/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
@@ -36,6 +36,9 @@
     <Reference Include="ServiceStack.Common">
       <HintPath>..\..\lib\ServiceStack.Common.dll</HintPath>
     </Reference>
+    <Reference Include="ServiceStack.Common.Tests">
+      <HintPath>..\..\lib\tests\ServiceStack.Common.Tests.dll</HintPath>
+    </Reference>
     <Reference Include="ServiceStack.Interfaces">
       <HintPath>..\..\lib\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
@@ -71,6 +74,7 @@
     <Compile Include="Expressions\UnaryExpressionsTest.cs" />
     <Compile Include="ForeignKeyAttributeTests.cs" />
     <Compile Include="OrmLiteTestBase.cs" />
+    <Compile Include="QueryTests.cs" />
     <Compile Include="SqlServerExpressionVisitorQueryTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TypeWithByteArrayFieldTests.cs" />


### PR DESCRIPTION
QuerySingle with multiple sql statements worked in 3.9.33. Now it is being parameterized and breaks on multiple statements.

The query:

``` sql
update [ModelWithOnlyStringFields] set AlbumName = @AlbumName + 'test' from [ModelWithOnlyStringFields] where AlbumName=@AlbumName;select * from [ModelWithOnlyStringFields] where AlbumName=@AlbumName + 'test'
```

is now changed to be the following when called from QuerySingle:

``` sql
SELECT "Id" ,"Name" ,"AlbumId" ,"AlbumName"  FROM "ModelWithOnlyStringFields" WHERE update [ModelWithOnlyStringFields] set AlbumName = @AlbumName + 'test' from [ModelWithOnlyStringFields] where AlbumName=@AlbumName;select * from [ModelWithOnlyStringFields] where AlbumName=@AlbumName + 'test'
```
