### PR TITLE
Inserting enum inserts incorrect value when using InsertParam + Unicode

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServerTests/EnumTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/EnumTests.cs
@@ -27,11 +27,32 @@ namespace ServiceStack.OrmLite.SqlServerTests
             using (var con = OpenDbConnection())
             {
                 con.CreateTable<TypeWithEnum>(true);
-                var obj = new TypeWithEnum { Id = 1, EnumValue = SomeEnum.Value1 };
+                var obj = new TypeWithEnum { Id = 1, EnumValue = SomeEnum.Value2 };
                 con.Save(obj);
                 var target = con.GetById<TypeWithEnum>(obj.Id);
                 Assert.AreEqual(obj.Id, target.Id);
                 Assert.AreEqual(obj.EnumValue, target.EnumValue);
+            }
+        }
+
+        [Test]
+        public void CanGetEnumValue_when_using_unicode_and_InsertParam()
+        {
+            bool originalUseUnicode = SqlServerDialect.Provider.UseUnicode;
+            try {
+                SqlServerDialect.Provider.UseUnicode = true;
+
+                using(var con = OpenDbConnection()) {
+                    con.CreateTable<TypeWithEnum>(true);
+                    var obj = new TypeWithEnum { Id = 1, EnumValue = SomeEnum.Value2 };
+                    con.InsertParam(obj);
+                    var target = con.GetById<TypeWithEnum>(obj.Id);
+                    Assert.AreEqual(obj.Id, target.Id);
+                    Assert.AreEqual(obj.EnumValue, target.EnumValue);
+                }
+            }
+            finally {
+                SqlServerDialect.Provider.UseUnicode = originalUseUnicode;
             }
         }
 


### PR DESCRIPTION
The generated SQL for the insert will be this:

``` SQL
exec sp_executesql N'INSERT INTO "TypeWithEnum" ("Id","EnumValue") VALUES (@Id,@EnumValue)',N'@Id int,@EnumValue nvarchar(8)',@Id=1,@EnumValue=N'N''Value2'
```

The problem is `@EnumValue` contains a leading `N'`.
Traced it back to \src\servicestack.ormlite\ormlitedialectproviderbase.cs:631 where 

``` C#
var unquotedVal = OrmLiteConfig.DialectProvider.GetQuotedValue(value, fieldDef.FieldType)
    .TrimStart('\'').TrimEnd('\''); ;
```

quotes the value (`UseUnicode == true` adds `N'` to the begining), and tries to "unquote" it, but that leaves the `N'` on the beginning.

(btw, enums default to the first possible value, so with SomeEnum.Value1, the test would succeed)
