### PR TITLE
Added support for NonQuery to get affected rows

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteReadConnectionExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadConnectionExtensions.cs
@@ -160,19 +160,19 @@ namespace ServiceStack.OrmLite
             return dbConn.Exec(dbCmd => dbCmd.Query<T>(sql, dict));
         }
 
-        public static int NonQuery(this IDbConnection dbConn, string sql)
+        public static int ExecuteNonQuery(this IDbConnection dbConn, string sql)
         {
-            return dbConn.Exec(dbCmd => dbCmd.NonQuery(sql));
+            return dbConn.Exec(dbCmd => dbCmd.ExecuteNonQuery(sql));
         }
 
-        public static int NonQuery(this IDbConnection dbConn, string sql, object anonType)
+        public static int ExecuteNonQuery(this IDbConnection dbConn, string sql, object anonType)
         {
-            return dbConn.Exec(dbCmd => dbCmd.NonQuery(sql, anonType));
+            return dbConn.Exec(dbCmd => dbCmd.ExecuteNonQuery(sql, anonType));
         }
 
-        public static int NonQuery(this IDbConnection dbConn, string sql, Dictionary<string, object> dict)
+        public static int ExecuteNonQuery(this IDbConnection dbConn, string sql, Dictionary<string, object> dict)
         {
-            return dbConn.Exec(dbCmd => dbCmd.NonQuery(sql, dict));
+            return dbConn.Exec(dbCmd => dbCmd.ExecuteNonQuery(sql, dict));
         }
 
         public static T QueryScalar<T>(this IDbConnection dbConn, object anonType)

--- a/src/ServiceStack.OrmLite/OrmLiteReadExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadExtensions.cs
@@ -424,7 +424,7 @@ namespace ServiceStack.OrmLite
 					: dbReader.ConvertToList<T>();
 		}
 
-        internal static int NonQuery(this IDbCommand dbCmd, string sql, object anonType = null)
+        internal static int ExecuteNonQuery(this IDbCommand dbCmd, string sql, object anonType = null)
         {
             if (anonType != null)
                 dbCmd.SetParameters(anonType, excludeNulls: false);
@@ -433,7 +433,7 @@ namespace ServiceStack.OrmLite
             return dbCmd.ExecuteNonQuery();
         }
 
