### PR TITLE
Fixed setting parameter value to "NULL" instead of DBNull for complex type

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
+++ b/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="TypeWithByteArrayFieldTests.cs" />
     <Compile Include="UnicodeTests.cs" />
     <Compile Include="UpdateTests.cs" />
+    <Compile Include="UseCase\NestedComplexTypeUseCase.cs" />
     <Compile Include="UseCase\TestEntityWithAliases.cs" />
     <Compile Include="UseCase\SimpleUseCase.cs" />
     <Compile Include="UseCase\TestEntity.cs" />

--- a/src/ServiceStack.OrmLite.SqlServerTests/UseCase/NestedComplexTypeUseCase.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/UseCase/NestedComplexTypeUseCase.cs
@@ -1,0 +1,76 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Data;
+using NUnit.Framework;
+using ServiceStack.DataAnnotations;
+
+namespace ServiceStack.OrmLite.SqlServerTests.UseCase
+{
+    [TestFixture]
+    public class NestedComplexTypeUseCase : OrmLiteTestBase
+    {
+        public class Location
+        {
+            [AutoIncrement]
+            public int Id { get; set; }
+
+            [StringLength(50)]
+            public string Description { get; set; }
+
+            public GeoLocation GeoLocation { get; set; }
+        }
+
+        public class GeoLocation
+        {
+            [StringLength(50)]
+            public string Latitude { get; set; }
+            [StringLength(50)]
+            public string Longitude { get; set; }
+        }
+
+        [Test]
+        public void Handles_NULL_correctly_on_InsertParam_entity_with_nested_complex_type_where_nested_property_is_null()
+        {
+            using (IDbConnection db = OpenDbConnection())
+            {
+                db.CreateTable<Location>(true);
+
+                var location = new Location
+                {
+                    Description = "HQ",
+                    GeoLocation = null
+                };
+
+                location.Id = (int)db.InsertParam<Location>(location, true);
+
+                var newLocation = db.GetByIdOrDefault<Location>(location.Id);
+
+                Assert.That(newLocation, Is.Not.Null);
+                Assert.That(newLocation.Id, Is.EqualTo(location.Id));
+                Assert.That(newLocation.GeoLocation, Is.Null);
+            }
+        }
+
+        [Test]
+        public void Handles_NULL_correctly_on_Insert_entity_with_nested_complex_type_where_nested_property_is_null()
+        {
+            using (IDbConnection db = OpenDbConnection())
+            {
+                db.CreateTable<Location>(true);
+
+                var location = new Location
+                {
+                    Description = "HQ",
+                    GeoLocation = null
+                };
+
+                db.Insert<Location>(location);
+                location.Id = (int)db.GetLastInsertId();
+
+                var newLocation = db.GetByIdOrDefault<Location>(location.Id);
+
+                Assert.That(newLocation, Is.Not.Null);
+                Assert.That(newLocation.GeoLocation, Is.Null);
+            }
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -609,9 +609,8 @@ namespace ServiceStack.OrmLite
             }
             else
             {
-                var unquotedVal = fieldDef.GetQuotedValue(objWithProperties).TrimStart('\'').TrimEnd('\'');
                 p.DbType = DbType.String;
-                p.Value = GetValueOrDbNull(unquotedVal);
+                p.Value = GetQuotedValueOrDbNull(fieldDef, objWithProperties);
             }
 
             command.Parameters.Add(p);
@@ -622,12 +621,20 @@ namespace ServiceStack.OrmLite
             return fieldDef.GetValue(objWithProperties) ?? DBNull.Value;
         }
 
-        private object GetValueOrDbNull(String value)
+        protected object GetQuotedValueOrDbNull(FieldDefinition fieldDef, object objWithProperties)
         {
-            if (String.IsNullOrEmpty(value))
+            var value = fieldDef.GetValue(objWithProperties);
+
+            if (value == null)
                 return DBNull.Value;
 
-            return value;
+            var unquotedVal = OrmLiteConfig.DialectProvider.GetQuotedValue(value, fieldDef.FieldType)
+                .TrimStart('\'').TrimEnd('\''); ;
+
+            if (string.IsNullOrEmpty(unquotedVal))
+                return DBNull.Value;
+
+            return unquotedVal;
         }
 
         public virtual string ToUpdateRowStatement(object objWithProperties, ICollection<string> updateFields = null)


### PR DESCRIPTION
If POCO has a complex type property with null value (e.g. PocoObject.ComplexChildProperty = null), the string "NULL" was being written to the database, where it should have written a DBNull instead.
