### PR TITLE
Fixed connection string parsing issue with UNC pathes

### DIFF
--- a/src/ServiceStack.OrmLite.Sqlite32/SqliteOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Sqlite32/SqliteOrmLiteDialectProvider.cs
@@ -10,7 +10,7 @@ namespace ServiceStack.OrmLite.Sqlite
 
 		protected override IDbConnection CreateConnection(string connectionString)
 		{
-			return new SQLiteConnection(connectionString);
+			return new SQLiteConnection(connectionString, true);
 		}
 
 		public SqliteOrmLiteDialectProvider WithPassword(string password) {

--- a/src/ServiceStack.OrmLite.Sqlite64/SqliteOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Sqlite64/SqliteOrmLiteDialectProvider.cs
@@ -10,7 +10,7 @@ namespace ServiceStack.OrmLite.Sqlite
 
 		protected override IDbConnection CreateConnection(string connectionString)
 		{
-			return new SQLiteConnection(connectionString);
+			return new SQLiteConnection(connectionString, true);
 		}
 	}
 }


### PR DESCRIPTION
The issue can be fixed by setting the constructor parameter "parseViaFramework" of SQLiteConnection to true.

Only few documentation is available about that change that was apparently introduced with bugfix http://sqlite.1065341.n5.nabble.com/3-7-7-URI-filenames-and-UNC-paths-td6893.html

N.B.: I don't know wether or not the Mono version is affected.
