### PR TITLE
Converted AssemblyVersion attribute to a central GlobalAssemblyInfo.cs file.

### DIFF
--- a/src/GlobalAssemblyInfo.cs
+++ b/src/GlobalAssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Reflection;
+
+[assembly: AssemblyVersion("3.9.43.0")]

--- a/src/ServiceStack.OrmLite.Firebird/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.OrmLite.Firebird/Properties/AssemblyInfo.cs
@@ -13,12 +13,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion("1.0.*")]
-
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.
 

--- a/src/ServiceStack.OrmLite.Firebird/ServiceStack.OrmLite.Firebird.csproj
+++ b/src/ServiceStack.OrmLite.Firebird/ServiceStack.OrmLite.Firebird.csproj
@@ -44,6 +44,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="DbSchema\IColumn.cs" />
     <Compile Include="DbSchema\IParameter.cs" />
     <Compile Include="DbSchema\IProcedure.cs" />

--- a/src/ServiceStack.OrmLite.MySql.Tests/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.OrmLite.MySql.Tests/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("6753faeb-f6c3-4aa1-bca0-2a15d2bf1522")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.OrmLite.MySql.Tests/ServiceStack.OrmLite.MySql.Tests.csproj
+++ b/src/ServiceStack.OrmLite.MySql.Tests/ServiceStack.OrmLite.MySql.Tests.csproj
@@ -62,6 +62,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="BooleanTests.cs" />
     <Compile Include="DateTimeColumnTest.cs" />
     <Compile Include="EnumTests.cs" />

--- a/src/ServiceStack.OrmLite.MySql/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.OrmLite.MySql/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("a47c24c1-27c2-443c-a1bf-b88d25aa3fc9")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.OrmLite.MySql/ServiceStack.OrmLite.MySql.csproj
+++ b/src/ServiceStack.OrmLite.MySql/ServiceStack.OrmLite.MySql.csproj
@@ -50,6 +50,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="MySqlDialect.cs" />
     <Compile Include="MySqlDialectProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/ServiceStack.OrmLite.Oracle.Tests/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.OrmLite.Oracle.Tests/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("98a76291-26c2-4012-aeef-ab688752d30b")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.OrmLite.Oracle.Tests/ServiceStack.OrmLite.Oracle.Tests.csproj
+++ b/src/ServiceStack.OrmLite.Oracle.Tests/ServiceStack.OrmLite.Oracle.Tests.csproj
@@ -50,6 +50,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="OracleParamTests.cs" />
     <Compile Include="OracleSyntaxTests.cs" />
     <Compile Include="OracleTestBase.cs">

--- a/src/ServiceStack.OrmLite.Oracle/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.OrmLite.Oracle/Properties/AssemblyInfo.cs
@@ -13,12 +13,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-
-[assembly: AssemblyVersion("1.0.*")]
-
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.
 

--- a/src/ServiceStack.OrmLite.Oracle/ServiceStack.OrmLite.Oracle.csproj
+++ b/src/ServiceStack.OrmLite.Oracle/ServiceStack.OrmLite.Oracle.csproj
@@ -43,6 +43,9 @@
     <Reference Include="System.Data.OracleClient" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="DbSchema\IColumn.cs" />
     <Compile Include="DbSchema\IParameter.cs" />
     <Compile Include="DbSchema\IProcedure.cs" />

--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("38883b7a-520a-46dc-86dd-87d4ea07d9e9")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/ServiceStack.OrmLite.PostgreSQL.Tests.csproj
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/ServiceStack.OrmLite.PostgreSQL.Tests.csproj
@@ -65,6 +65,9 @@
     <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="CreatePostgreSQLTablesTests.cs" />
     <Compile Include="EnumTests.cs" />
     <Compile Include="Expressions\AdditiveExpressionsTest.cs" />

--- a/src/ServiceStack.OrmLite.PostgreSQL/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b89c24c2-77c5-843c-f1bf-c33d25af3f16")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.OrmLite.PostgreSQL/ServiceStack.OrmLite.PostgreSQL.csproj
+++ b/src/ServiceStack.OrmLite.PostgreSQL/ServiceStack.OrmLite.PostgreSQL.csproj
@@ -45,6 +45,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="PostgreSqlDialect.cs" />
     <Compile Include="PostgreSQLDialectProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/ServiceStack.OrmLite.SqlServer/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("19f4a9ca-8076-4743-a4f3-e60708f24708")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.OrmLite.SqlServer/ServiceStack.OrmLite.SqlServer.csproj
