### PR TITLE
JoinSqlBuilder now works with Alias'ed properties.

### DIFF
--- a/src/ServiceStack.OrmLite/JoinSqlBuilder.cs
+++ b/src/ServiceStack.OrmLite/JoinSqlBuilder.cs
@@ -48,9 +48,9 @@ namespace ServiceStack.OrmLite
             foreach (var item in pocoType.GetModelDefinition().FieldDefinitions)
             {
                 if (withTablePrefix)
-                    result.Add(string.Format("{0}.{1}", OrmLiteConfig.DialectProvider.GetQuotedTableName(tableName), OrmLiteConfig.DialectProvider.GetQuotedColumnName(item.Name)));
+                    result.Add(string.Format("{0}.{1}", OrmLiteConfig.DialectProvider.GetQuotedTableName(tableName), OrmLiteConfig.DialectProvider.GetQuotedColumnName(item.FieldName)));
                 else
-                    result.Add(string.Format("{0}", OrmLiteConfig.DialectProvider.GetQuotedColumnName(item.Name)));
+                    result.Add(string.Format("{0}", OrmLiteConfig.DialectProvider.GetQuotedColumnName(item.FieldName)));
             }
             return result;
         }


### PR DESCRIPTION
...applied to their properties.  Switched from use of FieldDefinition.Name to FieldDefinition.FieldName.
