### PR TITLE
Avoid generating invalid SQL when a LINQ Contains() expressions references an empty collection.

### DIFF
--- a/src/ServiceStack.OrmLite/Expressions/SqlExpressionVisitor.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpressionVisitor.cs
@@ -1064,11 +1064,21 @@ namespace ServiceStack.OrmLite
                     var inArgs = Sql.Flatten(getter() as IEnumerable);
 
                     StringBuilder sIn = new StringBuilder();
-                    foreach (Object e in inArgs)
+
+                    if (inArgs.Any())
                     {
-                        sIn.AppendFormat("{0}{1}",
-                                     sIn.Length > 0 ? "," : "",
-                                     OrmLiteConfig.DialectProvider.GetQuotedValue(e, e.GetType()));
+                        foreach (Object e in inArgs)
+                        {
+                            sIn.AppendFormat("{0}{1}",
+                                             sIn.Length > 0 ? "," : "",
+                                             OrmLiteConfig.DialectProvider.GetQuotedValue(e, e.GetType()));
+                        }
+                    }
+                    else
+                    {
+                        // The collection is empty, so avoid generating invalid SQL syntax of "ColumnName IN ()".
+                        // Instead, just select from the null set via "ColumnName IN (NULL)"
+                        sIn.Append("NULL");
                     }
 
                     statement = string.Format("{0} {1} ({2})", quotedColName, "In", sIn.ToString());


### PR DESCRIPTION
When a LINQ Contains() expression references an empty collection, `SqlExpressionVisitor` generates invalid SQL of the form `ColumnName IN ()`. All the SQL parsers complain about those two parentheses with nothing in between.

Consider this code:

```
class Person
{
    public int Id { get; set; }
    public string Name {get; set; }
}

var personIds = new List<int>();

// Some code that populates personIds with IDs of the rows you want to select
...

// This query will cause a SQL syntax error if personIds is an empty collection
var persons = Db.Select<Person>(person => personIds.Contains(person.Id));
```

That last line will generate `SELECT "Id", "Name" FROM "Person" WHERE "Id" In ()` and throw an exception.

So currently, any code that uses a LINQ `Contains()` method needs to be guarded with a clumsy clause:

```
var persons = new List<Person>();

if( personIds.Any() )
{
    persons = Db.Select<Person>(person => personIds.Contains(person.Id));
}
```

That isn't very wrist-friendly. :(

With this commit, any time the collection referenced by a `Contains()` method is empty, the generated SQL clause will be `(NULL)` instead of `()`, which is semantically the same thing, but valid SQL.

Now the one-liner query:

```
var persons = Db.Select<Person>(person => personIds.Contains(person.Id));
```

will return an empty list as expected, without throwing an exception.
