### PR TITLE
Fixed SQL Server support for LIMIT and DISTINCT

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerExpressionVisitor.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerExpressionVisitor.cs
@@ -26,7 +26,9 @@ namespace ServiceStack.OrmLite.SqlServer
 
                 sql = base.ToSelectStatement();
                 if (sql == null || sql.Length < "SELECT".Length) return sql;
-                sql = "SELECT TOP " + take + " " + sql.Substring("SELECT".Length, sql.Length - "SELECT".Length);
+                bool hasDistinctInBaseQuery = sql.StartsWithIgnoreCase("SELECT DISTINCT");
+                string stringToRemoveFromBaseQuery = hasDistinctInBaseQuery ? "SELECT DISTINCT" : "SELECT";
+                sql = stringToRemoveFromBaseQuery + " TOP " + take + " " + sql.Substring(stringToRemoveFromBaseQuery.Length, sql.Length - stringToRemoveFromBaseQuery.Length);
                 return sql;
             }
 	        

--- a/src/ServiceStack.OrmLite.SqlServerTests/Expressions/AuthorUseCase.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/Expressions/AuthorUseCase.cs
@@ -224,9 +224,16 @@ namespace ServiceStack.OrmLite.SqlServerTests.Expressions
                 Assert.AreEqual("Rodger Contreras".ToUpper(), author.Name);
 
                 // select distinct..
-                ev.Limit().OrderBy(); // clear limit, clear order for postres
+                ev.Limit().OrderBy(); // clear limit, clear orde
                 ev.SelectDistinct(r => r.City);
                 expected = 6;
+                result = db.Select(ev);
+                Assert.AreEqual(expected, result.Count);
+
+                // select distinct with limit
+                ev.Limit(0, 4);
+                ev.SelectDistinct(r => r.City);
+                expected = 4;
                 result = db.Select(ev);
                 Assert.AreEqual(expected, result.Count);
 


### PR DESCRIPTION
Resolved bad SQL generated when using LIMIT (simple case) and DISTINCT in combination
by SQL Server. This method is already hacky as anything... suggestions
welcome!
