### PR TITLE
Support for SearchPath in ConnectionString when creating table

### DIFF
--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/CreatePostgreSQLTablesTests.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/CreatePostgreSQLTablesTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using NUnit.Framework;
 using ServiceStack.DataAnnotations;
 using ServiceStack.OrmLite.Tests;
+using ServiceStack.Text;
 
 namespace ServiceStack.OrmLite.PostgreSQL.Tests
 {
@@ -33,7 +34,8 @@ namespace ServiceStack.OrmLite.PostgreSQL.Tests
 
         private void _reCreateTheTable()
         {
-            using(var db = ConnectionString.OpenDbConnection()) {
+            using (var db = ConnectionString.OpenDbConnection())
+            {
                 db.CreateTable<CreatePostgreSQLTablesTests_dummy_table>(true);
             }
         }
@@ -47,6 +49,56 @@ namespace ServiceStack.OrmLite.PostgreSQL.Tests
 
             [StringLength(100)]
             public String String100Characters { get; set; }
+        }
+
+        [Test]
+        public void can_create_same_table_in_multiple_schemas_based_on_conn_string_search_path()
+        {
+            var builder = new Npgsql.NpgsqlConnectionStringBuilder(ConnectionString);
+            var schema1 = "schema_1";
+            var schema2 = "schema_2";
+            using (var db = ConnectionString.OpenDbConnection())
+            {
+                CreateSchemaIfNotExists(db, schema1);
+                CreateSchemaIfNotExists(db, schema2);
+            }
+
+            builder.SearchPath = schema1;
+            using (var dbS1 = builder.ToString().OpenDbConnection())
+            {
+                dbS1.DropTable<CreatePostgreSQLTablesTests_dummy_table>();
+                dbS1.CreateTable<CreatePostgreSQLTablesTests_dummy_table>();
+                Assert.That(dbS1.Count<CreatePostgreSQLTablesTests_dummy_table>(), Is.EqualTo(0));
+            }
+            builder.SearchPath = schema2;
+
+            using (var dbS2 = builder.ToString().OpenDbConnection())
+            {
+                dbS2.DropTable<CreatePostgreSQLTablesTests_dummy_table>();
+                dbS2.CreateTable<CreatePostgreSQLTablesTests_dummy_table>();
+                Assert.That(dbS2.Count<CreatePostgreSQLTablesTests_dummy_table>(), Is.EqualTo(0));
+            }
+
+        }
+
+        private void CreateSchemaIfNotExists(System.Data.IDbConnection db, string name)
+        {
+            string createSchemaSQL = @"DO $$
+BEGIN
+
+    IF NOT EXISTS(
+        SELECT schema_name
+          FROM information_schema.schemata
+          WHERE schema_name = '{0}'
+      )
+    THEN
+      EXECUTE 'CREATE SCHEMA ""{0}""';
+    END IF;
+
+END
+$$;"
+                .Fmt(name);
+            db.ExecuteSql(createSchemaSQL);
         }
     }
 }

