### PR TITLE
Extend INamingStrategy with the absolute minimum needed to make the Orac...

### DIFF
--- a/src/ServiceStack.OrmLite.PostgreSQL/PostgreSqlNamingStrategy.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL/PostgreSqlNamingStrategy.cs
@@ -2,14 +2,14 @@
 
 namespace ServiceStack.OrmLite.PostgreSQL
 {
-    public class PostgreSqlNamingStrategy : INamingStrategy
+    public class PostgreSqlNamingStrategy : OrmLiteNamingStrategyBase
     {
-        public string GetTableName(string name)
+        public override string GetTableName(string name)
         {
             return name.ToLowercaseUnderscore();
         }
 
-        public string GetColumnName(string name)
+        public override string GetColumnName(string name)
         {
             return name.ToLowercaseUnderscore();
         }

--- a/src/ServiceStack.OrmLite/FieldDefinition.cs
+++ b/src/ServiceStack.OrmLite/FieldDefinition.cs
@@ -112,7 +112,9 @@ namespace ServiceStack.OrmLite
                 var refModelName = refModelDef.IsInSchema
                     ? refModelDef.Schema + "_" + NamingStrategy.GetTableName(refModelDef.ModelName)
                     : NamingStrategy.GetTableName(refModelDef.ModelName);
-                return string.Format("FK_{0}_{1}_{2}", modelName, refModelName, fieldDef.FieldName);
+
+                var fkName = string.Format("FK_{0}_{1}_{2}", modelName, refModelName, fieldDef.FieldName);
+                return NamingStrategy.ApplyNameRestrictions(fkName);
             } else { return ForeignKeyName; }
         }
     }

--- a/src/ServiceStack.OrmLite/INamingStrategy.cs
+++ b/src/ServiceStack.OrmLite/INamingStrategy.cs
@@ -5,5 +5,6 @@ namespace ServiceStack.OrmLite
 	{
 		string GetTableName(string name);
 		string GetColumnName(string name);
+		string ApplyNameRestrictions(string name);
 	}
 }

--- a/src/ServiceStack.OrmLite/OrmLiteNamingStrategyBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteNamingStrategyBase.cs
@@ -23,5 +23,10 @@ namespace ServiceStack.OrmLite
 		{
 			return name;
 		}
+
+		public virtual string ApplyNameRestrictions(string name)
+		{
+			return name;
+		}
 	}
 }


### PR DESCRIPTION
...le

provider work, namely an ApplyNameRestrictions method which can be used to
truncate long names.

IMO, INamingStrategy should be extended so that all name generation, including index and foreign key names is done through it. I don't really have time to do that now, so I'm hoping you'll accept this very minimal extension.
