### PR TITLE
updated FirebirdTests to fix transactions use.

### DIFF
--- a/tests/ServiceStack.OrmLite.FirebirdTests/DateTimeColumnTest.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/DateTimeColumnTest.cs
@@ -15,7 +15,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
         [Test]
         public void Can_create_table_containing_DateTime_column()
         {
-            using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
             {
                 db.CreateTable<Analyze>(true);
             }
@@ -24,7 +24,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
         [Test]
         public void Can_store_DateTime_Value()
         {
-            using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
             {
                 db.CreateTable<Analyze>(true);
 
@@ -41,7 +41,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
         [Test]
         public void Can_store_and_retrieve_DateTime_Value()
         {
-            using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
             {
                 db.CreateTable<Analyze>(true);
 

--- a/tests/ServiceStack.OrmLite.FirebirdTests/ForeignKeyAttributeTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/ForeignKeyAttributeTests.cs
@@ -9,7 +9,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[TestFixtureSetUp]
 		public void Setup()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+			using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ReferencedType>(true);
 			}
@@ -18,7 +18,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void CanCreateSimpleForeignKey()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+			using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<TypeWithSimpleForeignKey>(true);
 			}
@@ -27,7 +27,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void CanCreateForeignWithOnDeleteCascade()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+			using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<TypeWithOnDeleteCascade>(true);
 			}
@@ -36,7 +36,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void CascadesOnDelete()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+			using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<TypeWithOnDeleteCascade>(true);
 				
@@ -56,7 +56,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void CanCreateForeignWithOnDeleteCascadeAndOnUpdateCascade()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+			using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<TypeWithOnDeleteAndUpdateCascade>(true);
 			}
@@ -65,7 +65,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void CanCreateForeignWithOnDeleteNoAction()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+			using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<TypeWithOnDeleteNoAction>(true);
 			}
@@ -74,7 +74,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void CanCreateForeignWithOnDeleteRestrict()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+			using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<TypeWithOnDeleteRestrict>(true);
 			}
@@ -84,7 +84,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void CanCreateForeignWithOnDeleteSetDefault()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+			using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<TypeWithOnDeleteSetDefault>(true);
 			}
@@ -93,7 +93,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void CanCreateForeignWithOnDeleteSetNull()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+			using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<TypeWithOnDeleteSetNull>(true);
 			}
@@ -102,7 +102,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[TestFixtureTearDown]
 		public void TearDwon()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+			using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.DropTable<TypeWithOnDeleteAndUpdateCascade>();
 				db.DropTable<TypeWithOnDeleteSetNull>();

--- a/tests/ServiceStack.OrmLite.FirebirdTests/LocalizationTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/LocalizationTests.cs
@@ -42,11 +42,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_query_using_float_in_alernate_culuture()
 		{
-			var dbFactory = new OrmLiteConnectionFactory(
-				GetFileConnectionString(),
-				FirebirdOrmLiteDialectProvider.Instance);
-
-            using (var db = dbFactory.Open())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<Point>(true);
 

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteBasicPersistenceProviderTest.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteBasicPersistenceProviderTest.cs
@@ -19,7 +19,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_GetById_from_basic_persistence_provider()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 
@@ -38,7 +38,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_GetByIds_from_basic_persistence_provider()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 
@@ -61,7 +61,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_Store_from_basic_persistence_provider()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 
@@ -84,7 +84,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_Delete_from_basic_persistence_provider()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteComplexTypesTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteComplexTypesTests.cs
@@ -14,7 +14,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_insert_into_ModelWithComplexTypes_table()
 		{
-            using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithComplexTypes>(true);
 
@@ -28,7 +28,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_insert_and_select_from_ModelWithComplexTypes_table()
 		{
-            using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithComplexTypes>(true);
 
@@ -47,7 +47,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_insert_and_select_from_OrderLineData()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<SampleOrderLine>(true);
 

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteConnectionTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteConnectionTests.cs
@@ -21,7 +21,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_create_connection()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 			}
 		}
@@ -56,11 +56,11 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_open_two_ReadOnlyConnections_to_same_database()
 		{
-			var db = "User=SYSDBA;Password=masterkey;Database=ormlite-tests.fdb;DataSource=localhost;Dialect=3;charset=ISO8859_1;".OpenDbConnection();
+            var db = ConnectionString.OpenReadOnlyDbConnection();
             db.CreateTable<ModelWithIdAndName>(true);
             db.Insert(new ModelWithIdAndName(1));
 
-			var dbReadOnly = "User=SYSDBA;Password=masterkey;Database=ormlite-tests.fdb;DataSource=localhost;Dialect=3;charset=ISO8859_1;".OpenDbConnection();
+            var dbReadOnly = ConnectionString.OpenReadOnlyDbConnection();
             dbReadOnly.Insert(new ModelWithIdAndName(2));
             var rows = dbReadOnly.Select<ModelWithIdAndName>();
             Assert.That(rows, Has.Count.EqualTo(2));

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteCreateTableTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteCreateTableTests.cs
@@ -12,7 +12,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Does_table_Exists()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.DropTable<ModelWithIdOnly>();
 
@@ -31,7 +31,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_create_ModelWithIdOnly_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIdOnly>(true);
 			}
@@ -40,7 +40,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_create_ModelWithOnlyStringFields_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 			}
@@ -49,7 +49,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_create_ModelWithLongIdAndStringFields_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithLongIdAndStringFields>(true);
 			}
