### PR TITLE
Fixed JoinSqlBuilder to use field Aliases

### DIFF
--- a/tests/ServiceStack.OrmLite.FirebirdTests/NorthwindTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/NorthwindTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using ServiceStack.OrmLite.Firebird;
+using Northwind.Common.DataModel;
+
+namespace ServiceStack.OrmLite.FirebirdTests
+{
+    [TestFixture]
+    class NorthwindTests : OrmLiteTestBase
+    {
+        [Test]
+        public void JoinSqlBuilderWithFieldAliasTest()
+        {
+            var factory = new OrmLiteConnectionFactory(ConnectionString, FirebirdDialect.Provider);
+
+            using (var db = factory.OpenDbConnection())
+            {
+                var jn = new JoinSqlBuilder<Northwind.Common.DataModel.Employee, Northwind.Common.DataModel.EmployeeTerritory>();
+
+                jn = jn.Join<Northwind.Common.DataModel.Employee, Northwind.Common.DataModel.EmployeeTerritory>(x => x.Id, x => x.EmployeeId)
+                       .LeftJoin<Northwind.Common.DataModel.EmployeeTerritory, Northwind.Common.DataModel.Territory>(x => x.TerritoryId, x => x.Id)
+                       .Where<Northwind.Common.DataModel.Territory>(x => x.TerritoryDescription == "Westboro");
+                
+                var sql = jn.ToSql();
+                // here sql should contain Employees.EmployeID instead of Employees.Id
+
+                var result = db.Query<Northwind.Common.DataModel.Employee>(sql); 
+            
+            }
+        }
+    }
+}

--- a/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteTestBase.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/OrmLiteTestBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Configuration;
 using System.Data;
 using NUnit.Framework;
 using ServiceStack.Logging;
@@ -12,9 +13,8 @@ namespace ServiceStack.OrmLite.FirebirdTests
 
 		protected string GetFileConnectionString()
 		{
-			// add ormlite-tests.fdb = {PATH TO FDB FILE} D:\\ormlite-tests.fdb to your firebird  alias.conf 
-			return "User=SYSDBA;Password=masterkey;Database=ormlite-tests.fdb;DataSource=localhost;Dialect=3;charset=ISO8859_1;MinPoolSize=0;MaxPoolSize=100;";
-		}
+            return ConfigurationManager.ConnectionStrings["testDb"].ConnectionString;
+        }
 
 		protected void CreateNewDatabase()
 		{

--- a/tests/ServiceStack.OrmLite.FirebirdTests/app.config
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/app.config
@@ -3,6 +3,7 @@
   <configSections>
   </configSections>
   <connectionStrings>
-    <add name="testDb" connectionString="User=SYSDBA;Password=masterkey;Database=ormlite-tests.fdb;DataSource=localhost;Dialect=3;charset=ISO8859_1;MinPoolSize=0;MaxPoolSize=100;" providerName="FirebirdSql.Data.FirebirdClient"/>
+    <!-- add ormlite-tests.fdb = {PATH TO FDB FILE} D:\\ormlite-tests.fdb to your firebird  alias.conf  -->
+    <add name="testDb" connectionString="User=SYSDBA;Password=masterkey;Database=northwind;DataSource=localhost;Dialect=3;charset=ISO8859_1;MinPoolSize=0;MaxPoolSize=100;" providerName="FirebirdSql.Data.FirebirdClient"/>
   </connectionStrings>
 </configuration>


### PR DESCRIPTION
The SQL generated by the JoinSqlBuilder class was ignoring field aliases.

It should generate Employees.EmployeID instead of Employees.Id since Employees has an alias on field Id.

The main change is in ProcessMemberAccess() method where these two lines were added:

```
var pocoType = typeof(T);
var fieldName = pocoType.GetModelDefinition().FieldDefinitions.First(f => f.Name == m.Member.Name).Alias;
```

```
protected void ProcessMemberAccess<T>(string tableName, MemberExpression m, List<string> lst, bool withTablePrefix, string alias = "")
{
    if (m.Expression != null
        && (m.Expression.NodeType == ExpressionType.Parameter || m.Expression.NodeType == ExpressionType.Convert))
    {
        var pocoType = typeof(T);
        /// Get fieldname alias from POCO definition
        var fieldName = pocoType.GetModelDefinition().FieldDefinitions.First(f => f.Name == m.Member.Name).Alias;

        if (withTablePrefix)
            lst.Add(string.Format("{0}.{1}{2}", OrmLiteConfig.DialectProvider.GetQuotedTableName(tableName), OrmLiteConfig.DialectProvider.GetQuotedColumnName(fieldName), string.IsNullOrEmpty(alias) ? string.Empty : string.Format(" AS {0}", OrmLiteConfig.DialectProvider.GetQuotedColumnName(alias))));
        else
            lst.Add(string.Format("{0}{1}", OrmLiteConfig.DialectProvider.GetQuotedColumnName(fieldName), string.IsNullOrEmpty(alias) ? string.Empty : string.Format(" AS {0}", OrmLiteConfig.DialectProvider.GetQuotedColumnName(alias))));
        return;
    }
    throw new Exception("Only Members are allowed");
}
```

Also added a simple test to check if the result Sql text is the expected.
