### PR TITLE
Refactored the 3 places composing IN expressions to use common code.

### DIFF
--- a/src/ServiceStack.OrmLite.Sqlite/SqliteExpressionVisitor.cs
+++ b/src/ServiceStack.OrmLite.Sqlite/SqliteExpressionVisitor.cs
@@ -52,14 +52,9 @@ namespace ServiceStack.OrmLite.Sqlite
 
                     var inArgs = Sql.Flatten(getter() as IEnumerable);
 
-                    var sIn = new StringBuilder();
-                    foreach (var e in inArgs)
-                    {
-                        sIn.AppendFormat("{0}{1}",
-                                     sIn.Length > 0 ? "," : "",
-                                     OrmLiteConfig.DialectProvider.GetQuotedValue(e, e.GetType()));
-                    }
-                    statement = string.Format("{0} {1} ({2})", quotedColName, m.Method.Name, sIn);
+                    var inExpression = ComposeInExpression(inArgs);
+
+                    statement = string.Format("{0} {1} ({2})", quotedColName, m.Method.Name, inExpression);
                     break;
                 case "Desc":
                     statement = string.Format("{0} DESC", quotedColName);

--- a/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
@@ -22,6 +22,8 @@ namespace ServiceStack.OrmLite
 
         string ParamString { get; set; }
 
+        string EmptySetExpression { get; set; }
+
         bool UseUnicode { get; set; }
 
         INamingStrategy NamingStrategy { get; set; }

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -166,6 +166,13 @@ namespace ServiceStack.OrmLite
             }
         }
 
+        private string emptySetExpression = "NULL";
+        public string EmptySetExpression
+        {
+            get { return emptySetExpression; }
+            set { emptySetExpression = value; }
+        }
+
         private INamingStrategy namingStrategy = new OrmLiteNamingStrategyBase();
         public INamingStrategy NamingStrategy
         {

--- a/tests/ServiceStack.OrmLite.Tests/ExpressionVisitorTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/ExpressionVisitorTests.cs
@@ -140,6 +140,26 @@ namespace ServiceStack.OrmLite.Tests
         }
 
         [Test]
+        public void Can_Select_using_IN_using_empty_Array()
+        {
+            var emptyIds = new int[] { };
+
+            var visitor = OrmLiteConfig.DialectProvider.ExpressionVisitor<TestType>();
+            visitor.Where(q => Sql.In(q.Id, emptyIds));
+            var target = OpenDbConnection().Select(visitor);
+            Assert.AreEqual(0, target.Count);
+        }
+
+        [Test]
+        public void Can_Select_using_empty_Array_Contains()
+        {
+            var emptyIds = new int[] { };
+
+            var target = OpenDbConnection().Select<TestType>(t => emptyIds.Contains(t.Id));
+            Assert.AreEqual(0, target.Count);
+        }
+
+        [Test]
         public void Can_Select_using_Startswith()
         {
             var target = OpenDbConnection().Select<TestType>(q => q.TextCol.StartsWith("asdf"));


### PR DESCRIPTION
My previous pull request on this edge case only covered 1 of the 3 cases.

Added new IOrmLiteDialectProvider.EmptySetExpression property, in case specific dialects need something other than "ColumnName IN (NULL)" to represent an empty set.
Added unit test coverage for the empty collection case.