--- a/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
@@ -7,191 +7,202 @@ using Npgsql;
 namespace ServiceStack.OrmLite.PostgreSQL
 {
     public class PostgreSQLDialectProvider : OrmLiteDialectProviderBase<PostgreSQLDialectProvider>
-	{
-		public static PostgreSQLDialectProvider Instance = new PostgreSQLDialectProvider();
+    {
+        public static PostgreSQLDialectProvider Instance = new PostgreSQLDialectProvider();
         const string textColumnDefinition = "text";
 
-		private PostgreSQLDialectProvider()
-		{
-			base.AutoIncrementDefinition = "";
-			base.IntColumnDefinition = "integer";
-			base.BoolColumnDefinition = "boolean";
-			base.TimeColumnDefinition = "time";
-			base.DateTimeColumnDefinition = "timestamp";
-			base.DecimalColumnDefinition = "numeric(38,6)";
-			base.GuidColumnDefinition = "uuid";
-			base.ParamString = ":";
-			base.BlobColumnDefinition = "bytea";
-			base.RealColumnDefinition = "double precision";
+        private PostgreSQLDialectProvider()
+        {
+            base.AutoIncrementDefinition = "";
+            base.IntColumnDefinition = "integer";
+            base.BoolColumnDefinition = "boolean";
+            base.TimeColumnDefinition = "time";
+            base.DateTimeColumnDefinition = "timestamp";
+            base.DecimalColumnDefinition = "numeric(38,6)";
+            base.GuidColumnDefinition = "uuid";
+            base.ParamString = ":";
+            base.BlobColumnDefinition = "bytea";
+            base.RealColumnDefinition = "double precision";
             base.StringLengthColumnDefinitionFormat = textColumnDefinition;
             //there is no "n"varchar in postgres. All strings are either unicode or non-unicode, inherited from the database.
             base.StringLengthUnicodeColumnDefinitionFormat = "character varying({0})";
-            base.StringLengthNonUnicodeColumnDefinitionFormat = "character varying({0})"; 
-			base.InitColumnTypeMap();
+            base.StringLengthNonUnicodeColumnDefinitionFormat = "character varying({0})";
+            base.InitColumnTypeMap();
 
             DbTypeMap.Set<TimeSpan>(DbType.Time, "Interval");
             DbTypeMap.Set<TimeSpan?>(DbType.Time, "Interval");
-		}
+        }
 
-		public override string GetColumnDefinition(
-			string fieldName,
-			Type fieldType,
-			bool isPrimaryKey,
-			bool autoIncrement,
-			bool isNullable,
-			int? fieldLength,
-			int? scale,
-			string defaultValue)
-		{
-			string fieldDefinition = null;
-			if (fieldType == typeof(string))
-			{
-				if (fieldLength != null)
-				{
-					fieldDefinition = string.Format(base.StringLengthColumnDefinitionFormat, fieldLength);
-				}
-				else
-				{
+        public override string GetColumnDefinition(
+            string fieldName,
+            Type fieldType,
+            bool isPrimaryKey,
+            bool autoIncrement,
+            bool isNullable,
+            int? fieldLength,
+            int? scale,
+            string defaultValue)
+        {
+            string fieldDefinition = null;
+            if (fieldType == typeof(string))
+            {
+                if (fieldLength != null)
+                {
+                    fieldDefinition = string.Format(base.StringLengthColumnDefinitionFormat, fieldLength);
+                }
+                else
+                {
                     fieldDefinition = textColumnDefinition;
-				}
-			}
-			else
-			{
-				if (autoIncrement)
-				{
-					if (fieldType == typeof(long))
-						fieldDefinition = "bigserial";
-					else if (fieldType == typeof(int))
-						fieldDefinition = "serial";
-				}
-				else
-				{
-					fieldDefinition = GetColumnTypeDefinition(fieldType);
-				}
-			}
+                }
+            }
+            else
+            {
+                if (autoIncrement)
+                {
+                    if (fieldType == typeof(long))
+                        fieldDefinition = "bigserial";
+                    else if (fieldType == typeof(int))
+                        fieldDefinition = "serial";
+                }
+                else
+                {
+                    fieldDefinition = GetColumnTypeDefinition(fieldType);
+                }
+            }
 
-			var sql = new StringBuilder();
-			sql.AppendFormat("{0} {1}", GetQuotedColumnName(fieldName), fieldDefinition);
+            var sql = new StringBuilder();
+            sql.AppendFormat("{0} {1}", GetQuotedColumnName(fieldName), fieldDefinition);
 
-			if (isPrimaryKey)
-			{
-				sql.Append(" PRIMARY KEY");
-			}
-			else
-			{
-				if (isNullable)
-				{
-					sql.Append(" NULL");
-				}
-				else
-				{
-					sql.Append(" NOT NULL");
-				}
-			}
+            if (isPrimaryKey)
+            {
+                sql.Append(" PRIMARY KEY");
+            }
+            else
+            {
+                if (isNullable)
+                {
+                    sql.Append(" NULL");
+                }
+                else
+                {
+                    sql.Append(" NOT NULL");
+                }
+            }
 
-			if (!string.IsNullOrEmpty(defaultValue))
-			{
-				sql.AppendFormat(DefaultValueFormat, defaultValue);
-			}
+            if (!string.IsNullOrEmpty(defaultValue))
+            {
+                sql.AppendFormat(DefaultValueFormat, defaultValue);
+            }
 
-			return sql.ToString();
-		}		
+            return sql.ToString();
+        }
 
         public override string GetQuotedParam(string paramValue)
         {
             return "'" + paramValue.Replace("'", @"''") + "'";
         }
 
-		public override IDbConnection CreateConnection(string connectionString, Dictionary<string, string> options)
-		{
-			return new NpgsqlConnection(connectionString);
-		}
+        public override IDbConnection CreateConnection(string connectionString, Dictionary<string, string> options)
+        {
+            return new NpgsqlConnection(connectionString);
+        }
 
-		public override string GetQuotedValue(object value, Type fieldType)
-		{
-			if (value == null) return "NULL";
+        public override string GetQuotedValue(object value, Type fieldType)
+        {
+            if (value == null) return "NULL";
 
-			if (fieldType == typeof(DateTime))
-			{
-				var dateValue = (DateTime)value;
-				const string iso8601Format = "yyyy-MM-dd HH:mm:ss.fff";
-				return base.GetQuotedValue(dateValue.ToString(iso8601Format), typeof(string));
-			}
-			if (fieldType == typeof(Guid))
-			{
-				var guidValue = (Guid)value;
-				return base.GetQuotedValue(guidValue.ToString("N"), typeof(string));
-			}
-			if(fieldType == typeof(byte[]))
-			{
-				return "E'" + ToBinary(value) + "'";
-			}
+            if (fieldType == typeof(DateTime))
+            {
+                var dateValue = (DateTime)value;
+                const string iso8601Format = "yyyy-MM-dd HH:mm:ss.fff";
+                return base.GetQuotedValue(dateValue.ToString(iso8601Format), typeof(string));
+            }
+            if (fieldType == typeof(Guid))
+            {
+                var guidValue = (Guid)value;
+                return base.GetQuotedValue(guidValue.ToString("N"), typeof(string));
+            }
+            if (fieldType == typeof(byte[]))
+            {
+                return "E'" + ToBinary(value) + "'";
+            }
 
-			return base.GetQuotedValue(value, fieldType);
-		}
+            return base.GetQuotedValue(value, fieldType);
+        }
 
-		public override object ConvertDbValue(object value, Type type)
-		{
-			if (value == null || value is DBNull) return null;
-			
-			if(type == typeof(byte[])) { return value; }
+        public override object ConvertDbValue(object value, Type type)
+        {
+            if (value == null || value is DBNull) return null;
 
-			return base.ConvertDbValue(value, type);
-		}
+            if (type == typeof(byte[])) { return value; }
 
-		public override long GetLastInsertId(IDbCommand command)
-		{
-			command.CommandText = "SELECT LASTVAL()";
-			var result = command.ExecuteScalar();
-			if (result is DBNull)
-				return default(long);
-			return Convert.ToInt64(result);
-		}
-		
-		public override SqlExpressionVisitor<T> ExpressionVisitor<T>()
-		{
-			return new PostgreSQLExpressionVisitor<T>();
-		}
+            return base.ConvertDbValue(value, type);
+        }
 
-		public override bool DoesTableExist(IDbCommand dbCmd, string tableName)
-		{
-			var sql = "SELECT COUNT(*) FROM pg_class WHERE relname = {0}"
-				.SqlFormat(tableName);
+        public override long GetLastInsertId(IDbCommand command)
+        {
+            command.CommandText = "SELECT LASTVAL()";
+            var result = command.ExecuteScalar();
+            if (result is DBNull)
+                return default(long);
+            return Convert.ToInt64(result);
+        }
 
-			dbCmd.CommandText = sql;
-			var result = dbCmd.GetLongScalar();
+        public override SqlExpressionVisitor<T> ExpressionVisitor<T>()
+        {
+            return new PostgreSQLExpressionVisitor<T>();
+        }
 
-			return result > 0;
-		}
+        public override bool DoesTableExist(IDbCommand dbCmd, string tableName)
+        {
+            var conn = dbCmd.Connection as NpgsqlConnection;
 
-		public override string ToExecuteProcedureStatement(object objWithProperties)
-		{
-			var sbColumnValues = new StringBuilder();
+            var sql = "SELECT COUNT(*) FROM pg_class WHERE relname = {0}"
+               .SqlFormat(tableName);
 
-			var tableType = objWithProperties.GetType();
-			var modelDef = GetModel(tableType);
+            if (conn != null)
+            {
+                var builder = new NpgsqlConnectionStringBuilder(conn.ConnectionString);
+                // If a search path (schema) is specified, and there is only one, then assume the CREATE TABLE directive should apply to that schema.
+                if (!String.IsNullOrEmpty(builder.SearchPath) && !builder.SearchPath.Contains(","))
+                    sql = "SELECT COUNT(*) FROM pg_class JOIN pg_catalog.pg_namespace n ON n.oid = pg_class.relnamespace WHERE relname = {0} AND nspname = {1}"
+                        .SqlFormat(tableName, builder.SearchPath);
+            }                                                                                       
 
-			foreach (var fieldDef in modelDef.FieldDefinitions)
-			{
-				if (sbColumnValues.Length > 0) sbColumnValues.Append(",");
-				try
-				{
-					sbColumnValues.Append(fieldDef.GetQuotedValue(objWithProperties));
-				}
-				catch (Exception)
-				{
-					throw;
-				}
-			}
+            dbCmd.CommandText = sql;
+            var result = dbCmd.GetLongScalar();
 
-			var sql = string.Format("{0} {1}{2}{3};",
-				GetQuotedTableName(modelDef),
-				sbColumnValues.Length > 0 ? "(" : "",
-				sbColumnValues,
-				sbColumnValues.Length > 0 ? ")" : "");
+            return result > 0;
+        }
 
-			return sql;
-		}
+        public override string ToExecuteProcedureStatement(object objWithProperties)
+        {
+            var sbColumnValues = new StringBuilder();
+
+            var tableType = objWithProperties.GetType();
+            var modelDef = GetModel(tableType);
+
+            foreach (var fieldDef in modelDef.FieldDefinitions)
+            {
+                if (sbColumnValues.Length > 0) sbColumnValues.Append(",");
+                try
+                {
+                    sbColumnValues.Append(fieldDef.GetQuotedValue(objWithProperties));
+                }
+                catch (Exception)
+                {
+                    throw;
+                }
+            }
+
+            var sql = string.Format("{0} {1}{2}{3};",
+                GetQuotedTableName(modelDef),
+                sbColumnValues.Length > 0 ? "(" : "",
+                sbColumnValues,
+                sbColumnValues.Length > 0 ? ")" : "");
+
+            return sql;
+        }
 
         public override string GetQuotedTableName(ModelDefinition modelDef)
         {
@@ -203,26 +214,26 @@ namespace ServiceStack.OrmLite.PostgreSQL
             return string.Format("\"{0}\".\"{1}\"", escapedSchema, base.NamingStrategy.GetTableName(modelDef.ModelName));
         }
 
-		/// <summary>
-		/// based on Npgsql2's source: Npgsql2\src\NpgsqlTypes\NpgsqlTypeConverters.cs
-		/// </summary>
-		/// <param name="TypeInfo"></param>
-		/// <param name="NativeData"></param>
-		/// <param name="ForExtendedQuery"></param>
-		/// <returns></returns>
-		internal static String ToBinary(Object NativeData)
-		{
-			Byte[] byteArray = (Byte[])NativeData;
-			StringBuilder res = new StringBuilder(byteArray.Length * 5);
-			foreach(byte b in byteArray)
-				if(b >= 0x20 && b < 0x7F && b != 0x27 && b != 0x5C)
-					res.Append((char)b);
-				else
-					res.Append("\\\\")
-						.Append((char)('0' + (7 & (b >> 6))))
-						.Append((char)('0' + (7 & (b >> 3))))
-						.Append((char)('0' + (7 & b)));
-			return res.ToString();
-		}
-	}
+        /// <summary>
+        /// based on Npgsql2's source: Npgsql2\src\NpgsqlTypes\NpgsqlTypeConverters.cs
+        /// </summary>
+        /// <param name="TypeInfo"></param>
+        /// <param name="NativeData"></param>
+        /// <param name="ForExtendedQuery"></param>
+        /// <returns></returns>
+        internal static String ToBinary(Object NativeData)
+        {
+            Byte[] byteArray = (Byte[])NativeData;
+            StringBuilder res = new StringBuilder(byteArray.Length * 5);
+            foreach (byte b in byteArray)
+                if (b >= 0x20 && b < 0x7F && b != 0x27 && b != 0x5C)
+                    res.Append((char)b);
+                else
+                    res.Append("\\\\")
+                        .Append((char)('0' + (7 & (b >> 6))))
+                        .Append((char)('0' + (7 & (b >> 3))))
+                        .Append((char)('0' + (7 & b)));
+            return res.ToString();
+        }
+    }
 }


### PR DESCRIPTION
Hi, 
I'm currently building a mutli-tenanted service using Postgres and ORMLite, and using CreateTable<> to build the schema when a tenant is created.  I'm using SearchPath in the connection string to identify the tenantID, which then maps to the tenant schema.  

I found that the "table exists" lookup finds a table if they are in any schema in the db, which meant the tables weren't being created.  The fix will only apply when the SearchPath in the connection string has a single schema in it.

Cheers, 
Chris
