### PR TITLE
Precision and Scale for decimal types

### DIFF
--- a/src/ServiceStack.OrmLite.MySql.Tests/DecimalPrecisionScaleTest.cs
+++ b/src/ServiceStack.OrmLite.MySql.Tests/DecimalPrecisionScaleTest.cs
@@ -1,0 +1,52 @@
+using System;
+using NUnit.Framework;
+using ServiceStack.DataAnnotations;
+using ServiceStack.DesignPatterns.Model;
+
+namespace ServiceStack.OrmLite.MySql.Tests
+{
+	[TestFixture]
+	public class DecimalPrecisionScaleTest
+		: OrmLiteTestBase
+	{
+		[Test]
+		public void CanCreateDecimalWithPrecisionAndScale()
+		{
+			var fielDef = ModelDefinition<DecimalTest>.Definition.GetFieldDefinition<DecimalTest> (f => f.SomeDecimalWithPrecisionAndScale);
+			Assert.AreEqual("ALTER TABLE `DecimalTest` ADD COLUMN `SomeDecimalWithPrecisionAndScale` DECIMAL (15,2) NOT NULL;",
+			                OrmLiteConfig.DialectProvider.ToAddColumnStatement (typeof(DecimalTest), fielDef));
+		}
+						
+		[Test]
+		public void CanCreateDecimal()
+		{
+			var fielDef = ModelDefinition<DecimalTest>.Definition.GetFieldDefinition<DecimalTest> (f => f.SomeDecimal);
+			Assert.AreEqual("ALTER TABLE `DecimalTest` ADD COLUMN `SomeDecimal` DECIMAL (38,6) NOT NULL;",
+			                OrmLiteConfig.DialectProvider.ToAddColumnStatement (typeof(DecimalTest), fielDef));
+		}
+
+		public class DecimalTest 
+		{
+
+			public int Id
+			{
+				get;
+				set;
+			}
+
+			public decimal SomeDecimal
+			{
+				get;
+				set;
+			}
+
+			[DecimalLength(15,2)]
+			public decimal SomeDecimalWithPrecisionAndScale
+			{
+				get;
+				set;
+			}
+
+		}
+	}
+}

--- a/src/ServiceStack.OrmLite.MySql.Tests/ServiceStack.OrmLite.MySql.Tests.csproj
+++ b/src/ServiceStack.OrmLite.MySql.Tests/ServiceStack.OrmLite.MySql.Tests.csproj
@@ -13,9 +13,9 @@
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
+    <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
+    <Optimize>False</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>True</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
@@ -58,7 +58,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="MySql.Data">
-      <HintPath>..\..\lib\mysql.data.dll</HintPath>
+      <HintPath>..\..\lib\MySql.Data.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -106,6 +106,7 @@
     <Compile Include="UseCase\SimpleUseCase.cs" />
     <Compile Include="OrmLiteGetScalarTests.cs" />
     <Compile Include="OrmLiteCreateTableWithNamingStrategyTests.cs" />
+    <Compile Include="DecimalPrecisionScaleTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServiceStack.OrmLite.MySql\ServiceStack.OrmLite.MySql.csproj">

--- a/src/ServiceStack.OrmLite.MySql/MySqlDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.MySql/MySqlDialectProvider.cs
@@ -20,11 +20,13 @@ namespace ServiceStack.OrmLite.MySql
             base.IntColumnDefinition = "int(11)";
             base.BoolColumnDefinition = "tinyint(1)";
             base.TimeColumnDefinition = "time";
-            base.DecimalColumnDefinition = "decimal(38,6)";
+            //base.DecimalColumnDefinition = "decimal(38,6)";
             base.GuidColumnDefinition = "char(32)";
             base.DefaultStringLength = 255;
             base.InitColumnTypeMap();
     	    base.DefaultValueFormat = " DEFAULT '{0}'";
+			DefaultDecimalPrecision=38;
+			DefaultDecimalScale=6;
         }
 
         public override string GetQuotedParam(string paramValue)

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -370,7 +370,13 @@ namespace ServiceStack.OrmLite
             {
                 fieldDefinition = string.Format(StringLengthColumnDefinitionFormat, fieldLength.GetValueOrDefault(DefaultStringLength));
             }
-            else
+			else if( fieldType==typeof(decimal) )
+			{
+				fieldDefinition= string.Format("{0} ({1},{2})", DecimalColumnDefinition, 
+				                               fieldLength.GetValueOrDefault(DefaultDecimalPrecision),
+				                               scale.GetValueOrDefault(DefaultDecimalScale) );
+			}
+			else
             {
                 if (!DbTypeMap.ColumnTypeMap.TryGetValue(fieldType, out fieldDefinition))
                 {


### PR DESCRIPTION
using DecimalLengthAttribute, precision and scale can be set ;

public decimal SomeDecimal   {get   set;    }
will produce: 
for mysql:  .... `SomeDecimal` DECIMAL (38,6) NOT NULL;
for the rest:  ... `SomeDecimal` DECIMAL (18,12) NOT NULL; 

[DecimalLength(15,2)]
public decimal SomeDecimalWithPrecisionAndScale {get;set;   }
will produce: `SomeDecimal` DECIMAL (15,2) NOT NULL;
