### PR TITLE
Generalize parameter name munging so that a provider can override it. I ...

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
@@ -193,7 +193,7 @@ namespace ServiceStack.OrmLite.Oracle
                 try
                 {
                     sbColumnNames.Append(GetQuotedColumnName(fieldDef.FieldName));
-                    sbColumnValues.Append(this.GetParam(fieldDef.FieldName));
+                    sbColumnValues.Append(this.GetParam(SanitizeFieldNameForParamName(fieldDef.FieldName)));
 
                     AddParameter(dbCommand, fieldDef);
                 }
@@ -211,7 +211,7 @@ namespace ServiceStack.OrmLite.Oracle
         public override void SetParameterValues<T>(IDbCommand dbCmd, object obj)
         {
             var modelDef = GetModel(typeof(T));
-            var fieldMap = modelDef.FieldDefinitionMap;
+            var fieldMap = modelDef.GetFieldDefinitionMap(SanitizeFieldNameForParamName);
 
             foreach (IDataParameter p in dbCmd.Parameters)
             {

--- a/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
@@ -53,6 +53,8 @@ namespace ServiceStack.OrmLite
 
         string GetQuotedName(string columnName);
 
+        string SanitizeFieldNameForParamName(string fieldName);
+
         string GetColumnDefinition(
             string fieldName, Type fieldType, bool isPrimaryKey, bool autoIncrement,
             bool isNullable, int? fieldLength,

--- a/src/ServiceStack.OrmLite/ModelDefinition.cs
+++ b/src/ServiceStack.OrmLite/ModelDefinition.cs
@@ -110,20 +110,19 @@ namespace ServiceStack.OrmLite
         }
 
         private Dictionary<string, FieldDefinition> fieldDefinitionMap;
-        public Dictionary<string, FieldDefinition> FieldDefinitionMap
+	    private Func<string, string> fieldNameSanitizer;
+        public Dictionary<string, FieldDefinition> GetFieldDefinitionMap(Func<string, string> sanitizeFieldName)
         {
-            get
+            if (fieldDefinitionMap == null || fieldNameSanitizer != sanitizeFieldName)
             {
-                if (fieldDefinitionMap == null)
+                fieldNameSanitizer = sanitizeFieldName;
+                fieldDefinitionMap = new Dictionary<string, FieldDefinition>();
+                foreach (var fieldDef in FieldDefinitionsArray)
                 {
-                    fieldDefinitionMap = new Dictionary<string, FieldDefinition>();
-                    foreach (var fieldDef in FieldDefinitionsArray)
-                    {
-                        fieldDefinitionMap[fieldDef.FieldName.Replace(" ","")] = fieldDef;
-                    }
+                    fieldDefinitionMap[sanitizeFieldName(fieldDef.FieldName)] = fieldDef;
                 }
-                return fieldDefinitionMap;
             }
+            return fieldDefinitionMap;
         }
 		
 		public List<CompositeIndexAttribute> CompositeIndexes { get; set; }

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -424,6 +424,11 @@ namespace ServiceStack.OrmLite
             return string.Format("\"{0}\"", name);
         }
 
+        public virtual string SanitizeFieldNameForParamName(string fieldName)
+        {
+            return (fieldName ?? "").Replace(" ", "");
+        }
+
         protected virtual string GetUndefinedColumnDefinition(Type fieldType, int? fieldLength)
         {
             return string.Format(StringLengthColumnDefinitionFormat, fieldLength.GetValueOrDefault(DefaultStringLength));
@@ -623,7 +628,7 @@ namespace ServiceStack.OrmLite
                 try
                 {
                     sbColumnNames.Append(GetQuotedColumnName(fieldDef.FieldName));
-                    sbColumnValues.Append(OrmLiteConfig.DialectProvider.GetParam(fieldDef.FieldName));
+                    sbColumnValues.Append(this.GetParam(SanitizeFieldNameForParamName(fieldDef.FieldName)));
 
                     AddParameter(cmd, fieldDef);
                 }
@@ -659,7 +664,7 @@ namespace ServiceStack.OrmLite
                         sqlFilter
                             .Append(GetQuotedColumnName(fieldDef.FieldName))
                             .Append("=")
-                            .Append(this.GetParam(fieldDef.FieldName));
+                            .Append(this.GetParam(SanitizeFieldNameForParamName(fieldDef.FieldName)));
 
                         AddParameter(cmd, fieldDef);
 
@@ -674,7 +679,7 @@ namespace ServiceStack.OrmLite
 
                     sql.Append(GetQuotedColumnName(fieldDef.FieldName))
                        .Append("=")
-                       .Append(this.GetParam(fieldDef.FieldName));
+                       .Append(this.GetParam(SanitizeFieldNameForParamName(fieldDef.FieldName)));
 
                     AddParameter(cmd, fieldDef);
                 }
@@ -711,7 +716,7 @@ namespace ServiceStack.OrmLite
                     sqlFilter
                         .Append(GetQuotedColumnName(fieldDef.FieldName))
                         .Append("=")
-                        .Append(this.GetParam(fieldDef.FieldName));
+                        .Append(this.GetParam(SanitizeFieldNameForParamName(fieldDef.FieldName)));
 
                     AddParameter(cmd, fieldDef);
                 }
@@ -734,7 +739,7 @@ namespace ServiceStack.OrmLite
 
         public virtual void SetParameter(FieldDefinition fieldDef, IDbDataParameter p)
         {
-            p.ParameterName = OrmLiteConfig.DialectProvider.GetParam(fieldDef.FieldName);
+            p.ParameterName = this.GetParam(SanitizeFieldNameForParamName(fieldDef.FieldName));
 
             DbType dbType;
             p.DbType = DbTypeMap.ColumnDbTypeMap.TryGetValue(fieldDef.ColumnType, out dbType)
@@ -745,7 +750,7 @@ namespace ServiceStack.OrmLite
         public virtual void SetParameterValues<T>(IDbCommand dbCmd, object obj)
         {
             var modelDef = GetModel(typeof(T));
-            var fieldMap = modelDef.FieldDefinitionMap;
+            var fieldMap = modelDef.GetFieldDefinitionMap(SanitizeFieldNameForParamName);
 
             foreach (IDataParameter p in dbCmd.Parameters)
             {

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderExtensions.cs
@@ -4,7 +4,7 @@ namespace ServiceStack.OrmLite
     {
         public static string GetParam(this IOrmLiteDialectProvider dialect, string name)
         {
-            return dialect.ParamString + (name ?? "").Replace(" ","");
+            return dialect.ParamString + name;
         }
 
         public static string GetParam(this IOrmLiteDialectProvider dialect, int indexNo = 0)


### PR DESCRIPTION
...need that for Oracle ODP.NET since it does not like some names as parameter names.

I think this change is OK - the same 4 tests fail after as before.
