### PR TITLE
Fix Oracle provider problems pointed out by recent changes.

### DIFF
--- a/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
@@ -41,6 +41,9 @@ namespace ServiceStack.OrmLite
 
         object ConvertDbValue(object value, Type type);
 
+        GetValueDelegate GetReaderGuidDelegate(IDataRecord reader);
+        GetValueDelegate GetReaderNullableGuidDelegate(IDataRecord reader);
+
         string GetQuotedValue(object value, Type fieldType);
 
         IDbConnection CreateConnection(string filePath, Dictionary<string, string> options);

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -368,6 +368,16 @@ namespace ServiceStack.OrmLite
             }
         }
 
+        public virtual GetValueDelegate GetReaderGuidDelegate(IDataRecord reader)
+        {
+            return i => reader.GetGuid(i);
+        }
+
+        public virtual GetValueDelegate GetReaderNullableGuidDelegate(IDataRecord reader)
+        {
+            return i => reader.IsDBNull(i) ? null : (Guid?)reader.GetGuid(i);
+        }
+
         public virtual string GetQuotedValue(object value, Type fieldType)
         {
             if (value == null) return "NULL";

--- a/src/ServiceStack.OrmLite/OrmLiteReadExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadExtensions.cs
@@ -114,8 +114,8 @@ namespace ServiceStack.OrmLite
                         return i => reader.GetDateTime(i);
                 }
 
-                if (typeof(T) == typeof(Guid))
-                    return i => reader.GetGuid(i);
+                if (typeof (T) == typeof(Guid))
+                    return OrmLiteConfig.DialectProvider.GetReaderGuidDelegate(reader);
             }
             else
             {
@@ -143,7 +143,7 @@ namespace ServiceStack.OrmLite
                 }
 
                 if (typeof(T) == typeof(Guid))
-                    return i => reader.IsDBNull(i) ? null : (Guid?)reader.GetGuid(i);
+                    return OrmLiteConfig.DialectProvider.GetReaderNullableGuidDelegate(reader);
             }
 
             return reader.GetValue;


### PR DESCRIPTION
This change fixes (a) problems with "long" fields that your recent change pointed out, (b) make Oracle consistent with other providers in explicitly specifying null for nullable fields, and (c) make it possible to read Guids from the database with your recent changes. Change (c) also makes it possible to use the CompactGuid setting in the Oracle provider as now it completely works. Hopefully you think the changes I made for (c) are OK. Cheers, Bruce
