### PR TITLE
Add overloaded ByExampleWhere<T>() method with excludeNulls parameter

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteReadConnectionExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadConnectionExtensions.cs
@@ -200,6 +200,11 @@ namespace ServiceStack.OrmLite
             return dbConn.Exec(dbCmd => dbCmd.ByExampleWhere<T>(anonType));
         }
 
+        public static List<T> ByExampleWhere<T>(this IDbConnection dbConn, object anonType, bool excludeNulls)
+        {
+            return dbConn.Exec(dbCmd => dbCmd.ByExampleWhere<T>(anonType, excludeNulls));
+        }
+
         public static List<T> QueryByExample<T>(this IDbConnection dbConn, string sql, object anonType = null)
         {
             return dbConn.Exec(dbCmd => dbCmd.QueryByExample<T>(sql, anonType));

--- a/src/ServiceStack.OrmLite/OrmLiteReadExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadExtensions.cs
@@ -452,9 +452,14 @@ namespace ServiceStack.OrmLite
                 return GetScalar<T>(dbReader);
         }
 
-	    internal static List<T> ByExampleWhere<T>(this IDbCommand dbCmd, object anonType)
+        internal static List<T> ByExampleWhere<T>(this IDbCommand dbCmd, object anonType)
+        {
+            return ByExampleWhere<T>(dbCmd, anonType, false);
+        }
+
+        internal static List<T> ByExampleWhere<T>(this IDbCommand dbCmd, object anonType, bool excludeNulls)
 		{
-            dbCmd.SetFilters<T>(anonType, excludeNulls: false);
+            dbCmd.SetFilters<T>(anonType, excludeNulls);
 
 			using (var dbReader = dbCmd.ExecuteReader())
 				return dbReader.ConvertToList<T>();


### PR DESCRIPTION
Added overloaded ByExampleWhere<T>(this IDbConnection dbConn, object anonType, bool excludeNulls) because OrmLiteQueryTests that used ByExample were failing.

In this test the object is created with only one property assigned, but the the resulting SQL statement contains all fields in the where clause because OrmLite always assumes excludeNulls=false.

```
var queryByExample = new ModelWithOnlyStringFields { AlbumName = filterRow.AlbumName };
rows = db.ByExampleWhere<ModelWithOnlyStringFields>(queryByExample);
```

becomes

```
...
rows = db.ByExampleWhere<ModelWithOnlyStringFields>(queryByExample, true);
```

generating this sql query: 

```
SELECT * FROM ModelWithOnlyStringFields WHERE AlbumName = @AlbumName;
```

Having an option to pass the excludeNulls all the way allows for more flexibility and for the correct sql statement to be generated.
In this case not having the where clause with null value properties which is what the test expects anyway and in my opinion what will be used most with this method.
