### PR TITLE
Support for single schema in search path for table creation

### DIFF
--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/CreatePostgreSQLTablesTests.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/CreatePostgreSQLTablesTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using NUnit.Framework;
 using ServiceStack.DataAnnotations;
 using ServiceStack.OrmLite.Tests;
+using ServiceStack.Text;
 
 namespace ServiceStack.OrmLite.PostgreSQL.Tests
 {
@@ -47,6 +48,56 @@ namespace ServiceStack.OrmLite.PostgreSQL.Tests
 
             [StringLength(100)]
             public String String100Characters { get; set; }
+        }
+          
+        [Test]
+        public void can_create_same_table_in_multiple_schemas_based_on_conn_string_search_path()
+        {
+            var builder = new Npgsql.NpgsqlConnectionStringBuilder(ConnectionString);
+            var schema1 = "schema_1";
+            var schema2 = "schema_2";
+            using (var db = ConnectionString.OpenDbConnection())
+            {
+                CreateSchemaIfNotExists(db, schema1);
+                CreateSchemaIfNotExists(db, schema2);
+            }
+
+            builder.SearchPath = schema1;
+            using (var dbS1 = builder.ToString().OpenDbConnection())
+            {
+                dbS1.DropTable<CreatePostgreSQLTablesTests_dummy_table>();
+                dbS1.CreateTable<CreatePostgreSQLTablesTests_dummy_table>();
+                Assert.That(dbS1.Count<CreatePostgreSQLTablesTests_dummy_table>(), Is.EqualTo(0));
+            }
+            builder.SearchPath = schema2;
+
+            using (var dbS2 = builder.ToString().OpenDbConnection())
+            {
+                dbS2.DropTable<CreatePostgreSQLTablesTests_dummy_table>();
+                dbS2.CreateTable<CreatePostgreSQLTablesTests_dummy_table>();
+                Assert.That(dbS2.Count<CreatePostgreSQLTablesTests_dummy_table>(), Is.EqualTo(0));
+            }
+
+        }
+
+        private void CreateSchemaIfNotExists(System.Data.IDbConnection db, string name)
+        {
+            string createSchemaSQL = @"DO $$
+BEGIN
+
+    IF NOT EXISTS(
+        SELECT schema_name
+          FROM information_schema.schemata
+          WHERE schema_name = '{0}'
+      )
+    THEN
+      EXECUTE 'CREATE SCHEMA ""{0}""';
+    END IF;
+
+END
+$$;"
+                .Fmt(name);
+            db.ExecuteSql(createSchemaSQL);
         }
     }
 }

--- a/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
@@ -157,7 +157,15 @@ namespace ServiceStack.OrmLite.PostgreSQL
 		{
 			var sql = "SELECT COUNT(*) FROM pg_class WHERE relname = {0}"
 				.SqlFormat(tableName);
-
+		    var conn = dbCmd.Connection;
+            if (conn != null)
+            {
+                var builder = new NpgsqlConnectionStringBuilder(conn.ConnectionString);
+                // If a search path (schema) is specified, and there is only one, then assume the CREATE TABLE directive should apply to that schema.
+                if (!String.IsNullOrEmpty(builder.SearchPath) && !builder.SearchPath.Contains(","))
+                    sql = "SELECT COUNT(*) FROM pg_class JOIN pg_catalog.pg_namespace n ON n.oid = pg_class.relnamespace WHERE relname = {0} AND nspname = {1}"
+                          .SqlFormat(tableName, builder.SearchPath);
+            }     
 			dbCmd.CommandText = sql;
 			var result = dbCmd.GetLongScalar();
 


### PR DESCRIPTION
Hi, 
I'm currently building a mutli-tenanted service using Postgres and ORMLite, and using CreateTable<> to build the schema when a tenant is created. I'm using SearchPath in the connection string to identify the tenantID, which then maps to the tenant schema.

I found that the "table exists" lookup finds a table if they are in any schema in the db, which meant the tables weren't being created. The fix will only apply when the SearchPath in the connection string has a single schema in it.

Cheers, 
Chris

PS (Apologies for previous PR, my VS changed the alignment)
