### PR TITLE
Failing tests to show that DropTable does not respect naming strategy.

### DIFF
--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteDropTableWithNamingStrategyTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteDropTableWithNamingStrategyTests.cs
@@ -1,0 +1,65 @@
+﻿using NUnit.Framework;
+using ServiceStack.Common.Tests.Models;
+
+namespace ServiceStack.OrmLite.Tests
+{
+    public class OrmLiteDropTableWithNamingStrategyTests
+        : OrmLiteTestBase
+    {
+        [Test]
+        public void Can_drop_TableWithNamigStrategy_table_prefix()
+        {
+            OrmLiteConfig.DialectProvider.NamingStrategy = new PrefixNamingStrategy
+            {
+                TablePrefix = "tab_",
+                ColumnPrefix = "col_"
+            };
+
+            using (var db = ConnectionString.OpenDbConnection())
+            {
+                db.CreateTable<ModelWithOnlyStringFields>(true);
+
+                db.DropTable<ModelWithOnlyStringFields>();
+
+                Assert.False(db.TableExists("tab_ModelWithOnlyStringFields"));
+            }
+            
+            OrmLiteConfig.DialectProvider.NamingStrategy = new OrmLiteNamingStrategyBase();
+        }
+
+        [Test]
+        public void Can_drop_TableWithNamigStrategy_table_lowered()
+        {
+            OrmLiteConfig.DialectProvider.NamingStrategy = new LowercaseNamingStrategy();
+
+            using (var db = ConnectionString.OpenDbConnection())
+            {
+                db.CreateTable<ModelWithOnlyStringFields>(true);
+
+                db.DropTable<ModelWithOnlyStringFields>();
+
+                Assert.False(db.TableExists("modelwithonlystringfields"));
+            }
+
+            OrmLiteConfig.DialectProvider.NamingStrategy = new OrmLiteNamingStrategyBase();
+        }
+
+
+        [Test]
+        public void Can_drop_TableWithNamigStrategy_table_nameUnderscoreCompound()
+        {
+            OrmLiteConfig.DialectProvider.NamingStrategy = new UnderscoreSeparatedCompoundNamingStrategy();
+
+            using (var db = ConnectionString.OpenDbConnection())
+            {
+                db.CreateTable<ModelWithOnlyStringFields>(true);
+
+                db.DropTable<ModelWithOnlyStringFields>();
+
+                Assert.False(db.TableExists("model_with_only_string_fields"));
+            }
+
+            OrmLiteConfig.DialectProvider.NamingStrategy = new OrmLiteNamingStrategyBase();
+        }
+    }
+}

--- a/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
+++ b/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Expression\UnaryExpressionsTest.cs" />
     <Compile Include="ForeignKeyAttributeTests.cs" />
     <Compile Include="OrmLiteDropTableTests.cs" />
+    <Compile Include="OrmLiteDropTableWithNamingStrategyTests.cs" />
     <Compile Include="OrmLiteQueryTests.cs" />
     <Compile Include="LocalizationTests.cs" />
     <Compile Include="OrmLiteConnectionFactoryTests.cs" />


### PR DESCRIPTION
Lowercase passes, but prefix and underscore fail.
