### PR TITLE
Default to NVARCHAR(MAX) for serialized blobs, but accept override

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -399,7 +399,7 @@ namespace ServiceStack.OrmLite
         {
             if (TypeSerializer.CanCreateFromString(fieldType))
             {
-                return string.Format(StringLengthColumnDefinitionFormat, fieldLength.GetValueOrDefault(DefaultStringLength));
+                return string.Format(StringLengthColumnDefinitionFormat, fieldLength.HasValue ? fieldLength.Value.ToString() : "MAX");
             }
 
             throw new NotSupportedException(


### PR DESCRIPTION
I'd like to be able to serialize graphs larger than 8000, can we make MAX the default instead?
