### PR TITLE
fix sql contains and in expression visitors to allow for value types

### DIFF
--- a/src/ServiceStack.OrmLite/Expressions/SqlExpressionVisitor.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpressionVisitor.cs
@@ -1061,27 +1061,14 @@ namespace ServiceStack.OrmLite
                     var lambda = Expression.Lambda<Func<object>>(member);
                     var getter = lambda.Compile();
 
-                    var inArgs = getter() as object[];
+                    var inArgs = Sql.Flatten(getter() as IEnumerable);
 
                     StringBuilder sIn = new StringBuilder();
                     foreach (Object e in inArgs)
                     {
-                        if (e.GetType().ToString() != "System.Collections.Generic.List`1[System.Object]")
-                        {
-                            sIn.AppendFormat("{0}{1}",
-                                         sIn.Length > 0 ? "," : "",
-                                         OrmLiteConfig.DialectProvider.GetQuotedValue(e, e.GetType()));
-                        }
-                        else
-                        {
-                            var listArgs = e as IList<Object>;
-                            foreach (Object el in listArgs)
-                            {
-                                sIn.AppendFormat("{0}{1}",
-                                         sIn.Length > 0 ? "," : "",
-                                         OrmLiteConfig.DialectProvider.GetQuotedValue(el, el.GetType()));
-                            }
-                        }
+                        sIn.AppendFormat("{0}{1}",
+                                     sIn.Length > 0 ? "," : "",
+                                     OrmLiteConfig.DialectProvider.GetQuotedValue(e, e.GetType()));
                     }
 
                     statement = string.Format("{0} {1} ({2})", quotedColName, "In", sIn.ToString());
@@ -1110,7 +1097,7 @@ namespace ServiceStack.OrmLite
                     var lambda = Expression.Lambda<Func<object>>(member);
                     var getter = lambda.Compile();
 
-                    var inArgs = getter() as object[];
+                    var inArgs = Sql.Flatten(getter() as IEnumerable);
 
                     StringBuilder sIn = new StringBuilder();
                     foreach (Object e in inArgs)

--- a/tests/ServiceStack.OrmLite.Tests/ExpressionVisitorTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/ExpressionVisitorTests.cs
@@ -145,12 +145,28 @@ namespace ServiceStack.OrmLite.Tests
         }
 
         [Test]
-        public void Can_Select_using_Array_Contains()
+        public void Can_Select_using_object_Array_Contains()
         {
             var vals = new object[]{ TestEnum.Val0, TestEnum.Val1 };
 
             var visitor1 = OrmLiteConfig.DialectProvider.ExpressionVisitor<TestType>();
             visitor1.Where(q => vals.Contains(q.EnumCol) || vals.Contains(q.EnumCol));
+            var sql1 = visitor1.ToSelectStatement();
+
+            var visitor2 = OrmLiteConfig.DialectProvider.ExpressionVisitor<TestType>();
+            visitor2.Where(q => Sql.In(q.EnumCol, vals) || Sql.In(q.EnumCol, vals));
+            var sql2 = visitor2.ToSelectStatement();
+
+            Assert.AreEqual(sql1, sql2);
+        }
+
+        [Test]
+        public void Can_Select_using_int_Array_Contains()
+        {
+            var vals = new int[] { (int)TestEnum.Val0, (int)TestEnum.Val1 };
+
+            var visitor1 = OrmLiteConfig.DialectProvider.ExpressionVisitor<TestType>();
+            visitor1.Where(q => vals.Contains((int)q.EnumCol) || vals.Contains((int)q.EnumCol));
             var sql1 = visitor1.ToSelectStatement();
 
             var visitor2 = OrmLiteConfig.DialectProvider.ExpressionVisitor<TestType>();


### PR DESCRIPTION
Based on my [question at SO](http://stackoverflow.com/questions/17691194/ormlite-where-contains-fails). I basically copied the fix from the recent commit for sqlite (9f0b0e8cfa4410da5d288bf754ba6538805cbec0).