+++ b/src/ServiceStack.OrmLite.SqlServer/ServiceStack.OrmLite.SqlServer.csproj
@@ -70,6 +70,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="SqlServerDialect.cs" />
     <Compile Include="SqlServerExpressionVisitor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/ServiceStack.OrmLite.SqlServerTests/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b31d406b-57e0-4fe8-bd91-f601e47d641d")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
+++ b/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
@@ -53,6 +53,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Datetime2Tests.cs" />
     <Compile Include="EnsureUtcTest.cs" />
     <Compile Include="InsertParam_GetLastInsertId.cs" />

--- a/src/ServiceStack.OrmLite.Sqlite/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.OrmLite.Sqlite/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ac105634-e91a-4fcc-a4f9-36aacd9fd47c")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.OrmLite.Sqlite/ServiceStack.OrmLite.Sqlite.csproj
+++ b/src/ServiceStack.OrmLite.Sqlite/ServiceStack.OrmLite.Sqlite.csproj
@@ -89,6 +89,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="SqliteDialect.cs" />
     <Compile Include="SqliteOrmLiteDialectProviderBase.cs" />
     <Compile Include="SqliteOrmLiteDialectProvider.cs" />

--- a/src/ServiceStack.OrmLite.Sqlite32/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.OrmLite.Sqlite32/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("81b2eb97-03e7-4e80-9cb8-9c4e1fe414cc")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.OrmLite.Sqlite32/ServiceStack.OrmLite.Sqlite32.csproj
+++ b/src/ServiceStack.OrmLite.Sqlite32/ServiceStack.OrmLite.Sqlite32.csproj
@@ -52,6 +52,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="..\ServiceStack.OrmLite.Sqlite\SqliteExpressionVisitor.cs">
       <Link>SqliteExpressionVisitor.cs</Link>
     </Compile>

--- a/src/ServiceStack.OrmLite.Sqlite32/ServiceStack.OrmLite.Sqlite32v40.csproj
+++ b/src/ServiceStack.OrmLite.Sqlite32/ServiceStack.OrmLite.Sqlite32v40.csproj
@@ -53,6 +53,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="..\ServiceStack.OrmLite.Sqlite\SqliteExpressionVisitor.cs">
       <Link>SqliteExpressionVisitor.cs</Link>
     </Compile>

--- a/src/ServiceStack.OrmLite.Sqlite64/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.OrmLite.Sqlite64/Properties/AssemblyInfo.cs
@@ -21,16 +21,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("540d6e0c-97cd-42a8-9bed-89a7a887928b")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/ServiceStack.OrmLite.Sqlite64/ServiceStack.OrmLite.Sqlite64.csproj
+++ b/src/ServiceStack.OrmLite.Sqlite64/ServiceStack.OrmLite.Sqlite64.csproj
@@ -51,6 +51,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="..\ServiceStack.OrmLite.Sqlite\SqliteExpressionVisitor.cs">
       <Link>SqliteExpressionVisitor.cs</Link>
     </Compile>

--- a/src/ServiceStack.OrmLite.Sqlite64/ServiceStack.OrmLite.Sqlite64v40.csproj
+++ b/src/ServiceStack.OrmLite.Sqlite64/ServiceStack.OrmLite.Sqlite64v40.csproj
@@ -52,6 +52,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="..\ServiceStack.OrmLite.Sqlite\SqliteExpressionVisitor.cs">
       <Link>SqliteExpressionVisitor.cs</Link>
     </Compile>

--- a/src/ServiceStack.OrmLite/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.OrmLite/Properties/AssemblyInfo.cs
@@ -20,16 +20,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d0f92eb9-6843-4996-951a-a0f04b076ec9")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.9.43.0")]
-//[assembly: AssemblyFileVersion("1.0.*")]

--- a/src/ServiceStack.OrmLite/ServiceStack.OrmLite.csproj
+++ b/src/ServiceStack.OrmLite/ServiceStack.OrmLite.csproj
@@ -93,6 +93,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="BelongToAttribute.cs" />
     <Compile Include="Expressions\ExpressionVisitor.cs" />
     <Compile Include="Expressions\ParameterRebinder.cs" />


### PR DESCRIPTION
This simplifies future version number updates, although the nuspec files still require their own version edits. It also would allow other common attributes (like AssemblyCopyright) to be moved to this file in the future, and no longer duplicated across all projects' AssemblyInfo.cs files.

I did not touch the projects under tests, not wanting to reference ../../src/GlobalAssemblyInfo.cs from them, although that could be done, or this file could be moved up another level, or a second GlobalAssemblyInfo.cs file could be created under tests.
