### PR TITLE
Clean up unit tests so they can be used for the Oracle provider and one ...

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteWriteExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteWriteExtensions.cs
@@ -371,7 +371,7 @@ namespace ServiceStack.OrmLite
                 OrmLiteConfig.UpdateFilter(dbCmd, obj);
 
             OrmLiteConfig.DialectProvider.PrepareParameterizedUpdateStatement<T>(dbCmd);
-            if (dbCmd.CommandText == null)
+            if (string.IsNullOrEmpty(dbCmd.CommandText))
                 return 0;
 
             OrmLiteConfig.DialectProvider.SetParameterValues<T>(dbCmd, obj);
@@ -397,7 +397,7 @@ namespace ServiceStack.OrmLite
                 var dialectProvider = OrmLiteConfig.DialectProvider;
 
                 dialectProvider.PrepareParameterizedUpdateStatement<T>(dbCmd);
-                if (dbCmd.CommandText == null)
+                if (string.IsNullOrEmpty(dbCmd.CommandText))
                     return 0;
 
                 foreach (var obj in objs)

--- a/tests/ServiceStack.OrmLite.Tests/ApiSqlServerTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/ApiSqlServerTests.cs
@@ -15,6 +15,7 @@ namespace ServiceStack.OrmLite.Tests
         [SetUp]
         public void SetUp()
         {
+            SuppressIfOracle("SQL Server tests");
             db = CreateSqlServerDbFactory().OpenDbConnection();
             db.DropAndCreateTable<Person>();
             db.DropAndCreateTable<PersonWithAutoId>();

--- a/tests/ServiceStack.OrmLite.Tests/CustomSqlTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/CustomSqlTests.cs
@@ -75,8 +75,10 @@ namespace ServiceStack.OrmLite.Tests
                 var createTableSql = db.GetLastSql();
                 createTableSql.Print();
 
-                Assert.That(createTableSql, Is.StringContaining("\"CharColumn\" CHAR(20) null"));
-                Assert.That(createTableSql, Is.StringContaining("\"DecimalColumn\" DECIMAL(18,4) null"));
+                Assert.That(createTableSql, Is.StringContaining("\"CharColumn\" CHAR(20) null")
+                                            .Or.StringContaining("CharColumn CHAR(20) null"));
+                Assert.That(createTableSql, Is.StringContaining("\"DecimalColumn\" DECIMAL(18,4) null")
+                                            .Or.StringContaining("DecimalColumn DECIMAL(18,4) null"));
             }
         }
 
@@ -100,6 +102,8 @@ namespace ServiceStack.OrmLite.Tests
         [Test]
         public void Does_execute_CustomSql_after_table_created()
         {
+            SuppressIfOracle("For Oracle need wrap multiple SQL statements in an anonymous block");
+
             using (var db = OpenDbConnection())
             {
                 db.DropAndCreateTable<ModelWithSeedDataSql>();
@@ -113,6 +117,8 @@ namespace ServiceStack.OrmLite.Tests
         [Test]
         public void Does_execute_CustomSql_after_table_created_using_dynamic_attribute()
         {
+            SuppressIfOracle("For Oracle need wrap multiple SQL statements in an anonymous block");
+
             typeof(DynamicAttributeSeedData)
                 .AddAttributes(new PostCreateTableAttribute(
                     "INSERT INTO DynamicAttributeSeedData (Name) VALUES ('Foo');" +

--- a/tests/ServiceStack.OrmLite.Tests/DateTimeOffsetTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/DateTimeOffsetTests.cs
@@ -5,12 +5,12 @@ using NUnit.Framework;
 
 namespace ServiceStack.OrmLite.Tests
 {
-    internal class DateTimeOffsetTests : OrmLiteTestBase
+    public class DateTimeOffsetTests : OrmLiteTestBase
     {
         private IDbConnection db;
 
         [TestFixtureSetUp]
-        public void TestFixtureSetUp()
+        public new void TestFixtureSetUp()
         {
             db = base.OpenDbConnection();
         }
@@ -45,7 +45,7 @@ namespace ServiceStack.OrmLite.Tests
         {
             var dateTime = new DateTimeOffset(2012, 1, 30, 1, 1, 1, new TimeSpan(5, 0, 0));
             var x = InsertAndSelectDateTimeOffset<DateTimeOffsetObject, DateTimeOffset>(db, dateTime);
-            Assert.AreEqual(x.Test, dateTime);
+            Assert.That(x.Test, Is.EqualTo(dateTime));
         }
 
         [Test]
@@ -53,21 +53,24 @@ namespace ServiceStack.OrmLite.Tests
         {
             DateTimeOffset? dateTime = new DateTimeOffset(2012, 1, 30, 1, 1, 1, new TimeSpan(5, 0, 0));
             var x = InsertAndSelectDateTimeOffset<NullableDateTimeOffsetObject, DateTimeOffset?>(db, dateTime);
-            Assert.AreEqual(x.Test, dateTime);
+            Assert.That(x.Test, Is.EqualTo(dateTime));
         }
 
         private class DateTimeOffsetObject : IDateTimeOffsetObject<DateTimeOffset>
         {
+            public int Id { get; set; }
             public DateTimeOffset Test { get; set; }
         }
 
         private class NullableDateTimeOffsetObject : IDateTimeOffsetObject<DateTimeOffset?>
         {
+            public int Id { get; set; }
             public DateTimeOffset? Test { get; set; }
         }
 
         private interface IDateTimeOffsetObject<T>
         {
+            int Id { get; set; }
             T Test { get; set; }
         }
     }

--- a/tests/ServiceStack.OrmLite.Tests/EnumTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/EnumTests.cs
@@ -133,7 +133,7 @@ namespace ServiceStack.OrmLite.Tests
 
                 db.GetLastSql().Print();
 
-                Assert.That(db.GetLastSql(), Is.StringContaining("\"Flags\" INT"));
+                Assert.That(db.GetLastSql(), Is.StringContaining("\"Flags\" INT").Or.StringContaining("Flags INT"));
             }
         }
 
@@ -149,7 +149,7 @@ namespace ServiceStack.OrmLite.Tests
                 db.Insert(new TypeWithFlagsEnum { Id = 3, Flags = FlagsEnum.FlagOne | FlagsEnum.FlagTwo });
 
                 db.Update(new TypeWithFlagsEnum { Id = 1, Flags = FlagsEnum.FlagThree });
-                Assert.That(db.GetLastSql(), Is.StringContaining("=@Flags"));
+                Assert.That(db.GetLastSql(), Is.StringContaining("=@Flags").Or.StringContaining("=:Flags"));
                 db.GetLastSql().Print();
 
                 db.UpdateOnly(new TypeWithFlagsEnum { Id = 1, Flags = FlagsEnum.FlagThree }, q => q.Flags);

--- a/tests/ServiceStack.OrmLite.Tests/Expression/ExpressionsTestBase.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Expression/ExpressionsTestBase.cs
@@ -59,14 +59,5 @@ namespace ServiceStack.OrmLite.Tests.Expression
                 }
             }
         }
-
-        protected override string GetFileConnectionString()
-        {
-            var connectionString = Config.SqliteFileDir + this.GetType().Name + ".sqlite";
-            if (File.Exists(connectionString))
-                File.Delete(connectionString);
-
-            return connectionString;
-        }
     }
 }

