### PR TITLE
Prevent raising inner exceptions while IDataReader tries to get ordinal for field names.

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteReadExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadExtensions.cs
@@ -156,7 +156,7 @@ namespace ServiceStack.OrmLite
 			using (var reader = dbCmd.ExecReader(
 				OrmLiteConfig.DialectProvider.ToSelectStatement(typeof(T),  filter, filterParams)))
 			{
-                var indexCache = new Dictionary<string, int>();
+				var indexCache = reader.GetIndexFieldsCache(ModelDefinition<T>.Definition);
                 while (reader.Read())
 				{
                     var row = OrmLiteUtilExtensions.CreateInstance<T>();
@@ -481,7 +481,7 @@ namespace ServiceStack.OrmLite
 			var fieldDefs = ModelDefinition<T>.Definition.FieldDefinitionsArray;
 			using (var reader = dbCmd.ExecuteReader())
 			{
-                var indexCache = new Dictionary<string, int>();
+				var indexCache = reader.GetIndexFieldsCache(ModelDefinition<T>.Definition);
                 while (reader.Read())
 				{
                     var row = OrmLiteUtilExtensions.CreateInstance<T>();
@@ -498,7 +498,7 @@ namespace ServiceStack.OrmLite
 			var fieldDefs = ModelDefinition<T>.Definition.FieldDefinitionsArray;
 			using (var reader = dbCmd.ExecuteReader())
 			{
-                var indexCache = new Dictionary<string, int>();
+				var indexCache = reader.GetIndexFieldsCache(ModelDefinition<T>.Definition);
                 while (reader.Read())
 				{
                     var row = OrmLiteUtilExtensions.CreateInstance<T>();


### PR DESCRIPTION
Same as #271 but sanitized.

In some RBMS (MSSQL, PostgreSQL, etc) the method IDataReader.GetOrdinal functions throws an IndexOutRangeException instead or returning -1 for a non existent field.

If in the DTO you have ignored fields the OrmLiteWriterExtensions.PopulateWithSqlReader method will try to find every field, even if it is marked to be ignored (that is to support JoinFeature), but in scenarios like db.Select() where author has ignored fields, the method GetColumnIndex will produce a inner exception per every ignored field multiplied by the number or rows.

I've added an extension method OrmLiteUtilExtensions.GetIndexFieldsCache who returns a dictionary with the names and positions of every field inside an opened IDataReader. That cache of fields and ordinal positions is passed to the function OrmLiteWriterExtensions.PopulateWithSqlReader to avoid trying to get the ordinal directly from the reader.

The performance penalty is almost nothing because the read of IDataReader field names and positions occurs on per dataset query.