@@ -58,7 +58,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_create_ModelWithFieldsOfDifferentTypes_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 			}
@@ -67,7 +67,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_preserve_ModelWithIdOnly_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIdOnly>(true);
 
@@ -85,7 +85,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_preserve_ModelWithIdAndName_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIdAndName>(true);
 				db.DeleteAll<ModelWithIdAndName>();
@@ -104,7 +104,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_overwrite_ModelWithIdOnly_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIdOnly>(true);
 
@@ -122,7 +122,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_create_multiple_tables()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTables(true, typeof(ModelWithIdOnly), typeof(ModelWithIdAndName));
 

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteCreateTableWithIndexesTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteCreateTableWithIndexesTests.cs
@@ -14,7 +14,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		public void Can_create_ModelWithIndexFields_table()
 		{
 			OrmLiteConfig.DialectProvider.DefaultStringLength=128;
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIndexFields>(true);
 
@@ -29,7 +29,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		public void Can_create_ModelWithCompositeIndexFields_table()
 		{
 			OrmLiteConfig.DialectProvider.DefaultStringLength=128;
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithCompositeIndexFields>(true);
 

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteCreateTableWithNamigStrategyTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteCreateTableWithNamigStrategyTests.cs
@@ -16,7 +16,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		{
 			OrmLite.OrmLiteConfig.DialectProvider.NamingStrategy = new UnderscoreSeparatedCompoundNamingStrategy();
 
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 			}
@@ -33,7 +33,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 				ColumnPrefix = "col_",
 			};
 
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 				ModelWithOnlyStringFields m = new ModelWithOnlyStringFields() { Id= "999", AlbumId = "112", AlbumName="ElectroShip", Name = "MyNameIsBatman"};
@@ -56,7 +56,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 				ColumnPrefix = "col_",
 			};
 
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 				ModelWithOnlyStringFields m = new ModelWithOnlyStringFields() { Id = "998", AlbumId = "112", AlbumName = "ElectroShip", Name = "QueryByExample" };
@@ -78,7 +78,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 				ColumnPrefix = "col_",
 			};
 
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 				ModelWithOnlyStringFields m = new ModelWithOnlyStringFields() { Id = "998", AlbumId = "112", AlbumName = "ElectroShip", Name = "QueryByExample" };
@@ -95,7 +95,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 			
 			OrmLite.OrmLiteConfig.DialectProvider.NamingStrategy= new OrmLiteNamingStrategyBase();
 			
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 				ModelWithOnlyStringFields m = new ModelWithOnlyStringFields() { Id = "998", AlbumId = "112", AlbumName = "ElectroShip", Name = "QueryByExample" };
@@ -116,7 +116,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 				ColumnPrefix = "col_",
 			};
 
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 				ModelWithOnlyStringFields m = new ModelWithOnlyStringFields() { Id = "998", AlbumId = "112", AlbumName = "ElectroShip", Name = "QueryByExample" };

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteDeleteTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteDeleteTests.cs
@@ -19,7 +19,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_Delete_from_ModelWithFieldsOfDifferentTypes_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 
@@ -41,7 +41,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_DeleteById_from_ModelWithFieldsOfDifferentTypes_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 
@@ -60,7 +60,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_DeleteByIds_from_ModelWithFieldsOfDifferentTypes_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteGetScalarTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteGetScalarTests.cs
@@ -41,7 +41,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 				NDoubleProperty= 8.25
 			});
 			
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<Author>(true);
 				db.DeleteAll<Author>();

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteInsertTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteInsertTests.cs
@@ -16,7 +16,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_insert_into_ModelWithFieldsOfDifferentTypes_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 
@@ -29,7 +29,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_insert_and_select_from_ModelWithFieldsOfDifferentTypes_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 
@@ -48,7 +48,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_insert_and_select_from_ModelWithFieldsOfNullableTypes_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfNullableTypes>(true);
 
@@ -67,7 +67,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
         [Test]
         public void Can_insert_and_select_from_ModelWithFieldsOfDifferentAndNullableTypes_table_default_GUID()
         {
-            using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
                 Can_insert_and_select_from_ModelWithFieldsOfDifferentAndNullableTypes_table_impl(db);
         }
 
