### PR TITLE
avoid casting exception when db provider returns ulong for GetLongScalar...

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteReadExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadExtensions.cs
@@ -790,6 +790,7 @@ namespace ServiceStack.OrmLite
 			if (result is DBNull) return default(long);
 			if (result is int) return (int)result;
 			if (result is decimal) return Convert.ToInt64((decimal)result);
+			if (result is ulong) return Convert.ToInt64(result);
 			return (long)result;
 		}			
 	}


### PR DESCRIPTION
Since the GetLastInsertId refactor (commit https://github.com/ServiceStack/ServiceStack.OrmLite/commit/c4d584fcbeb17cf313396d2a71e19d2c512ba8d8), trying the use the GetLastInsertedId with MySql throws an invalid cast exception as MySql returns an ulong for the SelectIdentitySql)