--- a/tests/ServiceStack.OrmLite.Tests/JoinSqlBuilderTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/JoinSqlBuilderTests.cs
@@ -4,8 +4,8 @@ using ServiceStack.DataAnnotations;
 
 namespace ServiceStack.OrmLite.Tests
 {
-	[TestFixture ()]
-	public class JoinSqlBuilderTests
+	[TestFixture]
+	public class JoinSqlBuilderTests : OrmLiteTestBase
 	{
 		[Alias("Users")]
 		public class WithAliasUser 
@@ -50,9 +50,11 @@ namespace ServiceStack.OrmLite.Tests
 		}
 
 
-		[Test ()]
+		[Test]
 		public void FieldNameLeftJoinTest ()
 		{
+            SuppressIfOracle("These assert comparisons don't work with Oracle provider because it doesn't quote every name");
+
 			var joinQuery = new JoinSqlBuilder<User, User> ().LeftJoin<User, Address> (x => x.Id, x => x.UserId).ToSql ();
 			var expected = "SELECT \"User\".\"Id\",\"User\".\"Name\",\"User\".\"Age\" \nFROM \"User\" \n LEFT OUTER JOIN  \"Address\" ON \"User\".\"Id\" = \"Address\".\"UserId\"  \n";
 
@@ -71,10 +73,12 @@ namespace ServiceStack.OrmLite.Tests
 			Assert.AreEqual (expected, joinQuery);
 		}
 
-		[Test ()]
+		[Test]
 		public void DoubleWhereLeftJoinTest ()
 		{
-			var joinQuery = new JoinSqlBuilder<User, User> ().LeftJoin<User, WithAliasAddress> (x => x.Id, x => x.UserId
+            SuppressIfOracle("These assert comparisons don't work with Oracle provider because it doesn't quote every name");
+
+            var joinQuery = new JoinSqlBuilder<User, User>().LeftJoin<User, WithAliasAddress>(x => x.Id, x => x.UserId
 			                                                                                    , sourceWhere: x => x.Age > 18
 			                                                                                    , destinationWhere: x => x.Country == "Italy").ToSql ();
 			var expected = "SELECT \"User\".\"Id\",\"User\".\"Name\",\"User\".\"Age\" \nFROM \"User\" \n LEFT OUTER JOIN  \"Addresses\" ON \"User\".\"Id\" = \"Addresses\".\"UserId\"  \nWHERE (\"User\".\"Age\" > 18) AND (\"Addresses\".\"Countryalias\" = 'Italy') \n";

--- a/tests/ServiceStack.OrmLite.Tests/LoadReferencesTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/LoadReferencesTests.cs
@@ -74,6 +74,8 @@ namespace ServiceStack.OrmLite.Tests
         [Test]
         public void Does_not_include_complex_reference_type_in_sql()
         {
+            SuppressIfOracle("These assert comparisons don't work with Oracle provider because it doesn't quote every name");
+
             db.Select<Customer>();
             Assert.That(db.GetLastSql(), Is.EqualTo("SELECT \"Id\", \"Name\" FROM \"Customer\""));
         }

--- a/tests/ServiceStack.OrmLite.Tests/LocalizationTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/LocalizationTests.cs
@@ -3,20 +3,17 @@ using System.Globalization;
 using System.Threading;
 using NUnit.Framework;
 using ServiceStack.DataAnnotations;
-using ServiceStack.OrmLite.Sqlite;
-using ServiceStack.Text;
 
 namespace ServiceStack.OrmLite.Tests
 {
 	[TestFixture]
-	public class LocalizationTests
-		: OrmLiteTestBase
+	public class LocalizationTests : OrmLiteTestBase
 	{
 		private readonly CultureInfo CurrentCulture = Thread.CurrentThread.CurrentCulture;
 		private readonly CultureInfo CurrentUICulture = Thread.CurrentThread.CurrentUICulture;
 
 		[SetUp]
-		public void TestFixtureSetUp()
+		public void TestSetUp()
 		{
 			Thread.CurrentThread.CurrentCulture = new CultureInfo("vi-VN");
 			Thread.CurrentThread.CurrentUICulture = new CultureInfo("vi-VN");

--- a/tests/ServiceStack.OrmLite.Tests/MockAllApiTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/MockAllApiTests.cs
@@ -405,6 +405,8 @@ namespace ServiceStack.OrmLite.Tests
                 i += 2; db.Save(customer);
                 Assert.That(sqlStatements.Count, Is.EqualTo(i));
 
+                SuppressIfOracle("This seems wrong here as the save actually goes through to the database in Oracle to get the next number from the sequence");
+
                 i += 1; db.SaveReferences(customer, customer.PrimaryAddress);
                 Assert.That(sqlStatements.Count, Is.EqualTo(i));
 

--- a/tests/ServiceStack.OrmLite.Tests/NorthwindPerfTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/NorthwindPerfTests.cs
@@ -4,19 +4,16 @@ using System.Diagnostics;
 using Northwind.Common.DataModel;
 using NUnit.Framework;
 using ServiceStack.Data;
-using ServiceStack.OrmLite.Sqlite;
 
 namespace ServiceStack.OrmLite.Tests
 {
 	[Ignore("Perf test")]
 	[TestFixture]
-	public class NorthwindPerfTests
+	public class NorthwindPerfTests : OrmLiteTestBase
 	{
 		[Test]
 		public void Load_Northwind_database_with_OrmLite_sqlite_memory_db()
 		{
-			OrmLiteConfig.DialectProvider = new SqliteOrmLiteDialectProvider();
-
 			NorthwindData.LoadData(false);
 			GC.Collect();
 

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteComplexTypesTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteComplexTypesTests.cs
@@ -65,6 +65,8 @@ namespace ServiceStack.OrmLite.Tests
 	    [Test]
 	    public void Lists_Of_Guids_Are_Formatted_Correctly()
 	    {
+            SuppressIfOracle("Can't read a list of Guids with Oracle provider because core OrmLite doesn't give provider a chance to override conversion");
+
             using (var db = OpenDbConnection())
             {
                 db.DropAndCreateTable<WithAListOfGuids>();

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableTests.cs
@@ -148,7 +148,7 @@ namespace ServiceStack.OrmLite.Tests
             var createTableSql = OrmLiteConfig.DialectProvider.ToCreateTableStatement(typeof(ModelWithIdAndName));
 
             Console.WriteLine("createTableSql: " + createTableSql);
-            Assert.That(createTableSql.Contains("VARCHAR(255)"), Is.True);
+            Assert.That(createTableSql, Is.StringContaining("VARCHAR(255)").Or.StringContaining("VARCHAR2(255)"));
         }
 
         public class ModelWithGuid

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableWithIndexesTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableWithIndexesTests.cs
@@ -12,13 +12,15 @@ namespace ServiceStack.OrmLite.Tests
 		[Test]
 		public void Can_create_ModelWithIndexFields_table()
 		{
-			using (var db = OpenDbConnection())
+            using (var db = OpenDbConnection())
 			{
 				db.CreateTable<ModelWithIndexFields>(true);
 
 				var sql = OrmLiteConfig.DialectProvider.ToCreateIndexStatements( typeof (ModelWithIndexFields) ).Join();
 
-				Assert.IsTrue(sql.Contains("idx_modelwithindexfields_name"));
+                SuppressIfOracle("Assert comparisons don't work with Oracle provider because it had to squash names to satisfy length restrictions");
+
+                Assert.IsTrue(sql.Contains("idx_modelwithindexfields_name"));
 				Assert.IsTrue(sql.Contains("uidx_modelwithindexfields_uniquename"));
 			}
 		}
@@ -26,13 +28,15 @@ namespace ServiceStack.OrmLite.Tests
 		[Test]
 		public void Can_create_ModelWithCompositeIndexFields_table()
 		{
-			using (var db = OpenDbConnection())
+            using (var db = OpenDbConnection())
 			{
 				db.CreateTable<ModelWithCompositeIndexFields>(true);
 
 				var sql = OrmLiteConfig.DialectProvider.ToCreateIndexStatements(typeof(ModelWithCompositeIndexFields)).Join();
 
-				Assert.IsTrue(sql.Contains("idx_modelwithcompositeindexfields_name"));
+                SuppressIfOracle("Assert comparisons don't work with Oracle provider because it had to squash names to satisfy length restrictions");
+
+                Assert.IsTrue(sql.Contains("idx_modelwithcompositeindexfields_name"));
 				Assert.IsTrue(sql.Contains("idx_modelwithcompositeindexfields_composite1_composite2"));
 			}
 		}
@@ -45,6 +49,8 @@ namespace ServiceStack.OrmLite.Tests
                 db.CreateTable<ModelWithNamedCompositeIndex>(true);
 
                 var sql = OrmLiteConfig.DialectProvider.ToCreateIndexStatements(typeof(ModelWithNamedCompositeIndex)).Join();
+
+                SuppressIfOracle("Assert comparisons don't work with Oracle provider because it had to squash names to satisfy length restrictions");
 
                 Assert.IsTrue(sql.Contains("idx_modelwithnamedcompositeindex_name"));
                 Assert.IsTrue(sql.Contains("custom_index_name"));

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableWithNamingStrategyTest.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableWithNamingStrategyTest.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Globalization;
 using NUnit.Framework;
 using ServiceStack.Common.Tests.Models;
 
@@ -9,6 +9,19 @@ namespace ServiceStack.OrmLite.Tests
 	public class OrmLiteCreateTableWithNamigStrategyTests 
 		: OrmLiteTestBase
 	{
+	    private INamingStrategy PreviousNamingStrategy { get; set; }
+
+        [SetUp]
+        public void SetUp()
+        {
+            PreviousNamingStrategy = OrmLiteConfig.DialectProvider.NamingStrategy;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            OrmLiteConfig.DialectProvider.NamingStrategy = PreviousNamingStrategy;
+        }
 
 		[Test]
 		public void Can_create_TableWithNamigStrategy_table_prefix()
@@ -23,8 +36,6 @@ namespace ServiceStack.OrmLite.Tests
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 			}
-			
-			OrmLiteConfig.DialectProvider.NamingStrategy= new OrmLiteNamingStrategyBase();
 		}
 
 		[Test]
@@ -36,8 +47,6 @@ namespace ServiceStack.OrmLite.Tests
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 			}
-			
-			OrmLiteConfig.DialectProvider.NamingStrategy= new OrmLiteNamingStrategyBase();
 		}
 
 
@@ -50,14 +59,12 @@ namespace ServiceStack.OrmLite.Tests
 			{
 				db.CreateTable<ModelWithOnlyStringFields>(true);
 			}
-			
-			OrmLiteConfig.DialectProvider.NamingStrategy= new OrmLiteNamingStrategyBase();
 		}
 
 		[Test]
 		public void Can_get_data_from_TableWithNamigStrategy_with_GetById()
 		{
-			OrmLiteConfig.DialectProvider.NamingStrategy = OrmLiteConfig.DialectProvider.NamingStrategy = new PrefixNamingStrategy
+			OrmLiteConfig.DialectProvider.NamingStrategy = new PrefixNamingStrategy
 			{
 				TablePrefix = "tab_",
 				ColumnPrefix = "col_",
@@ -73,15 +80,13 @@ namespace ServiceStack.OrmLite.Tests
 
 				Assert.AreEqual(m.Name, modelFromDb.Name);
 			}
-			
-			OrmLiteConfig.DialectProvider.NamingStrategy= new OrmLiteNamingStrategyBase();
 		}
 
 
 		[Test]
 		public void Can_get_data_from_TableWithNamigStrategy_with_query_by_example()
 		{
-			OrmLiteConfig.DialectProvider.NamingStrategy = OrmLiteConfig.DialectProvider.NamingStrategy = new PrefixNamingStrategy
+			OrmLiteConfig.DialectProvider.NamingStrategy = new PrefixNamingStrategy
 			{
 				TablePrefix = "tab_",
 				ColumnPrefix = "col_",
@@ -97,8 +102,6 @@ namespace ServiceStack.OrmLite.Tests
 
 				Assert.AreEqual(m.Name, modelFromDb.Name);
 			}
-			
-			OrmLiteConfig.DialectProvider.NamingStrategy= new OrmLiteNamingStrategyBase();
 		}
 		
 		[Test]
@@ -120,14 +123,12 @@ namespace ServiceStack.OrmLite.Tests
                 var modelFromDb = db.Single<ModelWithOnlyStringFields>(x => x.Name == "ReadConnectionExtensionFirst");
 				Assert.AreEqual(m.AlbumName, modelFromDb.AlbumName);
 			}
-
-            OrmLiteConfig.DialectProvider.NamingStrategy = new OrmLiteNamingStrategyBase();
         }
 		
 		[Test]
 		public void Can_get_data_from_TableWithNamigStrategy_AfterChangingNamingStrategy()
 		{			
-			OrmLiteConfig.DialectProvider.NamingStrategy = OrmLiteConfig.DialectProvider.NamingStrategy = new PrefixNamingStrategy
+			OrmLiteConfig.DialectProvider.NamingStrategy = new PrefixNamingStrategy
 			{
 				TablePrefix = "tab_",
 				ColumnPrefix = "col_",
@@ -164,7 +165,7 @@ namespace ServiceStack.OrmLite.Tests
 				Assert.AreEqual(m.Name, modelFromDb.Name);	
 			}
 			
-			OrmLiteConfig.DialectProvider.NamingStrategy = OrmLiteConfig.DialectProvider.NamingStrategy = new PrefixNamingStrategy
+			OrmLiteConfig.DialectProvider.NamingStrategy = new PrefixNamingStrategy
 			{
 				TablePrefix = "tab_",
 				ColumnPrefix = "col_",
@@ -183,8 +184,6 @@ namespace ServiceStack.OrmLite.Tests
                 modelFromDb = db.SingleById<ModelWithOnlyStringFields>("998");
 				Assert.AreEqual(m.Name, modelFromDb.Name);
 			}
-			
-			OrmLiteConfig.DialectProvider.NamingStrategy = new OrmLiteNamingStrategyBase();
 		}
 
 	}
@@ -240,11 +239,10 @@ namespace ServiceStack.OrmLite.Tests
 		string toUnderscoreSeparatedCompound(string name)
 		{
 
-			string r = char.ToLower(name[0]).ToString();
+			string r = char.ToLower(name[0]).ToString(CultureInfo.InvariantCulture);
 
 			for (int i = 1; i < name.Length; i++)
 			{
-				char c = name[i];
 				if (char.IsUpper(name[i]))
 				{
 					r += "_";

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteDeleteTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteDeleteTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -30,31 +31,36 @@ namespace ServiceStack.OrmLite.Tests
 		public void Can_Delete_from_ModelWithFieldsOfDifferentTypes_table()
 		{
             var rowIds = new List<int>(new[] { 1, 2, 3 });
-            rowIds.ForEach(x => db.Insert(ModelWithFieldsOfDifferentTypes.Create(x)));
+
+            for (var i = 0; i < rowIds.Count; i++)
+                rowIds[i] = (int)db.Insert(ModelWithFieldsOfDifferentTypes.Create(rowIds[i]), selectIdentity: true);
 
             var rows = db.Select<ModelWithFieldsOfDifferentTypes>();
-            var row2 = rows.First(x => x.Id == 2);
+
+            var row2 = rows.First(x => x.Id == rowIds[1]);
 
             db.Delete(row2);
 
             rows = db.SelectByIds<ModelWithFieldsOfDifferentTypes>(rowIds);
             var dbRowIds = rows.ConvertAll(x => x.Id);
 
-            Assert.That(dbRowIds, Is.EquivalentTo(new[] { 1, 3 }));
+            Assert.That(dbRowIds, Is.EquivalentTo(new[] { rowIds[0], rowIds[2] }));
         }
 
 		[Test]
 		public void Can_DeleteById_from_ModelWithFieldsOfDifferentTypes_table()
 		{
             var rowIds = new List<int>(new[] { 1, 2, 3 });
-            rowIds.ForEach(x => db.Insert(ModelWithFieldsOfDifferentTypes.Create(x)));
 
-            db.DeleteById<ModelWithFieldsOfDifferentTypes>(2);
+            for (var i = 0; i < rowIds.Count; i++)
+                rowIds[i] = (int)db.Insert(ModelWithFieldsOfDifferentTypes.Create(rowIds[i]), selectIdentity: true);
+
+            db.DeleteById<ModelWithFieldsOfDifferentTypes>(rowIds[1]);
 
             var rows = db.SelectByIds<ModelWithFieldsOfDifferentTypes>(rowIds);
             var dbRowIds = rows.ConvertAll(x => x.Id);
 
-            Assert.That(dbRowIds, Is.EquivalentTo(new[] { 1, 3 }));
+            Assert.That(dbRowIds, Is.EquivalentTo(new[] { rowIds[0], rowIds[2] }));
         }
 
 		[Test]
@@ -63,14 +69,16 @@ namespace ServiceStack.OrmLite.Tests
             db.DropAndCreateTable<ModelWithFieldsOfDifferentTypes>();
 
             var rowIds = new List<int>(new[] { 1, 2, 3 });
-            rowIds.ForEach(x => db.Insert(ModelWithFieldsOfDifferentTypes.Create(x)));
 
-            db.DeleteByIds<ModelWithFieldsOfDifferentTypes>(new[] { 1, 3 });
+            for (var i = 0; i < rowIds.Count; i++)
+                rowIds[i] = (int)db.Insert(ModelWithFieldsOfDifferentTypes.Create(rowIds[i]), selectIdentity: true);
+
+            db.DeleteByIds<ModelWithFieldsOfDifferentTypes>(new[] { rowIds[0], rowIds[2] });
 
             var rows = db.SelectByIds<ModelWithFieldsOfDifferentTypes>(rowIds);
             var dbRowIds = rows.ConvertAll(x => x.Id);
 
-            Assert.That(dbRowIds, Is.EquivalentTo(new[] { 2 }));
+            Assert.That(dbRowIds, Is.EquivalentTo(new[] { rowIds[1] }));
         }
         
         [Test]

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteDropTableWithNamingStrategyTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteDropTableWithNamingStrategyTests.cs
@@ -6,6 +6,20 @@ namespace ServiceStack.OrmLite.Tests
     public class OrmLiteDropTableWithNamingStrategyTests
         : OrmLiteTestBase
     {
+        private INamingStrategy PreviousNamingStrategy { get; set; }
+
+        [SetUp]
+        public void SetUp()
+        {
+            PreviousNamingStrategy = OrmLiteConfig.DialectProvider.NamingStrategy;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            OrmLiteConfig.DialectProvider.NamingStrategy = PreviousNamingStrategy;
+        }
+
         [Test]
         public void Can_drop_TableWithNamigStrategy_table_prefix()
         {
@@ -23,8 +37,6 @@ namespace ServiceStack.OrmLite.Tests
 
                 Assert.False(db.TableExists("tab_ModelWithOnlyStringFields"));
             }
-            
-            OrmLiteConfig.DialectProvider.NamingStrategy = new OrmLiteNamingStrategyBase();
         }
 
         [Test]
@@ -40,8 +52,6 @@ namespace ServiceStack.OrmLite.Tests
 
                 Assert.False(db.TableExists("modelwithonlystringfields"));
             }
-
-            OrmLiteConfig.DialectProvider.NamingStrategy = new OrmLiteNamingStrategyBase();
         }
 
 
@@ -58,8 +68,6 @@ namespace ServiceStack.OrmLite.Tests
 
                 Assert.False(db.TableExists("model_with_only_string_fields"));
             }
-
-            OrmLiteConfig.DialectProvider.NamingStrategy = new OrmLiteNamingStrategyBase();
         }
     }
 }

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteExecFilterTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteExecFilterTests.cs
@@ -60,6 +60,8 @@ namespace ServiceStack.OrmLite.Tests
         [Test]
         public void Can_add_replay_logic()
         {
+            SuppressIfOracle("Can't run this with Oracle until use trigger for AutoIncrement primary key insertion");
+
             var holdExecFilter = OrmLiteConfig.ExecFilter;
             OrmLiteConfig.ExecFilter = new ReplayOrmLiteExecFilter { ReplayTimes = 3 };
 

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteInsertTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteInsertTests.cs
@@ -152,6 +152,8 @@ namespace ServiceStack.OrmLite.Tests
 		[Test]
 		public void Can_insert_table_with_blobs()
 		{
+            SuppressIfOracle("Oracle provider's default string length is short enough that this fails. I think solution is better handling of blobs");
+
 			using (var db = OpenDbConnection())
 			{
 				db.DropAndCreateTable<OrderBlob>();
@@ -240,6 +242,8 @@ namespace ServiceStack.OrmLite.Tests
         [Test]
         public void Can_GetLastInsertedId_using_Insert()
         {
+            SuppressIfOracle("Need trigger for autoincrement keys to work in Oracle with caller supplied SQL");
+
             var date = new DateTime(2000, 1, 1);
             var testObject = new UserAuth { UserName = "test", CreatedDate = date, ModifiedDate = date };
 

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteSaveTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteSaveTests.cs
@@ -26,7 +26,7 @@ namespace ServiceStack.OrmLite.Tests
 
                 db.Save(row);
 
-                Assert.That(row.Id, Is.EqualTo(1));
+                Assert.That(row.Id, Is.Not.EqualTo(0));
             }
         }
 
@@ -52,8 +52,9 @@ namespace ServiceStack.OrmLite.Tests
 
                 db.Save(rows);
 
-                Assert.That(rows[0].Id, Is.EqualTo(1));
-                Assert.That(rows[1].Id, Is.EqualTo(2));
+                Assert.That(rows[0].Id, Is.Not.EqualTo(0));
+                Assert.That(rows[1].Id, Is.Not.EqualTo(0));
+                Assert.That(rows[0].Id, Is.Not.EqualTo(rows[1].Id));
             }
         }
 
