### PR TITLE
Support DateTimeOffset for PostgreSQL.

### DIFF
--- a/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
@@ -33,6 +33,8 @@ namespace ServiceStack.OrmLite.PostgreSQL
 
             DbTypeMap.Set<TimeSpan>(DbType.Time, "Interval");
             DbTypeMap.Set<TimeSpan?>(DbType.Time, "Interval");
+            DbTypeMap.Set<DateTimeOffset>(DbType.DateTimeOffset, "timestamp with time zone");
+            DbTypeMap.Set<DateTimeOffset?>(DbType.DateTimeOffset, "timestamp with time zone");
 		}
 
 		public override string GetColumnDefinition(


### PR DESCRIPTION
Adds support for DateTimeOffset for PostgreSQL, where it would previously be used as a timestamp column without timezone.
