### PR TITLE
Update OrmLite.Core.ttinclude

### DIFF
--- a/src/T4/OrmLite.Core.ttinclude
+++ b/src/T4/OrmLite.Core.ttinclude
@@ -2303,11 +2303,6 @@ public static class Inflector {
         return MakeInitialCaps(Regex.Replace(lowercaseAndUnderscoredWord, @"_", " "));
     }
 
-    public static string ToPascalCase(string underscoredWords){
-        return UpperCaseFirstCharacter(Regex.Replace(underscoredWords,@"_([a-z])",
-            delegate(Match match){return match.Captures[0].Value.ToUpper();}).Replace("_",""));
-    }
-
     /// <summary>
     /// Adds the underscores.
     /// </summary>


### PR DESCRIPTION
Removed static ToPascalCase method which doesn't contain any xml commenting and calls missing UpperCaseFisrtCharacter method. 
The T4 templates should be stable to just download and use without any issues now.

Refer to comments from commit: #268
