### PR TITLE
Fix IndexOutOfRangeException for ignored fields

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteWriteExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteWriteExtensions.cs
@@ -229,7 +229,7 @@ namespace ServiceStack.OrmLite
         {
             for (int i = 0; i < dataReader.FieldCount; i++)
             {
-                if (dataReader.GetName(i).Equals(fieldName, StringComparison.InvariantCultureIgnoreCase))
+                if (dataReader.GetName(i).Equals(OrmLiteConfig.DialectProvider.NamingStrategy.GetColumnName(fieldName), StringComparison.InvariantCultureIgnoreCase))
                     return i;
             }
             return NotFound;


### PR DESCRIPTION
As part of the "Ignored Fields Selection feature" commit, when using
OrmLiteUtilExtensions ConvertTo<T>, the PopulateWithSqlReader maps as
many of the fields it can to the type T. However if the datareader does
not contain a field, an IndexOutOfRangeException is thrown which,
although properly handled, bubbles up into the user's code such that if
they have exceptions turned on in VS it stops program flow and that is
not ideal.
