### PR TITLE
Added tests for Update/UpdateParam on Sql server 

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServerTests/UpdateTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/UpdateTests.cs
@@ -135,7 +135,7 @@ namespace ServiceStack.OrmLite.SqlServerTests
                 obj.Name = "Someothername";
                 con.UpdateParam(obj);
 
-                var target = con.GetById<SimpleType>(storedObj.Id);
+                var target = con.GetById<SimpleAliasedType>(storedObj.Id);
 
                 Assert.AreEqual(obj.Name, target.Name);
             }


### PR DESCRIPTION
I added a few tests for update/updateParam on Sql Server.

One test"Can_execute_updateParam_using_aliased_columns" on a model with Aliased columns fails as it does in a live environment for me. 
