### PR TITLE
Failing test: MsSql GetLastInsertedId does not work with InsertParam.

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServerTests/InsertParam_GetLastInsertId.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/InsertParam_GetLastInsertId.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+
+namespace ServiceStack.OrmLite.SqlServerTests
+{
+	public class InsertParam_GetLastInsertId : OrmLiteTestBase
+	{
+		[Test]
+		public void Can_GetLastInsertedId_using_InsertParam()
+		{
+			var testObject = new SimpleType { Name = "test" };
+
+			//verify that "normal" Insert works as expected
+			using(var con = ConnectionString.OpenDbConnection()) {
+				con.CreateTable<SimpleType>(true);
+
+				con.Insert(testObject);
+				var normalLastInsertedId = con.GetLastInsertId();
+				Assert.Greater(normalLastInsertedId, 0, "normal Insert");
+			}
+
+			//test with InsertParam
+			using(var con = ConnectionString.OpenDbConnection()) {
+				con.CreateTable<SimpleType>(true);
+
+				con.InsertParam(testObject);
+				var insertParamLastInsertedId = con.GetLastInsertId();
+				Assert.Greater(insertParamLastInsertedId, 0, "with InsertParam");
+			}
+		}
+	}
+}

--- a/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
+++ b/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
@@ -53,6 +53,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="InsertParam_GetLastInsertId.cs" />
     <Compile Include="NestedTransactions.cs" />
     <Compile Include="EnumTests.cs" />
     <Compile Include="Expressions\AdditiveExpressionsTest.cs" />


### PR DESCRIPTION
The executed statements from SQL profiler:
- Normal Insert:

``` SQL
INSERT INTO "SimpleType" ("Name") VALUES ('test')
SELECT SCOPE_IDENTITY()
```
- InsertParam:

``` SQL
exec sp_executesql N'INSERT INTO "SimpleType" ("Name") VALUES (@Name)',N'@Name nvarchar(4)',@Name=N'test'
SELECT SCOPE_IDENTITY()
```

If I'm right, this happens because sp_executesql runs in it's own batch/scope.

One possible solution would be to move the `select scope_identity()` inside InsertParam, and always return the identity (but that needs checking, at least determine whether the object itself has a Key).
