### PR TITLE
Add [Ignore] parameter 'IgnoreAlways' 

### DIFF
--- a/src/ServiceStack.OrmLite/FieldDefinition.cs
+++ b/src/ServiceStack.OrmLite/FieldDefinition.cs
@@ -38,6 +38,8 @@ namespace ServiceStack.OrmLite
 
         public bool IsIndexed { get; set; }
 
+        public bool AlwaysIgnored { get; set; }
+
         public bool IsUnique { get; set; }
 
         public int? FieldLength { get; set; }  // Precision for Decimal Type

--- a/src/ServiceStack.OrmLite/IgnoreAttribute.cs
+++ b/src/ServiceStack.OrmLite/IgnoreAttribute.cs
@@ -14,6 +14,25 @@ namespace ServiceStack.DataAnnotations
 	[AttributeUsage( AttributeTargets.Property)]
 	public class IgnoreAttribute : Attribute
 	{
+        public bool AlwaysIgnore { get; set; }
 
+
+        /// <summary>
+        /// Ignores field from SQL Table creation
+        /// </summary>
+        public IgnoreAttribute()
+        {
+
+        }
+
+
+        /// <summary>
+        /// Ignores field from SQL Table creation
+        /// </summary>
+        /// <param name="alwaysIgnore">Dont try to fetch from table</param>
+        public IgnoreAttribute(bool alwaysIgnore)
+        {
+            AlwaysIgnore = alwaysIgnore;
+        }
 	}
 }

--- a/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
@@ -113,6 +113,8 @@ namespace ServiceStack.OrmLite
                 var referencesAttr = propertyInfo.FirstAttribute<ReferencesAttribute>();
                 var foreignKeyAttr = propertyInfo.FirstAttribute<ForeignKeyAttribute>();
 
+                var ignoreAttr = propertyInfo.FirstAttribute<IgnoreAttribute>();
+
                 if (decimalAttribute != null && stringLengthAttr == null)
                     stringLengthAttr = new StringLengthAttribute(decimalAttribute.Precision);
 
@@ -123,6 +125,7 @@ namespace ServiceStack.OrmLite
                     PropertyInfo = propertyInfo,
                     IsNullable = isNullable,
                     IsPrimaryKey = isPrimaryKey,
+                    AlwaysIgnored = ignoreAttr != null && ignoreAttr.AlwaysIgnore,
                     AutoIncrement =
                         isPrimaryKey &&
                         propertyInfo.FirstAttribute<AutoIncrementAttribute>() != null,
@@ -153,7 +156,7 @@ namespace ServiceStack.OrmLite
                     BelongToModelName = belongToAttribute != null ? belongToAttribute.BelongToTableType.GetModelDefinition().ModelName : null, 
                 };
 
-                if (propertyInfo.FirstAttribute<IgnoreAttribute>() != null)
+                if (ignoreAttr != null)
                   modelDef.IgnoredFieldDefinitions.Add(fieldDefinition);
                 else
                   modelDef.FieldDefinitions.Add(fieldDefinition);                

--- a/src/ServiceStack.OrmLite/OrmLiteWriteExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteWriteExtensions.cs
@@ -236,6 +236,9 @@ namespace ServiceStack.OrmLite
 			{
 				foreach (var fieldDef in fieldDefs)
 				{
+                    if (fieldDef.AlwaysIgnored)
+                        continue;
+
                     int index;
                     if (indexCache != null)
                     {


### PR DESCRIPTION
This adds a IgnoreAlways constructor parameter to the [Ignore] attribute
IgnoreAlways will skip the field from getting fetched from the
DbReaderResult so non-existing fields can be properly skiped.

This avoids the extensive amounts of OutOfIndexExceptions to be thown
when the fields is missing from the result set.

I'm open for improvements :)
