### PR TITLE
Removing hard coded Stored Procedure ParameterDirection in T4

### DIFF
--- a/src/T4/OrmLite.SP.tt
+++ b/src/T4/OrmLite.SP.tt
@@ -45,7 +45,7 @@ namespace <#=SPNamespace#>
 			dbCommand.CommandType = CommandType.StoredProcedure;
 			dbCommand.Transaction = OrmLiteConfig.TSTransaction!= null ? (DbTransaction)OrmLiteConfig.TSTransaction : null;
 <#if (sp.Parameters.Count > 0) { foreach(var param in sp.Parameters){#>
-			dbCommand.Parameters.Add(CreateNewParameter(dbCommand,"<#=param.Name#>",<#=Inflector.MakeInitialLowerCase(param.Name)#>,ParameterDirection.Input,<#=param.DbType#>));
+			dbCommand.Parameters.Add(CreateNewParameter(dbCommand,"<#=param.Name#>",<#=Inflector.MakeInitialLowerCase(param.Name)#>,<#=param.Direction#>,<#=param.DbType#>));
 <#}#> <#}#>
 			return new OrmLiteSPStatement(dbCommand);
 		}


### PR DESCRIPTION
T4 templates stored procedure paramete code generation was hard coded to ParameterDirection.Input
