### PR TITLE
Fixed problem with PostgreSQLDialectProvider that is not generating correct table name when schema is not null.

### DIFF
--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/SchemaTests.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/SchemaTests.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using ServiceStack.DataAnnotations;
+
+namespace ServiceStack.OrmLite.Tests
+{
+    [TestFixture]
+    public class SchemaTests : OrmLiteTestBase
+    {
+        [Alias("Users")]
+        [Schema("TestSchema")]
+        public class User
+        {
+            [AutoIncrement]
+            public int Id { get; set; }
+
+            [Index]
+            public string Name { get; set; }
+
+            public DateTime CreatedDate { get; set; }
+        }
+
+        private void CreateSchemaIfNotExists(System.Data.IDbConnection db)
+        {
+            const string createSchemaSQL = @"DO $$
+BEGIN
+
+    IF NOT EXISTS(
+        SELECT schema_name
+          FROM information_schema.schemata
+          WHERE schema_name = 'TestSchema'
+      )
+    THEN
+      EXECUTE 'CREATE SCHEMA ""TestSchema""';
+    END IF;
+
+END
+$$;";
+            db.ExecuteSql(createSchemaSQL);
+        }
+
+        [Test]
+        public void Can_Create_Tables_With_Schema_in_PostgreSQL()
+        {
+            using (var db = ConnectionString.OpenDbConnection())
+            using (var dbCmd = db.CreateCommand())
+            {
+                CreateSchemaIfNotExists(db);
+                db.DropAndCreateTable<User>();
+
+                var tables = db.GetFirstColumn<string>
+                    (@"SELECT '[' || n.nspname || '].[' || c.relname ||']' FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relname = 'Users' AND n.nspname = 'TestSchema'");
+                
+                //PostgreSQL dialect should create the table in the schema
+                Assert.That(tables.Contains("[TestSchema].[Users]"));
+            }
+        }
+
+        [Test]
+        public void Can_Perform_CRUD_Operations_On_Table_With_Schema()
+        {
+            using (var db = ConnectionString.OpenDbConnection())
+            using (var dbCmd = db.CreateCommand())
+            {
+                CreateSchemaIfNotExists(db);
+                db.CreateTable<User>(true);
+
+                db.Insert(new User { Id = 1, Name = "A", CreatedDate = DateTime.Now });
+                db.Insert(new User { Id = 2, Name = "B", CreatedDate = DateTime.Now });
+                db.Insert(new User { Id = 3, Name = "B", CreatedDate = DateTime.Now });
+
+                var lastInsertId = db.GetLastInsertId();
+                Assert.That(lastInsertId, Is.GreaterThan(0));
+
+                var rowsB = db.Select<User>("\"Name\" = {0}", "B");
+                Assert.That(rowsB, Has.Count.EqualTo(2));
+
+                var rowIds = rowsB.ConvertAll(x => x.Id);
+                Assert.That(rowIds, Is.EquivalentTo(new List<long> { 2, 3 }));
+
+                rowsB.ForEach(x => db.Delete(x));
+
+                rowsB = db.Select<User>("\"Name\" = {0}", "B");
+                Assert.That(rowsB, Has.Count.EqualTo(0));
+
+                var rowsLeft = db.Select<User>();
+                Assert.That(rowsLeft, Has.Count.EqualTo(1));
+
+                Assert.That(rowsLeft[0].Name, Is.EqualTo("A"));
+            }
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/ServiceStack.OrmLite.PostgreSQL.Tests.csproj
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/ServiceStack.OrmLite.PostgreSQL.Tests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="OrmLiteTestBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="OrmLiteGetScalarTests.cs" />
+    <Compile Include="SchemaTests.cs" />
     <Compile Include="TypeWithByteArrayFieldTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
@@ -184,5 +184,15 @@ namespace ServiceStack.OrmLite.PostgreSQL
 
 			return sql;
 		}
+
+        public override string GetQuotedTableName(ModelDefinition modelDef)
+        {
+            if (!modelDef.IsInSchema)
+            {
+                return base.GetQuotedTableName(modelDef);
+            }
+            string escapedSchema = modelDef.Schema.Replace(".", "\".\"");
+            return string.Format("\"{0}\".\"{1}\"", escapedSchema, base.NamingStrategy.GetTableName(modelDef.ModelName));
+        }
 	}
 }


### PR DESCRIPTION
The table name generated by PostgreSQLDialectProvider is always "MyTableName" (even it has a schema name).So I patched it just like SqlServerOrmLiteDialectProvider, and test ok under PostgreSQL 9.2