@@ -80,8 +81,9 @@ namespace ServiceStack.OrmLite.Tests
 
                 db.Save(rows);
 
-                Assert.That(rows[0].Id, Is.EqualTo(1));
-                Assert.That(rows[1].Id, Is.EqualTo(2));
+                Assert.That(rows[0].Id, Is.Not.EqualTo(0));
+                Assert.That(rows[1].Id, Is.Not.EqualTo(0));
+                Assert.That(rows[0].Id, Is.Not.EqualTo(rows[1].Id));
 
                 trans.Commit();
             }

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteSelectTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteSelectTests.cs
@@ -21,11 +21,12 @@ namespace ServiceStack.OrmLite.Tests
 
 				var rowIds = new List<int>(new[] { 1, 2, 3 });
 
-				rowIds.ForEach(x => db.Insert(ModelWithFieldsOfDifferentTypes.Create(x)));
+                for (var i = 0; i < rowIds.Count; i++)
+                    rowIds[i] = (int)db.Insert(ModelWithFieldsOfDifferentTypes.Create(rowIds[i]), selectIdentity: true);
 
-                var row = db.SingleById<ModelWithFieldsOfDifferentTypes>(1);
+                var row = db.SingleById<ModelWithFieldsOfDifferentTypes>(rowIds[1]);
 
