### PR TITLE
Select object with byte[] is broken in Oracle.... Failing unit test supplied

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle.Tests/OracleParamTests.cs
+++ b/src/ServiceStack.OrmLite.Oracle.Tests/OracleParamTests.cs
@@ -18,6 +18,7 @@ namespace ServiceStack.OrmLite.Oracle.Tests
 
             db.CreateTable<ParamTestBO>(true);
             db.CreateTable<ParamRelBO>(true);
+            db.CreateTable<ParamByteBO>(true);
         }
 
         [Test]
@@ -226,6 +227,26 @@ namespace ServiceStack.OrmLite.Oracle.Tests
             }
         }
 
+        [Test]
+        public void ORA_ParamByteTest()
+        {
+            using (var db = ConnectionString.OpenDbConnection())
+            {
+                DropAndCreateTables(db);
+
+                db.DeleteAll<ParamByteBO>();
+                var bo1 = new ParamByteBO() { Id = 1, Data = new byte[] { 1, 25, 43, 3, 1, 66, 82, 23, 11, 44, 66, 22, 52, 62, 76, 19, 30, 91, 4 } };
+
+                db.InsertParam(bo1);
+                var bo1Check = db.SelectParam<ParamByteBO>(s => s.Id == bo1.Id).Single();
+
+                Assert.AreEqual(bo1.Id, bo1Check.Id);
+                Assert.AreEqual(bo1.Data, bo1Check.Data);
+
+                db.DeleteAll<ParamByteBO>();
+            }
+        }
+
 
 
         public class ParamTestBO
@@ -250,6 +271,12 @@ namespace ServiceStack.OrmLite.Oracle.Tests
 
             [Alias("InfoStr")]
             public string Info { get; set; }
+        }
+
+        public class ParamByteBO
+        {
+            public int Id { get; set; }
+            public byte[] Data { get; set; }
         }
     }
 }


### PR DESCRIPTION
As of Commit 584765e3 from pull request #169 this functionality appears to be broken at line 264 OrmLiteDialectProviderBase.cs

```
    public virtual object ConvertDbValue(object value, Type type)
    {
        if (value == null || value.GetType() == typeof(DBNull)) return null;

        if (value.GetType() == type)
        {
            if (type == typeof(byte[]))
                return TypeSerializer.DeserializeFromStream<byte[]>(new MemoryStream((byte[])value));
```

I would fix myself but I am not sure of the original intent of this fix so am a little wary of ammending this.

Some of my thoughts are:

if the target type is also byte, skip over this step?
create an oracle specific workaround (seems overkill since all that is required is to return the byte array as is)