@@ -104,7 +104,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_insert_table_with_null_fields()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIdAndName>(true);
 				db.DeleteAll<ModelWithIdAndName>();
@@ -124,7 +124,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_retrieve_LastInsertId_from_inserted_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIdAndName>(true);
 
@@ -148,7 +148,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_insert_TaskQueue_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<TaskQueue>(true);
 
@@ -170,7 +170,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_insert_table_with_blobs()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				var dsl= OrmLiteConfig.DialectProvider.DefaultStringLength;
 				OrmLiteConfig.DialectProvider.DefaultStringLength=1024;
@@ -228,7 +228,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_insert_table_with_UserAuth()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<UserAuth>(true);
 				

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteQueryTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteQueryTests.cs
@@ -13,7 +13,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_GetById_int_from_ModelWithFieldsOfDifferentTypes_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+			using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 
@@ -30,7 +30,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_GetById_string_from_ModelWithOnlyStringFields_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+			using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 
@@ -47,7 +47,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_select_with_filter_from_ModelWithOnlyStringFields_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+			using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 
@@ -87,7 +87,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_loop_each_with_filter_from_ModelWithOnlyStringFields_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+			using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteSaveTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteSaveTests.cs
@@ -13,7 +13,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_Save_into_ModelWithFieldsOfDifferentTypes_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 
@@ -26,7 +26,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_Save_and_select_from_ModelWithFieldsOfDifferentTypes_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 
@@ -45,7 +45,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_SaveAll_and_select_from_ModelWithFieldsOfDifferentTypes_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 
@@ -63,7 +63,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_SaveAll_and_select_from_ModelWithFieldsOfDifferentTypes_table_with_no_ids()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 				db.DeleteAll<ModelWithFieldsOfDifferentTypes>();
@@ -81,7 +81,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_Save_table_with_null_fields()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIdAndName>(true);
 				db.DeleteAll<ModelWithIdAndName>();
@@ -101,7 +101,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_Save_TaskQueue_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<TaskQueue>(true);
 