-				Assert.That(row.Id, Is.EqualTo(1));
+                Assert.That(row.Id, Is.EqualTo(rowIds[1]));
 			}
 		}
 
@@ -55,12 +56,13 @@ namespace ServiceStack.OrmLite.Tests
 
 				var rowIds = new List<int>(new[] { 1, 2, 3 });
 
-				rowIds.ForEach(x => db.Insert(ModelWithFieldsOfDifferentTypes.Create(x)));
+                for (var i = 0; i < rowIds.Count; i++)
+                    rowIds[i] = (int)db.Insert(ModelWithFieldsOfDifferentTypes.Create(rowIds[i]), selectIdentity: true);
 
 				var rows = db.SelectByIds<ModelWithFieldsOfDifferentTypes>(rowIds);
 				var dbRowIds = rows.ConvertAll(x => x.Id);
 
-				Assert.That(dbRowIds, Is.EquivalentTo(rowIds));
+                Assert.That(dbRowIds, Is.EquivalentTo(rowIds));
 			}
 		}
 
@@ -257,9 +259,12 @@ namespace ServiceStack.OrmLite.Tests
 
 				var rowIds = new List<int>(new[] { 1, 2, 3 });
 
-				rowIds.ForEach(x => db.Insert(ModelWithFieldsOfDifferentTypes.Create(x)));
+                for (var i = 0; i < rowIds.Count; i++)
+                    rowIds[i] = (int)db.Insert(ModelWithFieldsOfDifferentTypes.Create(rowIds[i]), selectIdentity: true);
 
