### PR TITLE
Fix build error in Xamarin.Android due to a missing file reference.

### DIFF
--- a/src/ServiceStack.OrmLite/ServiceStack.OrmLite.Android.csproj
+++ b/src/ServiceStack.OrmLite/ServiceStack.OrmLite.Android.csproj
@@ -97,6 +97,7 @@
     <Compile Include="UntypedApi.cs" />
     <Compile Include="UpperCaseNamingStrategy.cs" />
     <Compile Include="Dapper\SqlMapper.cs" />
+    <Compile Include="IUntypedApi.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="OrmLiteApi.cd" />


### PR DESCRIPTION
The file `IUntypedApi.cs` was missing from `ServiceStack.OrmLite.Android.csproj` resulting in a compilation error in Xamarin Studio.
