### PR TITLE
Fixed JoinSqlBuilder for SqlLite

### DIFF
--- a/src/ServiceStack.OrmLite/JoinSqlBuilder.cs
+++ b/src/ServiceStack.OrmLite/JoinSqlBuilder.cs
@@ -78,12 +78,15 @@ namespace ServiceStack.OrmLite
                 && (m.Expression.NodeType == ExpressionType.Parameter || m.Expression.NodeType == ExpressionType.Convert))
             {
                 var pocoType = typeof(T);
-                var fieldName = pocoType.GetModelDefinition().FieldDefinitions.First(f => f.Name == m.Member.Name).Alias;
+                var fieldDef = pocoType.GetModelDefinition().FieldDefinitions.First(f => f.Name == m.Member.Name);
+                var fieldName = String.IsNullOrEmpty(fieldDef.Alias) ? fieldDef.Name : fieldDef.Alias;
+
+                alias = string.IsNullOrEmpty(alias) ? string.Empty : string.Format(" AS {0}", OrmLiteConfig.DialectProvider.GetQuotedColumnName(alias));
 
                 if (withTablePrefix)
-                    lst.Add(string.Format("{0}.{1}{2}", OrmLiteConfig.DialectProvider.GetQuotedTableName(tableName), OrmLiteConfig.DialectProvider.GetQuotedColumnName(fieldName), string.IsNullOrEmpty(alias) ? string.Empty : string.Format(" AS {0}", OrmLiteConfig.DialectProvider.GetQuotedColumnName(alias))));
+                    lst.Add(string.Format("{0}.{1}{2}", OrmLiteConfig.DialectProvider.GetQuotedTableName(tableName), OrmLiteConfig.DialectProvider.GetQuotedColumnName(fieldName), alias));
                 else
-                    lst.Add(string.Format("{0}{1}", OrmLiteConfig.DialectProvider.GetQuotedColumnName(fieldName), string.IsNullOrEmpty(alias) ? string.Empty : string.Format(" AS {0}", OrmLiteConfig.DialectProvider.GetQuotedColumnName(alias))));
+                    lst.Add(string.Format("{0}{1}", OrmLiteConfig.DialectProvider.GetQuotedColumnName(fieldName), alias));
                 return;
             }
             throw new Exception("Only Members are allowed");

--- a/src/SqliteExpressionsTest/JoinTest.cs
+++ b/src/SqliteExpressionsTest/JoinTest.cs
@@ -29,6 +29,7 @@ namespace SqliteExpressionsTest
         public long Id { get; set; }
         [BelongTo(typeof(User))]
         public string Name { get; set; }
+        [BelongTo(typeof(User))]
         public DateTime CreatedDate { get; set; }
         [BelongTo(typeof(UserData))]
         public string UserDataValue { get; set; }


### PR DESCRIPTION
With SqlLite provider the FieldDefinition.Alias doesn't default to FieldDefinition.Name when the field doesn't have an Alias attribute like in SqlServer or Firebird.

Added a check for null or empty to FieldDefinition.Alias before use.

```
var fieldName = String.IsNullOrEmpty(fieldDef.Alias) ? fieldDef.Name : fieldDef.Alias;
```

Also fixed the UserEx class in JoinTest.cs by adding a missing BelongTo attribute to CreatedDate property.

```
[BelongTo(typeof(User))]
public DateTime CreatedDate { get; set; }
```