-				var rows = db.SelectFmt<ModelWithIdAndName>("SELECT Id, Name FROM ModelWithFieldsOfDifferentTypes");
+                SuppressIfOracle("Oracle provider doesn't modify user supplied SQL to conform to name length restrictions");
+
+                var rows = db.SelectFmt<ModelWithIdAndName>("SELECT Id, Name FROM ModelWithFieldsOfDifferentTypes");
 				var dbRowIds = rows.ConvertAll(x => x.Id);
 
 				Assert.That(dbRowIds, Is.EquivalentTo(rowIds));
@@ -269,18 +274,19 @@ namespace ServiceStack.OrmLite.Tests
 		[Test]
 		public void Can_Select_Into_ModelWithIdAndName_from_ModelWithFieldsOfDifferentTypes_table()
 		{
-			using (var db = OpenDbConnection())
+            using (var db = OpenDbConnection())
 			{
                 db.DropAndCreateTable<ModelWithFieldsOfDifferentTypes>();
 
 				var rowIds = new List<int>(new[] { 1, 2, 3 });
 
-				rowIds.ForEach(x => db.Insert(ModelWithFieldsOfDifferentTypes.Create(x)));
-
+                for (var i = 0; i < rowIds.Count; i++)
+                    rowIds[i] = (int)db.Insert(ModelWithFieldsOfDifferentTypes.Create(rowIds[i]), selectIdentity: true);
+                
 				var rows = db.Select<ModelWithIdAndName>(typeof(ModelWithFieldsOfDifferentTypes));
 				var dbRowIds = rows.ConvertAll(x => x.Id);
 
-				Assert.That(dbRowIds, Is.EquivalentTo(rowIds));
+                Assert.That(dbRowIds, Is.EquivalentTo(rowIds));
 			}
 		}
 

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteTestBase.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteTestBase.cs
@@ -113,5 +113,10 @@ namespace ServiceStack.OrmLite.Tests
 
             return connString.OpenDbConnection();            
         }
