### PR TITLE
Add failing test for guid list format.

### DIFF
--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteComplexTypesTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteComplexTypesTests.cs
@@ -5,7 +5,10 @@ using ServiceStack.Common.Tests.Models;
 
 namespace ServiceStack.OrmLite.Tests
 {
-	[TestFixture]
+    using System.Collections;
+    using System.Collections.Generic;
+
+    [TestFixture]
 	public class OrmLiteComplexTypesTests
 		: OrmLiteTestBase
 	{
@@ -58,6 +61,41 @@ namespace ServiceStack.OrmLite.Tests
 			}
 		}
 
+	    [Test]
+	    public void Lists_Of_Guids_Are_Formatted_Correctly()
+	    {
+            using (var db = OpenDbConnection())
+            {
+                db.CreateTable<WithAListOfGuids>(true);
+
+                var item = new WithAListOfGuids
+                               {
+                                   GuidOne = new Guid("32cb0acb-db43-4061-a6aa-7f4902a7002a"),
+                                   GuidTwo = new Guid("13083231-b005-4ff4-ab62-41bdc7f50a4d"),
+                                   TheGuids = new[] { new Guid("18176030-7a1c-4288-82df-a52f71832381"), new Guid("017f986b-f7be-4b6f-b978-ff05fba3b0aa") },
+                               };
+
+                db.Insert(item);
+
+                var savedGuidOne = db.Select<string>("SELECT GuidOne FROM WithAListOfGuids").First();
+                Assert.That(savedGuidOne, Is.EqualTo("32cb0acb-db43-4061-a6aa-7f4902a7002a"));
+
+                var savedGuidTwo = db.Select<string>("SELECT GuidTwo FROM WithAListOfGuids").First();
+                Assert.That(savedGuidTwo, Is.EqualTo("13083231-b005-4ff4-ab62-41bdc7f50a4d"));
+
+                var savedGuidList = db.Select<string>("SELECT TheGuids FROM WithAListOfGuids").First();
+                Assert.That(savedGuidList, Is.EqualTo("[18176030-7a1c-4288-82df-a52f71832381,017f986b-f7be-4b6f-b978-ff05fba3b0aa]"));
+            }
+	    }
+
 	}
 
+    public class WithAListOfGuids
+    {
+        public Guid GuidOne { get; set; }
+
+        public Guid GuidTwo { get; set; }
+
+        public IEnumerable<Guid> TheGuids { get; set; }
+    }
 }


### PR DESCRIPTION
Hi Demis,

We have noticed that if we have an entity that has an enumerable of Guids as one of it's properties, it stores the values in the 32 digit (N) format.  This isn't a direct problem, in terms of serialising and deserialising, but it is a bit of an issue if through Sql Server Studio Manager you want to copy the value out and check it against another source table, where the values are true Guids.

I've traced the actual cause down to a function in ServiceStack.Text, 

```
public void WriteGuid(TextWriter writer, object oValue)
{
writer.Write(((Guid)oValue).ToString("N"));
}
```

Ideally, we'd be able to control this serialisation in some way.  Any thoughts?

Thanks

Richard
