### PR TITLE
Fixed NullReferenceException in Oracle non-parameterized update statements

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
@@ -311,9 +311,12 @@ namespace ServiceStack.OrmLite.Oracle
 		}
 
 		
-		public override string ToUpdateRowStatement(object objWithProperties, ICollection<string> updateFields)
+		public override string ToUpdateRowStatement(object objWithProperties, ICollection<string> updateFields = null)
 		{
-			var sqlFilter = new StringBuilder();
+		    if (updateFields == null)
+                updateFields = new List<string>();
+
+		    var sqlFilter = new StringBuilder();
 			var sql = new StringBuilder();
 			var tableType = objWithProperties.GetType();
 			var modelDef = GetModel(tableType);


### PR DESCRIPTION
Attempting to call `Db.Update(someObject);` on an Oracle database would cause `OracleOrmLiteDialectProvider.ToUpdateRowStatement()` to throw a NullReferenceException on `updateFields`.

The method was missing the standard if-null-then-use-an-empty-list pattern from elsewhere in OrmLite.

If `Db.UpdateParam(someObject);` was called instead, the DB call would work (since a different dialect method is called, which had the correct pattern).