+
+        protected void SuppressIfOracle(string reason, params object[] args)
+        {
+            // Not Oracle if this base class used
+        }
 	}
 }

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteUpdateTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteUpdateTests.cs
@@ -38,13 +38,13 @@ namespace ServiceStack.OrmLite.Tests
         {
             var row = CreateModelWithFieldsOfDifferentTypes();
 
-            db.Insert(row);
+            row.Id = (int)db.Insert(row, selectIdentity: true);
 
             row.Name = "UpdatedName";
 
             db.Update(row);
 
-            var dbRow = db.SingleById<ModelWithFieldsOfDifferentTypes>(1);
+            var dbRow = db.SingleById<ModelWithFieldsOfDifferentTypes>(row.Id);
 
             ModelWithFieldsOfDifferentTypes.AssertIsEqual(dbRow, row);
         }
@@ -54,13 +54,13 @@ namespace ServiceStack.OrmLite.Tests
         {
             var row = CreateModelWithFieldsOfDifferentTypes();
 
-            db.Insert(row);
+            row.Id = (int)db.Insert(row, selectIdentity: true);
 
             row.Name = "UpdatedName";
 
             db.Update(row, x => x.LongId <= row.LongId);
 
-            var dbRow = db.SingleById<ModelWithFieldsOfDifferentTypes>(1);
+            var dbRow = db.SingleById<ModelWithFieldsOfDifferentTypes>(row.Id);
 
             ModelWithFieldsOfDifferentTypes.AssertIsEqual(dbRow, row);
         }
