### PR TITLE
Added correct support for date time offsets in Sql Server.

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
@@ -13,7 +13,8 @@ namespace ServiceStack.OrmLite.SqlServer
 	{
 		public static SqlServerOrmLiteDialectProvider Instance = new SqlServerOrmLiteDialectProvider();
 
-		private static DateTime timeSpanOffset = new DateTime(1900,01,01);
+		private static readonly DateTime timeSpanOffset = new DateTime(1900,01,01);
+        private const string DateTimeOffsetColumnDefinition = "DATETIMEOFFSET";
 
 		public SqlServerOrmLiteDialectProvider()
 		{
@@ -28,6 +29,10 @@ namespace ServiceStack.OrmLite.SqlServer
 		    base.SelectIdentitySql = "SELECT SCOPE_IDENTITY()";
 
 			base.InitColumnTypeMap();
+
+            // add support for DateTimeOffset
+            DbTypeMap.Set<DateTimeOffset>(DbType.DateTimeOffset, DateTimeOffsetColumnDefinition);
+            DbTypeMap.Set<DateTimeOffset?>(DbType.DateTimeOffset, DateTimeOffsetColumnDefinition);
 		}
 
         public override string GetQuotedParam(string paramValue)
@@ -138,6 +143,12 @@ namespace ServiceStack.OrmLite.SqlServer
 				const string iso8601Format = "yyyyMMdd HH:mm:ss.fff";
 				return base.GetQuotedValue(dateValue.ToString(iso8601Format,CultureInfo.InvariantCulture) , typeof(string));
 			}
+            if (fieldType == typeof(DateTimeOffset))
+            {
+                var dateValue = (DateTimeOffset)value;
+                const string iso8601Format = "yyyyMMdd HH:mm:ss.fff zzz";
+                return base.GetQuotedValue(dateValue.ToString(iso8601Format, CultureInfo.InvariantCulture), typeof(string));
+            }
 			if (fieldType == typeof(bool))
 			{
 				var boolValue = (bool)value;

--- a/src/ServiceStack.OrmLite.SqlServerTests/DateTimeOffsetTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/DateTimeOffsetTests.cs
@@ -1,0 +1,76 @@
+﻿#region Using directives
+
+using System;
+using System.Data;
+using System.Linq;
+using NUnit.Framework;
+using ServiceStack.OrmLite.SqlServer;
+
+#endregion
+
+
+namespace ServiceStack.OrmLite.SqlServerTests
+{
+    internal class DateTimeOffsetTests : OrmLiteTestBase
+    {
+        /// <summary>
+        /// Generic way to create our test tables.
+        /// </summary>
+        /// <typeparam name="TTable"></typeparam>
+        /// <typeparam name="TProp"></typeparam>
+        /// <param name="db"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        private static TTable InsertAndSelectDateTimeOffset<TTable, TProp>(IDbConnection db, TProp value) where TTable : IDateTimeOffsetObject<TProp>, new()
+        {
+            db.DropAndCreateTable<TTable>();
+            db.Insert(new TTable
+            {
+                Test = value
+            });
+            var result = db.Select<TTable>().First();
+            return result;
+        }
+
+        [Test]
+        public void EnsureDateTimeOffsetSaves()
+        {
+            var dbFactory = new OrmLiteConnectionFactory(base.ConnectionString, SqlServerOrmLiteDialectProvider.Instance);
+
+            using (var db = dbFactory.OpenDbConnection())
+            {
+                var dateTime = new DateTimeOffset(2012, 1, 30, 1, 1, 1, new TimeSpan(5, 0, 0));
+                var x = InsertAndSelectDateTimeOffset<DateTimeOffsetObject, DateTimeOffset>(db, dateTime);
+                Assert.AreEqual(x.Test, dateTime);
+            }
+        }
+
+        [Test]
+        public void EnsureNullableDateTimeOffsetSaves()
+        {
+            var dbFactory = new OrmLiteConnectionFactory(base.ConnectionString, SqlServerOrmLiteDialectProvider.Instance);
+
+            using (var db = dbFactory.OpenDbConnection())
+            {
+                DateTimeOffset? dateTime = new DateTimeOffset(2012, 1, 30, 1, 1, 1, new TimeSpan(5, 0, 0));
+                var x = InsertAndSelectDateTimeOffset<NullableDateTimeOffsetObject, DateTimeOffset?>(db, dateTime);
+                Assert.AreEqual(x.Test, dateTime);
+            }
+        }
+
+        private class DateTimeOffsetObject : IDateTimeOffsetObject<DateTimeOffset>
+        {
+            public DateTimeOffset Test { get; set; }
+        }
+
+        private class NullableDateTimeOffsetObject : IDateTimeOffsetObject<DateTimeOffset?>
+        {
+            public DateTimeOffset? Test { get; set; }
+        }
+
+        private interface IDateTimeOffsetObject<T>
+        {
+             T Test { get; set; }
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
+++ b/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
@@ -57,6 +57,7 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Datetime2Tests.cs" />
+    <Compile Include="DateTimeOffsetTests.cs" />
     <Compile Include="EnsureUtcTest.cs" />
     <Compile Include="InsertParam_GetLastInsertId.cs" />
     <Compile Include="NestedTransactions.cs" />


### PR DESCRIPTION
This pull request contains proper support for  <code>DateTimeOffset</code> in SQL Server and fixes the following issues:
- <code>OrmLiteWriteExtensions.CreateTable{T}</code> was previously creating <code>time</code> coumns.
- Generated sql was incorrect when <code>CurrentCulture</code> was different to the <code>dateformat</code> specified in SQL Server.
  -   e.g CultureInfo is en-AU and  <code>SELECT Bar FROM FOO WHERE ("Bar" <= '13/11/2013 12:00:00 AM +00:00')</code> is generated for use with default dateformat MDY of SQL Server
