### PR TITLE
Force Firebird to use UpperCaseNamingStategy

### DIFF
--- a/src/ServiceStack.OrmLite.Firebird/FirebirdOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Firebird/FirebirdOrmLiteDialectProvider.cs
@@ -40,6 +40,8 @@ namespace ServiceStack.OrmLite.Firebird
 			base.DefaultStringLength=128;
 			base.InitColumnTypeMap();
 			DefaultValueFormat = " DEFAULT '{0}'";
+
+            NamingStrategy = new UpperCaseNamingStrategy();
 		}
 		
 		public override IDbConnection CreateConnection(string connectionString, Dictionary<string, string> options)

--- a/src/ServiceStack.OrmLite/ServiceStack.OrmLite.csproj
+++ b/src/ServiceStack.OrmLite/ServiceStack.OrmLite.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Expressions\Sql.cs" />
     <Compile Include="OrmLiteDDLExtensions.cs" />
     <Compile Include="Dapper\SqlMapper.cs" />
+    <Compile Include="UpperCaseNamingStrategy.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/src/ServiceStack.OrmLite/UpperCaseNamingStrategy.cs
+++ b/src/ServiceStack.OrmLite/UpperCaseNamingStrategy.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ServiceStack.OrmLite
+{
+    public class UpperCaseNamingStrategy: OrmLiteNamingStrategyBase
+	{
+		public virtual string GetTableName(string name)
+		{
+			return name.ToUpper();
+		}
+ 
+		public virtual string GetColumnName(string name)
+		{
+			return name.ToUpper();
+		}
+	}
+}


### PR DESCRIPTION
FireBird works better if we use table and field names in upper case.
If we have a poco named User, we can easily get in trouble with a query like this: select \* from User;

Forcing the FirebirdOrmLiteDialectProvider to use the UpperCaseNamingStrategy, this problem doesn't exist.

```
public FirebirdOrmLiteDialectProvider(bool compactGuid)
{
...
   NamingStrategy = new UpperCaseNamingStrategy();
}
```
