### PR TITLE
Allow PK attributes to take precedence over field names.

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
@@ -75,6 +75,8 @@ namespace ServiceStack.OrmLite
             var objProperties = modelType.GetProperties(
                 BindingFlags.Public | BindingFlags.Instance).ToList();
 
+            var hasPkAttr = objProperties.Any(p => p.HasAttribute<PrimaryKeyAttribute>());
+
             var hasIdField = CheckForIdField(objProperties);
 
             var i = 0;
@@ -86,7 +88,7 @@ namespace ServiceStack.OrmLite
                 var belongToAttribute = propertyInfo.FirstAttribute<BelongToAttribute>();
                 var isFirst = i++ == 0;
 
-                var isPrimaryKey = propertyInfo.Name == OrmLiteConfig.IdField || (!hasIdField && isFirst)
+                var isPrimaryKey = (!hasPkAttr && (propertyInfo.Name == OrmLiteConfig.IdField || (!hasIdField && isFirst)))
                     || propertyInfo.HasAttributeNamed(typeof(PrimaryKeyAttribute).Name);
 
                 var isNullableType = IsNullableType(propertyInfo.PropertyType);

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableTests.cs
@@ -5,7 +5,9 @@ using ServiceStack.Text;
 
 namespace ServiceStack.OrmLite.Tests
 {
-	[TestFixture]
+    using ServiceStack.DataAnnotations;
+
+    [TestFixture]
 	public class OrmLiteCreateTableTests 
 		: OrmLiteTestBase
 	{
@@ -178,6 +180,26 @@ namespace ServiceStack.OrmLite.Tests
                 newModel = db.Single<ModelWithGuid>(q => q.Guid == models[0].Guid);
 
                 Assert.That(newModel.Guid, Is.EqualTo(models[0].Guid));
+            }
+        }
+
+        public class ModelWithOddIds
+        {
+            [Index(false)]
+            public long Id { get; set; }
+
+            [PrimaryKey]
+            public Guid Guid { get; set; }
+        }
+
+        [Test]
+        public void Can_handle_table_with_non_conventional_id()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<ModelWithOddIds>();
+
+                db.GetLastSql().Print();
             }
         }
 	}


### PR DESCRIPTION
I encountered an issue whereby I had a field called _Id_ that I **didn't** want to be the primary key, and  had an additional field which we I want to be the primary key, decorated with the **PrimaryKey** attribute.  Upon table, errors were thrown because the _Id_ was still being created as a PK.

I have added a failing test, and a proposed fix here.
