### PR TITLE
SQLite dependency changed to x86

### DIFF
--- a/NuGet/ServiceStack.OrmLite.Sqlite32/servicestack.ormlite.sqlite32.nuspec
+++ b/NuGet/ServiceStack.OrmLite.Sqlite32/servicestack.ormlite.sqlite32.nuspec
@@ -17,7 +17,7 @@
     <copyright>ServiceStack 2013 and contributors</copyright>
     <dependencies>
         <dependency id="ServiceStack.Common" />
-        <dependency id="System.Data.SQLite" />
+        <dependency id="System.Data.SQLite.x86" />
     </dependencies> 
   </metadata> 
 </package>


### PR DESCRIPTION
because `System.Data.SQLite` contains unnecessary interop dlls
