### PR TITLE
Fixed Filtering with Anonymous Types and Aliased Field Names

### DIFF
--- a/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
+++ b/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
@@ -147,6 +147,7 @@
     <Compile Include="SqlBuilderTests.cs" />
     <Compile Include="SqlServerProviderTests.cs" />
     <Compile Include="TypeWithByteArrayFieldTests.cs" />
+    <Compile Include="UseCase\AliasedFieldUseCase.cs" />
     <Compile Include="UseCase\CustomerOrdersUseCase.cs" />
     <Compile Include="UseCase\SchemaUseCase.cs" />
     <Compile Include="UseCase\ShardingUseCase.cs" />

--- a/tests/ServiceStack.OrmLite.Tests/UseCase/AliasedFieldUseCase.cs
+++ b/tests/ServiceStack.OrmLite.Tests/UseCase/AliasedFieldUseCase.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using NUnit.Framework;
+using ServiceStack.DataAnnotations;
+
+namespace ServiceStack.OrmLite.Tests.UseCase
+{
+    [TestFixture]
+    public class AliasedFieldUseCase
+    {
+        [TestFixtureSetUp]
+        public void TestFixtureSetup() {
+            OrmLiteConfig.DialectProvider = SqliteDialect.Provider;
+        }
+
+        public class Foo
+        {
+            [Alias("SOME_COLUMN_NAME")]
+            public string Bar { get; set; }
+        }
+
+        [Test]
+        public void CanResolveAliasedFieldNameInAnonymousType()
+        {
+            using (IDbConnection db = ":memory:".OpenDbConnection())
+            {
+                db.CreateTable<Foo>(false);
+
+                db.Insert(new Foo { Bar = "some_value" });
+                db.Insert(new Foo { Bar = "a totally different value" });
+                db.Insert(new Foo { Bar = "whatever" });
+
+                // the original classes property name is used to create the anonymous type
+                List<Foo> foos = db.Where<Foo>(new { Bar = "some_value" });
+
+                Assert.That(foos, Has.Count.EqualTo(1));
+
+                // the aliased column name is used to create the anonymous type
+                foos = db.Where<Foo>(new { SOME_COLUMN_NAME = "some_value" });
+
+                Assert.That(foos, Has.Count.EqualTo(1));
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
changed SetParameter in OrmLiteReadExtensions
to handle the conversion to aliased field names
when filtering using anonymous type declarations
which reference the original field name.

**_I haven't looked it over from the perspective of 
how much slower running "SetParameter" might
become**_
