### PR TITLE
Use Single Connection Across Threads

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteConnection.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConnection.cs
@@ -16,6 +16,7 @@ namespace ServiceStack.OrmLite
         public IDbTransaction Transaction { get; internal set; }
 		private IDbConnection dbConnection;
 		private bool isOpen;
+        private int transactionThreadId = -1;
 
         public OrmLiteConnection(OrmLiteConnectionFactory factory)
         {
@@ -113,7 +114,13 @@ namespace ServiceStack.OrmLite
 			get { return DbConnection.State; }
 		}
 
-		public static explicit operator SqlConnection(OrmLiteConnection dbConn)
+	    public int TransactionThreadId
+	    {
+            get { lock(this){return transactionThreadId;} }
+            set { lock (this){transactionThreadId = value;} }
+	    }
+
+	    public static explicit operator SqlConnection(OrmLiteConnection dbConn)
 		{
 			return (SqlConnection)dbConn.DbConnection;
 		}


### PR DESCRIPTION
If trying to use an OrmLiteConnection across threads and you are trying to use transactions the following use case could occur:

Service 1 Starts Transaction
Service 2 Does Work (so it's attached to the transaction)
Service 1 Doesn't Commit Transaction
Service 2's work is lost

I've created a new UseTransaction to be used in scenarios like this. This function takes an Action to be fired in a using block for OpenTransaction so that the action can block
Exec calls off of the same connection (in other threads) and can block other UseTransaction calls (in other threads). A few unit tests for UseTransaction were also added.