@@ -123,7 +123,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_SaveAll_and_select_from_Movie_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<Movie>(true);
 

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteSelectTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteSelectTests.cs
@@ -16,7 +16,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_GetById_int_from_ModelWithFieldsOfDifferentTypes_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 
@@ -33,7 +33,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_GetById_string_from_ModelWithOnlyStringFields_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 
@@ -50,7 +50,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_GetByIds_int_from_ModelWithFieldsOfDifferentTypes_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 
@@ -68,7 +68,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_GetByIds_string_from_ModelWithOnlyStringFields_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 
@@ -86,7 +86,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_select_with_filter_from_ModelWithOnlyStringFields_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 
@@ -112,7 +112,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		{
 			const int n = 5;
 
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIdAndName>(true);
 				db.DeleteAll<ModelWithIdAndName>();
@@ -128,7 +128,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_loop_each_string_from_ModelWithOnlyStringFields_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 
@@ -149,7 +149,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_loop_each_with_filter_from_ModelWithOnlyStringFields_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 
@@ -179,7 +179,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		{
 			const int n = 5;
 
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIdAndName>(true);
 				db.DeleteAll<ModelWithIdAndName>();
@@ -197,7 +197,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		{
 			const int n = 5;
 
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIdAndName>(true);
 				db.DeleteAll<ModelWithIdAndName>();
@@ -215,7 +215,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		{
 			const int n = 5;
 
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIdAndName>(true);
 				db.DeleteAll<ModelWithIdAndName>();
@@ -239,7 +239,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		{
 			const int n = 5;
 
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIdAndName>(true);
 				db.DeleteAll<ModelWithIdAndName>();
@@ -256,7 +256,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_Select_subset_ModelWithIdAndName_from_ModelWithFieldsOfDifferentTypes_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 
@@ -274,7 +274,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_Select_Into_ModelWithIdAndName_from_ModelWithFieldsOfDifferentTypes_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 
@@ -295,7 +295,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		{
 			const int n = 5;
 
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIdAndName>(true);
 				db.DeleteAll<ModelWithIdAndName>();
@@ -324,7 +324,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_populate_PocoFlag()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				var rows = db.Select<PocoFlag>("SELECT 1 as Flag FROM RDB$DATABASE");
 				Assert.That(rows[0].Flag);
@@ -340,7 +340,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_populate_PocoFlagWithId()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				var rows = db.Select<PocoFlagWithId>("SELECT 1 as Id, 1 as Flag FROM RDB$DATABASE");
 				Assert.That(rows[0].Id, Is.EqualTo(1));

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteTestBase.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteTestBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Configuration;
 using NUnit.Framework;
 using ServiceStack.Common.Utils;
 using ServiceStack.Logging;
@@ -15,7 +16,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		protected string GetFileConnectionString()
 		{
 			// add ormlite-tests.fdb = D:\\ormlite-tests.fdb to your firebird  alias.conf 
-			return "User=SYSDBA;Password=masterkey;Database=ormlite-tests.fdb;DataSource=localhost;Dialect=3;charset=ISO8859_1;MinPoolSize=0;MaxPoolSize=100";
+			return ConfigurationManager.ConnectionStrings["testDb"].ConnectionString;
 		}
 
 		protected void CreateNewDatabase()
@@ -29,9 +30,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 			LogManager.LogFactory = new ConsoleLogFactory();
 
 			OrmLiteConfig.DialectProvider = FirebirdOrmLiteDialectProvider.Instance;
-			
 			ConnectionString = GetFileConnectionString();
-
 		}
 
 		public void Log(string text)

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteTransactionTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteTransactionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using NUnit.Framework;
+using ServiceStack.DataAnnotations;
 using ServiceStack.Common.Tests.Models;
 
 namespace ServiceStack.OrmLite.FirebirdTests
@@ -11,7 +12,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Transaction_commit_persists_data_to_the_db()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIdAndName>(true);
 				db.DeleteAll<ModelWithIdAndName>();
@@ -36,7 +37,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Transaction_rollsback_if_not_committed()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIdAndName>(true);
 				db.DeleteAll<ModelWithIdAndName>();
@@ -59,7 +60,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Transaction_rollsback_transactions_to_different_tables()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIdAndName>(true);
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
@@ -87,7 +88,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Transaction_commits_inserts_to_different_tables()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithIdAndName>(true);
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteUpdateTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteUpdateTests.cs
@@ -12,7 +12,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Can_update_ModelWithFieldsOfDifferentTypes_table()
 		{
-			using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
 			{
 				db.CreateTable<ModelWithFieldsOfDifferentTypes>(true);
 

--- a/tests/ServiceStack.OrmLite.FirebirdTests/ServiceStack.OrmLite.FirebirdTests.csproj
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/ServiceStack.OrmLite.FirebirdTests.csproj
@@ -135,4 +135,7 @@
       <Name>ServiceStack.OrmLite.Firebird</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
 </Project>

--- a/tests/ServiceStack.OrmLite.FirebirdTests/ShipperExample.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/ShipperExample.cs
@@ -68,7 +68,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 		[Test]
 		public void Shippers_UseCase()
 		{
-			using (IDbConnection db = "User=SYSDBA;Password=masterkey;Database=ormlite-tests.fdb;DataSource=localhost;Dialect=3;charset=ISO8859_1;".OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory("User=SYSDBA;Password=masterkey;Database=ormlite-tests.fdb;DataSource=localhost;Dialect=3;charset=ISO8859_1;", FirebirdDialect.Provider).Open())
 			{
 				const bool overwrite = false;
 				db.DropTable<Shipper>();

--- a/tests/ServiceStack.OrmLite.FirebirdTests/TypeWithByteArrayFieldTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/TypeWithByteArrayFieldTests.cs
@@ -9,7 +9,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
         {
             var orig = new TypeWithByteArrayField { Id = 1, Content = new byte[] { 0, 17, 0, 17, 0, 7 } };
 
-            using (var db = ConnectionString.OpenDbConnection())
+            using (var db = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider).Open())
             {
                 db.CreateTable<TypeWithByteArrayField>(true);
 

--- a/tests/ServiceStack.OrmLite.FirebirdTests/app.config
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/app.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+  </configSections>
+  <connectionStrings>
+    <add name="testDb" connectionString="User=SYSDBA;Password=masterkey;Database=ormlite-tests.fdb;DataSource=localhost;Dialect=3;charset=ISO8859_1;MinPoolSize=0;MaxPoolSize=100;" providerName="FirebirdSql.Data.FirebirdClient"/>
+  </connectionStrings>
+</configuration>


### PR DESCRIPTION
It seems that the FirebirdTest project is outdated, and Transactions didn't work.
It had to do with the way connections were initialized.

Changed:
using (var db = ConnectionString.OpenDbConnection())
To:
using (var db = new OrmLiteConnectionFactory(ConnectionString,
FirebirdDialect.Provider).Open())

With this change the Firebird provider works as expected, at least regarding the use of Transactions.
Also added app.config and changed OrmLiteTestBase.GetFileConnectionString() to use it, to allow an easy connection string setup.

Only remaining problem now is at OrmLiteQueryTest.Can_select_with_filter_from_ModelWithOnlyStringFields_table().
db.ByExampleWhere() doesn't ignore NULL properties and the query returns 0 rows.

Thanks.
