### PR TITLE
Redirects ServiceStack.Common.Extensions to ServiceStack.Common

### DIFF
--- a/src/AllDialectsTest/Dialect.cs
+++ b/src/AllDialectsTest/Dialect.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Data;
 using ServiceStack.Common.Utils;
 using ServiceStack.DataAnnotations;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using System.Reflection;
 using System.IO;
 using ServiceStack.OrmLite;

--- a/src/AllDialectsTest/Main.cs
+++ b/src/AllDialectsTest/Main.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Data;
 using ServiceStack.Common.Utils;
 using ServiceStack.DataAnnotations;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using ServiceStack.OrmLite;
 
 namespace AllDialectsTest

--- a/src/FirebirdTests/TestExpressions/Main.cs
+++ b/src/FirebirdTests/TestExpressions/Main.cs
@@ -6,7 +6,7 @@ using System.Data;
 
 using ServiceStack.Common.Utils;
 using ServiceStack.DataAnnotations;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using System.Reflection;
 
 using ServiceStack.OrmLite;

--- a/src/FirebirdTests/TestLiteFirebird00/Main.cs
+++ b/src/FirebirdTests/TestLiteFirebird00/Main.cs
@@ -6,7 +6,7 @@ using System.Data;
 
 using ServiceStack.Common.Utils;
 using ServiceStack.DataAnnotations;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using System.Reflection;
 
 using ServiceStack.OrmLite;

--- a/src/FirebirdTests/TestLiteFirebird04/Main.cs
+++ b/src/FirebirdTests/TestLiteFirebird04/Main.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 using ServiceStack.Common.Utils;
 using ServiceStack.DataAnnotations;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 
 using ServiceStack.OrmLite;
 using ServiceStack.OrmLite.Firebird;

--- a/src/FirebirdTests/TestSimpleFirebird01/Main.cs
+++ b/src/FirebirdTests/TestSimpleFirebird01/Main.cs
@@ -5,7 +5,7 @@ using System.Data;
 
 using ServiceStack.Common.Utils;
 using ServiceStack.DataAnnotations;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using System.Reflection;
 
 using ServiceStack.OrmLite;

--- a/src/FirebirdTests/TestSimpleFirebird02/Main.cs
+++ b/src/FirebirdTests/TestSimpleFirebird02/Main.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 using ServiceStack.Common.Utils;
 using ServiceStack.DataAnnotations;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using ServiceStack.DesignPatterns.Model;
 
 using ServiceStack.OrmLite;

--- a/src/FirebirdTests/TestSimpleFirebird03/Main.cs
+++ b/src/FirebirdTests/TestSimpleFirebird03/Main.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 using ServiceStack.Common.Utils;
 using ServiceStack.DataAnnotations;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 
 using ServiceStack.OrmLite;
 using ServiceStack.OrmLite.Firebird;

--- a/src/MySqlExpressionsTest/Program.cs
+++ b/src/MySqlExpressionsTest/Program.cs
@@ -6,7 +6,7 @@ using System.Data;
 
 using ServiceStack.Common.Utils;
 using ServiceStack.DataAnnotations;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using System.Reflection;
 
 using ServiceStack.OrmLite;

--- a/src/OracleTests/TestExpressions/Main.cs
+++ b/src/OracleTests/TestExpressions/Main.cs
@@ -6,7 +6,7 @@ using System.Data;
 
 using ServiceStack.Common.Utils;
 using ServiceStack.DataAnnotations;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using System.Reflection;
 
 using ServiceStack.OrmLite;

--- a/src/OracleTests/TestLiteOracle00/Main.cs
+++ b/src/OracleTests/TestLiteOracle00/Main.cs
@@ -6,7 +6,7 @@ using System.Data;
 
 using ServiceStack.Common.Utils;
 using ServiceStack.DataAnnotations;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using System.Reflection;
 
 using ServiceStack.OrmLite;

