### PR TITLE
Fixed a case-sensitive comparator which generated invalid SQL.

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle/OracleSqlExpression.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleSqlExpression.cs
@@ -49,7 +49,7 @@ namespace ServiceStack.OrmLite.Oracle
 
         private static string GetFirstColumn(string sql)
         {
-            var idx1 = sql.IndexOf("select") + 7;
+            var idx1 = sql.IndexOf("select", StringComparison.OrdinalIgnoreCase) + 7;
             var idx2 = sql.IndexOf(",", idx1);
             return sql.Substring(idx1, idx2 - 7).Trim();
         }


### PR DESCRIPTION
The result of the bad code would be that idx1 was always 6 instead of 7 and the last character of the first column name was chopped off, causing Oracle to throw ORA-00904: Invalid identifier.

This would happen for an Single<T> expressions with a Where predicate.
