### PR TITLE
Fix mysql long GetLastInsertId

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteReadExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadExtensions.cs
@@ -790,7 +790,7 @@ namespace ServiceStack.OrmLite
 			if (result is DBNull) return default(long);
 			if (result is int) return (int)result;
 			if (result is decimal) return Convert.ToInt64((decimal)result);
-			if (result is ulong) return Convert.ToInt64(result);
+			if (result is ulong) return (long)Convert.ToUInt64(result);
 			return (long)result;
 		}			
 	}


### PR DESCRIPTION
GetLastInsertId threw cast error when the returned value was ulong.
This was only visible when having a long Id field, triggering mysql
returning a ulong
