### PR TITLE
Don't break loop on NullReferenceException. ...

### DIFF
--- a/src/ServiceStack.OrmLite/FieldDefinition.cs
+++ b/src/ServiceStack.OrmLite/FieldDefinition.cs
@@ -62,7 +62,13 @@ namespace ServiceStack.OrmLite
             if (this.SetValueFn == null) return;
 
             var convertedValue = OrmLiteConfig.DialectProvider.ConvertDbValue(withValue, this.FieldType);
-            SetValueFn(onInstance, convertedValue);
+            try
+            {
+                SetValueFn(onInstance, convertedValue);
+            }
+            catch (NullReferenceException ex)
+            {
+            }
         }
 
         public string GetQuotedValue(object fromInstance)


### PR DESCRIPTION
I understand that this is not the ideal way to catch such errors, but I believe this is preferable to the current behavior of terminating the loop entirely when a conflicting thing occurs.

We encountered this due to a conflict between our DataContracts and our database. Someone failed to set the NOT NULL constraint on the DB and a stray NULL value was causing a malfunction here, because our DataContract does not allow that field to be nullable. This one NULL value was causing very erratic and hard to diagnose issues wherein our object was returning only half-filled. As it took some significant man-time to get to the bottom of this, I suggest the merge of this incomplete patch to keep the ramifications of this failure localized.

Under ideal circumstances, an exception would have been raised, sent all the way up to the application instead of terminating inside of OrmLite, and the language would have made the error obvious ("Attempted to set a NULL value on an object which doesn't allow NULL", or similar). However, as that fix is much more involved, I hope that this hotfix which minimizes the potential damage will be a satisfactory shim until a more appropriate fix can be created.