-        internal static int NonQuery(this IDbCommand dbCmd, string sql, Dictionary<string, object> dict)
+        internal static int ExecuteNonQuery(this IDbCommand dbCmd, string sql, Dictionary<string, object> dict)
         {
             if (dict != null)
                 dbCmd.SetParameters(dict, excludeNulls: false);

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteExecuteNonQueryTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteExecuteNonQueryTests.cs
@@ -9,7 +9,7 @@
     #endregion using
 
     [TestFixture]
-    public class OrmLiteNonQueryTests
+    public class OrmLiteExecuteNonQueryTests
     {
         public class UsingAnonType : OrmLiteTestBase
         {
@@ -22,7 +22,7 @@
 
                     var name = "Jane Doe";
 
-                    var affectedRows = db.NonQuery("insert into Person (Name) Values (@name);", new
+                    var affectedRows = db.ExecuteNonQuery("insert into Person (Name) Values (@name);", new
                     {
                         name
                     });
@@ -46,7 +46,7 @@
                     var name1 = "Jane Doe";
                     var name2 = "john Smith";
 
-                    var affectedRows = db.NonQuery(@"
+                    var affectedRows = db.ExecuteNonQuery(@"
                                                 insert into Person (Name)
                                                 Select @name1
                                                 Union
@@ -82,7 +82,7 @@
 
                     var newName = "John Smith";
 
-                    var affectedRows = db.NonQuery("Update Person Set Name = @newName where Id = @personId", new
+                    var affectedRows = db.ExecuteNonQuery("Update Person Set Name = @newName where Id = @personId", new
                     {
                         personId,
                         newName
@@ -111,7 +111,7 @@
 
                     var personId = db.GetLastInsertId();
 
-                    var affectedRows = db.NonQuery("Delete From Person where Id = @personId", new
+                    var affectedRows = db.ExecuteNonQuery("Delete From Person where Id = @personId", new
                     {
                         personId
                     });
@@ -130,7 +130,7 @@
                 {
                     db.DropAndCreateTable<Person>();
 
-                    var affectedRows = db.NonQuery(@"Delete From Person Where Id = @nonExistingId", new
+                    var affectedRows = db.ExecuteNonQuery(@"Delete From Person Where Id = @nonExistingId", new
                     {
                         nonExistingId = -1
                     });
@@ -151,7 +151,7 @@
 
                     var name = "Jane Doe";
 
-                    var affectedRows = db.NonQuery("insert into Person (Name) Values (@name);", new Dictionary<string, object>
+                    var affectedRows = db.ExecuteNonQuery("insert into Person (Name) Values (@name);", new Dictionary<string, object>
                     {
                         { "name", name }
                     });
@@ -175,7 +175,7 @@
                     var name1 = "Jane Doe";
                     var name2 = "john Smith";
 
-                    var affectedRows = db.NonQuery(@"
+                    var affectedRows = db.ExecuteNonQuery(@"
                                                 insert into Person (Name)
                                                 Select @name1
                                                 Union
@@ -211,7 +211,7 @@
 
                     var newName = "John Smith";
 
-                    var affectedRows = db.NonQuery("Update Person Set Name = @newName where Id = @personId", new Dictionary<string, object>
+                    var affectedRows = db.ExecuteNonQuery("Update Person Set Name = @newName where Id = @personId", new Dictionary<string, object>
                     {
                         { "personId", personId },
                         { "newName", newName }
@@ -240,7 +240,7 @@
 
                     var personId = db.GetLastInsertId();
 
-                    var affectedRows = db.NonQuery("Delete From Person where Id = @personId", new Dictionary<string, object>
+                    var affectedRows = db.ExecuteNonQuery("Delete From Person where Id = @personId", new Dictionary<string, object>
                     {
                         { "personId", personId }
                     });
@@ -259,7 +259,7 @@
                 {
                     db.DropAndCreateTable<Person>();
 
-                    var affectedRows = db.NonQuery(@"Delete From Person Where Id = @nonExistingId", new Dictionary<string, object>
+                    var affectedRows = db.ExecuteNonQuery(@"Delete From Person Where Id = @nonExistingId", new Dictionary<string, object>
                     {
                         { "nonExistingId", -1 }
                     });
@@ -282,7 +282,7 @@
 
                     var sql = string.Format("insert into Person (Name) Values ('{0}');", name);
 
-                    var affectedRows = db.NonQuery(sql);
+                    var affectedRows = db.ExecuteNonQuery(sql);
 
                     var personId = db.GetLastInsertId();
 
@@ -305,7 +305,7 @@
 
                     var sql = string.Format(@"insert into Person (Name) Select '{0}' Union Select '{1}'", name1, name2);
 
-                    var affectedRows = db.NonQuery(sql);
+                    var affectedRows = db.ExecuteNonQuery(sql);
 
                     var rows = db.SqlList<Person>("select * from Person order by name");
 
@@ -335,7 +335,7 @@
 
                     var sql = string.Format(@"Update Person Set Name = '{0}' where Id = {1}", newName, personId);
 
-                    var affectedRows = db.NonQuery(sql);
+                    var affectedRows = db.ExecuteNonQuery(sql);
 
                     var updatedPerson = db.GetById<Person>(personId);
 
@@ -362,7 +362,7 @@
 
                     var sql = string.Format(@"Delete From Person where Id = {0}", personId);
 
-                    var affectedRows = db.NonQuery(sql);
+                    var affectedRows = db.ExecuteNonQuery(sql);
 
                     var count = db.Count<Person>();
 
@@ -380,7 +380,7 @@
 
                     var sql = string.Format(@"Delete From Person where Id = {0}", -1);
 
-                    var affectedRows = db.NonQuery(sql);
+                    var affectedRows = db.ExecuteNonQuery(sql);
 
                     Assert.That(affectedRows, Is.EqualTo(0));
                 }

--- a/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
+++ b/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
@@ -118,7 +118,7 @@
     <Compile Include="ForeignKeyAttributeTests.cs" />
     <Compile Include="OrmLiteDropTableTests.cs" />
     <Compile Include="OrmLiteDropTableWithNamingStrategyTests.cs" />
-    <Compile Include="OrmLiteNonQueryTests.cs" />
+    <Compile Include="OrmLiteExecuteNonQueryTests.cs" />
     <Compile Include="OrmLiteQueryTests.cs" />
     <Compile Include="LocalizationTests.cs" />
     <Compile Include="OrmLiteConnectionFactoryTests.cs" />


### PR DESCRIPTION
- Added support for free text sql statements with optional params which allows the caller to get the number of affected rows of his statements. This should be usable across all databases since it's using the standard ExecuteNonQuery from IDbCommand.
- Added unit tests for the functionality
