### PR TITLE
SqlList<string>() causes a compiler error.

### DIFF
--- a/tests/ServiceStack.OrmLite.Tests/SqlServerProviderTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/SqlServerProviderTests.cs
@@ -147,9 +147,7 @@ END;";
             db.ExecuteSql("IF OBJECT_ID('DummyColumn') IS NOT NULL DROP PROC DummyColumn");
             db.ExecuteSql(sql);
 
-            var expected = 0;
-            10.Times(i => expected += i);
-
+	    // This produces a compiler error
             var results = db.SqlList<string>("EXEC DummyColumn @Times", new { Times = 10 });
             results.PrintDump();
             Assert.That(results.Count, Is.EqualTo(10));


### PR DESCRIPTION
As it stands, this produces a compiler error, due to `System.String` not having a default parameterless constructor. I'm not sure how to go about fixing this, but I think it should be addressed, as I'd imagine it would be a pretty common scenario to want to return a list of strings from a stored proc, using the same API call that you use to return a list of integers or other value types.
