### PR TITLE
Added GetModelDefinition to OrmLiteConfig for DB metadata usage inside p...

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteConfig.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConfig.cs
@@ -91,6 +91,11 @@ namespace ServiceStack.OrmLite
             OrmLiteConfigExtensions.ClearCache();
         }
 
+        public static ModelDefinition GetModelDefinition(Type modelType)
+        {
+            return OrmLiteConfigExtensions.GetModelDefinition(modelType);
+        }
+
         public static IDbConnection ToDbConnection(this string dbConnectionStringOrFilePath, IOrmLiteDialectProvider dialectProvider)
         {
             var dbConn = dialectProvider.CreateConnection(dbConnectionStringOrFilePath, options: null);


### PR DESCRIPTION
Why not have GetModelDefinition available for projects that use OrmLite?
ModelDefinition contains usable information about  DB table metada that can be used inside application that uses OrmLite.
