### PR TITLE
AddParameterForFieldToCommand override is not necessary to support datetime2 in Ms Sql

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
@@ -150,24 +150,8 @@ namespace ServiceStack.OrmLite.SqlServer
 		{
 			_useDateTime2 = shouldUseDatetime2;
 			DateTimeColumnDefinition = shouldUseDatetime2 ? "datetime2" : "datetime";
-			InitColumnTypeMap();
-		}
-
-		protected override void AddParameterForFieldToCommand(IDbCommand command, FieldDefinition fieldDef, object objWithProperties)
-		{
-			//have to override, because DbTypeMap.Set<T> expects DbType, and SqlDbType is not a DbType...
-			if(_useDateTime2 && (fieldDef.FieldType == typeof(DateTime) || fieldDef.FieldType == typeof(DateTime?))) {
-				var sqlCmd = (SqlCommand)command;//should be SqlCommand...
-				var p = sqlCmd.CreateParameter();
-				p.ParameterName = string.Format("{0}{1}", ParamString, fieldDef.FieldName);
-
-				p.SqlDbType = SqlDbType.DateTime2;
-				p.Value = GetValueOrDbNull(fieldDef, objWithProperties);
-
-				command.Parameters.Add(p);
-			} else {
-				base.AddParameterForFieldToCommand(command, fieldDef, objWithProperties);
-			}
+			base.DbTypeMap.Set<DateTime>(shouldUseDatetime2 ? DbType.DateTime2 : DbType.DateTime, DateTimeColumnDefinition);
+			base.DbTypeMap.Set<DateTime?>(shouldUseDatetime2 ? DbType.DateTime2 : DbType.DateTime, DateTimeColumnDefinition);
 		}
 
 		public override long GetLastInsertId(IDbCommand dbCmd)


### PR DESCRIPTION
Thanks @colinbreame for noticing it.
