### PR TITLE
Fixed FirebirdSqlExpressionVisitor Trim support

### DIFF
--- a/src/ServiceStack.OrmLite.Firebird/FirebirdSqlExpressionVisitor.cs
+++ b/src/ServiceStack.OrmLite.Firebird/FirebirdSqlExpressionVisitor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace ServiceStack.OrmLite.Firebird
@@ -120,6 +121,29 @@ namespace ServiceStack.OrmLite.Firebird
             }
 
             return c.Value;
+        }
+
+        protected override object VisitColumnAccessMethod(MethodCallExpression m)
+        {
+            List<Object> args = this.VisitExpressionList(m.Arguments);
+            var quotedColName = Visit(m.Object);
+            var statement = "";
+
+            switch (m.Method.Name)
+            {
+                case "Trim":
+                    statement = string.Format("trim({0})", quotedColName);
+                    break;
+                case "LTrim":
+                    statement = string.Format("trim(leading from {0})", quotedColName);
+                    break;
+                case "RTrim":
+                    statement = string.Format("trim(trailing from {0})", quotedColName);
+                    break;
+                default:
+                    return base.VisitColumnAccessMethod(m);
+            }
+            return new PartialSqlString(statement);
         }
 
         private bool IsTrueExpression(object exp)

--- a/tests/ServiceStack.OrmLite.FirebirdTests/NorthwindTests.cs
+++ b/tests/ServiceStack.OrmLite.FirebirdTests/NorthwindTests.cs
@@ -24,7 +24,7 @@ namespace ServiceStack.OrmLite.FirebirdTests
 
                 jn = jn.Join<Northwind.Common.DataModel.Employee, Northwind.Common.DataModel.EmployeeTerritory>(x => x.Id, x => x.EmployeeId)
                        .LeftJoin<Northwind.Common.DataModel.EmployeeTerritory, Northwind.Common.DataModel.Territory>(x => x.TerritoryId, x => x.Id)
-                       .Where<Northwind.Common.DataModel.Territory>(x => x.TerritoryDescription == "Westboro");
+                       .Where<Northwind.Common.DataModel.Territory>(x => x.TerritoryDescription.Trim() == "Westboro");
                 
                 var sql = jn.ToSql();
                 // here sql should contain Employees.EmployeID instead of Employees.Id


### PR DESCRIPTION
Firebird doesn't support LTrim or RTrim.

for LTrim we need to use Trim(leading from str).
for RTrim we need to use Trim(trailing from str).

This avoids errors when executing code like this:

```
.Where<Northwind.Common.DataModel.Territory>(x =>x.TerritoryDescription.Trim() == "Westboro");
```