@@ -70,7 +70,7 @@ namespace ServiceStack.OrmLite.Tests
         {
             var row = CreateModelWithFieldsOfDifferentTypes();
 
-            db.Insert(row);
+            row.Id = (int)db.Insert(row, selectIdentity: true);
             row.DateTime = DateTime.Now;
             row.Name = "UpdatedName";
 
@@ -87,7 +87,7 @@ namespace ServiceStack.OrmLite.Tests
         {
             var row = CreateModelWithFieldsOfDifferentTypes();
 
-            db.Insert(row);
+            row.Id = (int)db.Insert(row, selectIdentity: true);
             row.Name = "UpdatedName";
 
             db.UpdateFmt<ModelWithFieldsOfDifferentTypes>(set: "NAME = {0}".SqlFmt(row.Name), where: "LongId <= {0}".SqlFmt(row.LongId));
@@ -102,7 +102,7 @@ namespace ServiceStack.OrmLite.Tests
         {
             var row = CreateModelWithFieldsOfDifferentTypes();
 
-            db.Insert(row);
+            row.Id = (int)db.Insert(row, selectIdentity: true);
             row.Name = "UpdatedName";
 
             db.UpdateFmt(table: "ModelWithFieldsOfDifferentTypes",

--- a/tests/ServiceStack.OrmLite.Tests/ShippersExample.cs
+++ b/tests/ServiceStack.OrmLite.Tests/ShippersExample.cs
@@ -1,20 +1,14 @@
+using System;
 using System.Data;
 using NUnit.Framework;
 using ServiceStack.DataAnnotations;
 using ServiceStack.Model;
-using ServiceStack.OrmLite.Sqlite;
 
 namespace ServiceStack.OrmLite.Tests
 {
 	[TestFixture]
-	public class ShippersExample
+	public class ShippersExample : OrmLiteTestBase
 	{
-		static ShippersExample()
-		{
-			OrmLiteConfig.DialectProvider = SqliteOrmLiteDialectProvider.Instance;
-		}
-
-
 		[Alias("Shippers")]
 		public class Shipper
 			: IHasId<int>
@@ -65,10 +59,11 @@ namespace ServiceStack.OrmLite.Tests
 		[Test]
 		public void Shippers_UseCase()
 		{
-            using (IDbConnection db = ":memory:".OpenDbConnection())
+            using (IDbConnection db = OpenDbConnection())
 			{
+                db.DropTables(typeof(Shipper), typeof(ShipperType));
 				const bool overwrite = false;
-				db.CreateTables(overwrite, typeof(Shipper), typeof(ShipperType));
+                db.CreateTables(overwrite, typeof(ShipperType), typeof(Shipper));
 
 				int trainsTypeId, planesTypeId;
 

--- a/tests/ServiceStack.OrmLite.Tests/SqlBuilderTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/SqlBuilderTests.cs
@@ -8,7 +8,7 @@ using ServiceStack.DataAnnotations;
 namespace ServiceStack.OrmLite.Tests
 {
     [TestFixture]
-    public class SqlBuilderTests
+    public class SqlBuilderTests : OrmLiteTestBase
     {
         [Alias("Users")]
         public class User 
@@ -64,6 +64,8 @@ namespace ServiceStack.OrmLite.Tests
         [Test]
         public void BuilderTemplateWOComposition()
         {
+            SuppressIfOracle("Oracle provider is not smart enough to replace '@' parameter delimiter with ':'");
+
             var builder = new SqlBuilder();
             var template = builder.AddTemplate("SELECT COUNT(*) FROM Users WHERE Age = @age", new { age = 5 });
 

--- a/tests/ServiceStack.OrmLite.Tests/TypeWithByteArrayFieldTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/TypeWithByteArrayFieldTests.cs
@@ -55,6 +55,8 @@ namespace ServiceStack.OrmLite.Tests
         [Test, Explicit]
         public void Can_upload_attachment_via_sp()
         {
+            SuppressIfOracle("Oracle provider is not smart enough to replace parameter delimiter '@' with ':'");
+
             using (var db = OpenDbConnection())
             {
                 db.DropAndCreateTable<Attachment>();
@@ -93,6 +95,8 @@ end");
         [Test, Explicit]
         public void Can_upload_attachment_via_sp_with_ADONET()
         {
+            SuppressIfOracle("Oracle provider is not smart enough to replace parameter delimiter '@' with ':'");
+
             using (var db = OpenDbConnection())
             {
                 db.DropAndCreateTable<Attachment>();

--- a/tests/ServiceStack.OrmLite.Tests/UseCase/AliasedFieldUseCase.cs
+++ b/tests/ServiceStack.OrmLite.Tests/UseCase/AliasedFieldUseCase.cs
@@ -7,13 +7,8 @@ using ServiceStack.DataAnnotations;
 namespace ServiceStack.OrmLite.Tests.UseCase
 {
     [TestFixture]
-    public class AliasedFieldUseCase
+    public class AliasedFieldUseCase : OrmLiteTestBase
     {
-        [TestFixtureSetUp]
-        public void TestFixtureSetup() {
-            OrmLiteConfig.DialectProvider = SqliteDialect.Provider;
-        }
-
         public class Foo
         {
             [Alias("SOME_COLUMN_NAME")]
@@ -23,9 +18,9 @@ namespace ServiceStack.OrmLite.Tests.UseCase
         [Test]
         public void CanResolveAliasedFieldNameInAnonymousType()
         {
-            using (IDbConnection db = ":memory:".OpenDbConnection())
+            using (IDbConnection db = OpenDbConnection())
             {
-                db.CreateTable<Foo>(false);
+                db.CreateTable<Foo>(true);
 
                 db.Insert(new Foo { Bar = "some_value" });
                 db.Insert(new Foo { Bar = "a totally different value" });

--- a/tests/ServiceStack.OrmLite.Tests/UseCase/CustomerOrdersUseCase.cs
+++ b/tests/ServiceStack.OrmLite.Tests/UseCase/CustomerOrdersUseCase.cs
@@ -117,7 +117,7 @@ namespace ServiceStack.OrmLite.Tests.UseCase
     }
 
     [TestFixture]
-    public class CustomerOrdersUseCase
+    public class CustomerOrdersUseCase : OrmLiteTestBase
     {
         //Stand-alone class, No other configs, nothing but POCOs.
         [Test]

--- a/tests/ServiceStack.OrmLite.Tests/UseCase/ServiceStack_OrmLite_UseCase.cs
+++ b/tests/ServiceStack.OrmLite.Tests/UseCase/ServiceStack_OrmLite_UseCase.cs
@@ -15,13 +15,12 @@ namespace ServiceStack.OrmLite.Tests.UseCase
     }
 
     [TestFixture]
-    public class ServiceStack_OrmLite_UseCase
+    public class ServiceStack_OrmLite_UseCase : OrmLiteTestBase
     {
         [Test]
         public void Can_Add_Update_and_Delete_Todo_item()
         {
-            var dbFactory = new OrmLiteConnectionFactory(":memory:", SqliteDialect.Provider);
-            using (IDbConnection db = dbFactory.Open())
+            using (IDbConnection db = OpenDbConnection())
             {
                 db.DropAndCreateTable<Todo>();
                 var todo = new Todo

--- a/tests/ServiceStack.OrmLite.Tests/UseCase/SimpleUseCase.cs
+++ b/tests/ServiceStack.OrmLite.Tests/UseCase/SimpleUseCase.cs
@@ -6,15 +6,8 @@ using NUnit.Framework;
 namespace ServiceStack.OrmLite.Tests.UseCase
 {
 	[TestFixture]
-	public class SimpleUseCase
+	public class SimpleUseCase : OrmLiteTestBase
 	{
-		[TestFixtureSetUp]
-		public void TestFixtureSetUp()
-		{
-			//Inject your database provider here
-			OrmLiteConfig.DialectProvider = SqliteDialect.Provider;
-		}
-
 		public class User
 		{
 			public long Id { get; set; }
@@ -28,9 +21,9 @@ namespace ServiceStack.OrmLite.Tests.UseCase
 		[Test]
 		public void Simple_CRUD_example()
 		{
-			using (IDbConnection db = ":memory:".OpenDbConnection())
+			using (IDbConnection db = OpenDbConnection())
 			{
-				db.CreateTable<User>(false);
+				db.DropAndCreateTable<User>();
 
 				db.Insert(new User { Id = 1, Name = "A", CreatedDate = DateTime.Now });
 				db.Insert(new User { Id = 2, Name = "B", CreatedDate = DateTime.Now });


### PR DESCRIPTION
...bug fix.

The tests can now be soft linked to the ServiceStack.OrmLite.Oracle.Tests
project.

Fix the test for null updates in OrmLiteWriteExtensions to allow empty strings
as well as null.

Here is the first pull request to clean up the tests so that I can use them for testing the Oracle provider without having to duplicate them. I don't think I broke anything, but I can't test SQL Server from home and I've been at home all week. Some tests don't work, but they didn't work for me before.