--- a/src/OracleTests/TestLiteOracle04/Main.cs
+++ b/src/OracleTests/TestLiteOracle04/Main.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 using ServiceStack.Common.Utils;
 using ServiceStack.DataAnnotations;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 
 using ServiceStack.OrmLite;
 using ServiceStack.OrmLite.Oracle;

--- a/src/PostgreSQLExpressionsTest/Main.cs
+++ b/src/PostgreSQLExpressionsTest/Main.cs
@@ -6,7 +6,7 @@ using System.Data;
 
 using ServiceStack.Common.Utils;
 using ServiceStack.DataAnnotations;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using System.Reflection;
 
 using ServiceStack.OrmLite;

--- a/src/ServiceStack.OrmLite.Firebird/FirebirdOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Firebird/FirebirdOrmLiteDialectProvider.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using ServiceStack.Common.Utils;
 using System.Text;
 using FirebirdSql.Data.FirebirdClient;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 
 namespace ServiceStack.OrmLite.Firebird
 {

--- a/src/ServiceStack.OrmLite.MySql.Tests/OrmLiteCreateTableWithIndexesTests.cs
+++ b/src/ServiceStack.OrmLite.MySql.Tests/OrmLiteCreateTableWithIndexesTests.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using ServiceStack.Common.Tests.Models;
 
 namespace ServiceStack.OrmLite.MySql.Tests

--- a/src/ServiceStack.OrmLite.MySql.Tests/OrmLiteGetScalarTests.cs
+++ b/src/ServiceStack.OrmLite.MySql.Tests/OrmLiteGetScalarTests.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using NUnit.Framework;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using ServiceStack.Common.Tests.Models;
 using ServiceStack.Text;
 using ServiceStack.DataAnnotations;

--- a/src/ServiceStack.OrmLite.MySql.Tests/OrmLiteSelectTests.cs
+++ b/src/ServiceStack.OrmLite.MySql.Tests/OrmLiteSelectTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using NUnit.Framework;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using ServiceStack.Common.Tests.Models;
 
 namespace ServiceStack.OrmLite.MySql.Tests

--- a/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
@@ -4,7 +4,7 @@ using System.Data;
 using System.Reflection;
 using ServiceStack.Common.Utils;
 using System.Text;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using ServiceStack.OrmLite;
 using System.Data.OracleClient;
 

--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/OrmLiteGetScalarTests.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/OrmLiteGetScalarTests.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using NUnit.Framework;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using ServiceStack.Common.Tests.Models;
 using ServiceStack.Text;
 using ServiceStack.DataAnnotations;

--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/OrmLiteSelectTests.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/OrmLiteSelectTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using ServiceStack.Common.Tests.Models;
 using ServiceStack.Text;
 

--- a/src/ServiceStack.OrmLite/Expressions/WriteExtensions.cs
+++ b/src/ServiceStack.OrmLite/Expressions/WriteExtensions.cs
@@ -4,7 +4,7 @@ using System.Data;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using ServiceStack.Text;
 
 namespace ServiceStack.OrmLite

--- a/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
@@ -15,7 +15,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using ServiceStack.DataAnnotations;
 using ServiceStack.Text;
 

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -17,7 +17,7 @@ using System.Text;
 using ServiceStack.Logging;
 using ServiceStack.Text;
 using System.Diagnostics;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using System.IO;
 
 namespace ServiceStack.OrmLite

--- a/src/SqlServerExpressionsTets/Program.cs
+++ b/src/SqlServerExpressionsTets/Program.cs
@@ -7,7 +7,7 @@ using System.Data;
 
 using ServiceStack.Common.Utils;
 using ServiceStack.DataAnnotations;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using System.Reflection;
 
 using ServiceStack.OrmLite;

--- a/src/SqliteExpressionsTest/Program.cs
+++ b/src/SqliteExpressionsTest/Program.cs
@@ -7,7 +7,7 @@ using System.Data;
 
 using ServiceStack.Common.Utils;
 using ServiceStack.DataAnnotations;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using System.Reflection;
 
 using ServiceStack.OrmLite;

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteCreateTableWithIndexesTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteCreateTableWithIndexesTests.cs
@@ -1,6 +1,6 @@
 using System;
 using NUnit.Framework;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using ServiceStack.Common.Tests.Models;
 
 namespace ServiceStack.OrmLite.FirebirdTests

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteGetScalarTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteGetScalarTests.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using NUnit.Framework;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using ServiceStack.Common.Tests.Models;
 using ServiceStack.Text;
 using ServiceStack.DataAnnotations;

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteSelectTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteSelectTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using ServiceStack.Common.Tests.Models;
 using ServiceStack.Text;
 using ServiceStack.DataAnnotations;

--- a/tests/ServiceStack.OrmLite.FirebirdTests/ServiceStack.Common.Tests/ServiceStack.Common.Tests.Models/Movie.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/ServiceStack.Common.Tests/ServiceStack.Common.Tests.Models/Movie.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
 using System.Collections.Generic;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 
 namespace ServiceStack.Common.Tests.Models{
 	

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableWithIndexesTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableWithIndexesTests.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using ServiceStack.Common.Tests.Models;
 
 namespace ServiceStack.OrmLite.Tests

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteSelectTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteSelectTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using ServiceStack.Common.Tests.Models;
 using ServiceStack.Text;
 

--- a/tests/ServiceStack.OrmLite.TestsPerf/Scenarios/Northwind/SelectNorthwindDataScenario.cs
+++ b/tests/ServiceStack.OrmLite.TestsPerf/Scenarios/Northwind/SelectNorthwindDataScenario.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using Northwind.Common.DataModel;
 using Northwind.Perf;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 
 namespace ServiceStack.OrmLite.TestsPerf.Scenarios.Northwind
 {

--- a/tests/ServiceStack.OrmLite.TestsPerf/Scenarios/OrmLite/InsertModelWithFieldsOfDifferentTypesScenario.cs
+++ b/tests/ServiceStack.OrmLite.TestsPerf/Scenarios/OrmLite/InsertModelWithFieldsOfDifferentTypesScenario.cs
@@ -1,6 +1,6 @@
 using System.Data;
 using Northwind.Perf;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using ServiceStack.OrmLite.TestsPerf.Model;
 
 namespace ServiceStack.OrmLite.TestsPerf.Scenarios.OrmLite

--- a/tests/ServiceStack.OrmLite.TestsPerf/Scenarios/OrmLite/InsertSampleOrderLineScenario.cs
+++ b/tests/ServiceStack.OrmLite.TestsPerf/Scenarios/OrmLite/InsertSampleOrderLineScenario.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Data;
 using Northwind.Perf;
-using ServiceStack.Common.Extensions;
+using ServiceStack.Common;
 using ServiceStack.OrmLite.TestsPerf.Model;
 
 namespace ServiceStack.OrmLite.TestsPerf.Scenarios.OrmLite


### PR DESCRIPTION
On Issue #187

I noticed that all classes in the [ServiceStack.Common.Extensions](https://github.com/ServiceStack/ServiceStack/tree/master/src/ServiceStack.Common/Extensions) folder/namespace are now marked as obsolete.  A find and replace of [ServiceStack.Common.Extensions](https://github.com/ServiceStack/ServiceStack/tree/master/src/ServiceStack.Common/Extensions) with [ServiceStack.Common](https://github.com/ServiceStack/ServiceStack/tree/master/src/ServiceStack.Common) for all using statements in the [ServiceStack.OrmLite](https://github.com/ServiceStack/ServiceStack.OrmLite/tree/master/src/ServiceStack.OrmLite) solved the issue (#187).

I did find and replace for [ServiceStack.Common.Extensions](https://github.com/ServiceStack/ServiceStack/tree/master/src/ServiceStack.Common/Extensions) to [ServiceStack.Common](https://github.com/ServiceStack/ServiceStack/tree/master/src/ServiceStack.Common) for all using statements in the entire solution, too.

All test passed. The reported TypeLoadException is no more (an additional passed test; though not written)
