### PR TITLE
Change default naming strategy for postgres

### DIFF
--- a/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
@@ -28,6 +28,7 @@ namespace ServiceStack.OrmLite.PostgreSQL
             base.StringLengthUnicodeColumnDefinitionFormat = "character varying({0})";
             base.StringLengthNonUnicodeColumnDefinitionFormat = "character varying({0})"; 
 			base.InitColumnTypeMap();
+		    this.NamingStrategy = new PostgreSqlNamingStrategy();
 
             DbTypeMap.Set<TimeSpan>(DbType.Time, "Interval");
             DbTypeMap.Set<TimeSpan?>(DbType.Time, "Interval");

--- a/src/ServiceStack.OrmLite.PostgreSQL/PostgreSqlNamingStrategy.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL/PostgreSqlNamingStrategy.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using ServiceStack.Common;
+
+namespace ServiceStack.OrmLite.PostgreSQL
+{
+    public class PostgreSqlNamingStrategy : INamingStrategy
+    {
+        public string GetTableName(string name)
+        {
+            return name.ToLowercaseUnderscore();
+        }
+
+        public string GetColumnName(string name)
+        {
+            return name.ToLowercaseUnderscore();
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite.PostgreSQL/ServiceStack.OrmLite.PostgreSQL.csproj
+++ b/src/ServiceStack.OrmLite.PostgreSQL/ServiceStack.OrmLite.PostgreSQL.csproj
@@ -34,6 +34,9 @@
     <Reference Include="Mono.Security">
       <HintPath>..\..\lib\Mono.Security.dll</HintPath>
     </Reference>
+    <Reference Include="ServiceStack.Common">
+      <HintPath>..\..\lib\ServiceStack.Common.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -50,6 +53,7 @@
     </Compile>
     <Compile Include="PostgreSqlDialect.cs" />
     <Compile Include="PostgreSQLDialectProvider.cs" />
+    <Compile Include="PostgreSqlNamingStrategy.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PostgreSQLExpressionVisitor.cs" />
   </ItemGroup>


### PR DESCRIPTION
Change default naming strategy for postgres to enable wrist (and brain) friendly ad-hoc queries

https://github.com/ServiceStack/ServiceStack.OrmLite/issues/239
