### PR TITLE
Make DateTimeOffsetTests work for Oracle which does not allow such a col...

### DIFF
--- a/tests/ServiceStack.OrmLite.Tests/DateTimeOffsetTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/DateTimeOffsetTests.cs
@@ -76,13 +76,15 @@ namespace ServiceStack.OrmLite.Tests
         }
 
 
-        public class HasDateTimeOffsetMemeber
+        public class HasDateTimeOffsetMember
         {
+            public int Id { get; set; }
             public DateTimeOffset MomentInTime { get; set; }
         }
 
-        public class HasNullableDateTimeOffsetMemeber
+        public class HasNullableDateTimeOffsetMember
         {
+            public int Id { get; set; }
             public DateTimeOffset? MomentInTime { get; set; }
         }
 


### PR DESCRIPTION
...umn

to be a primary key or have a unique index. Which makes perfect sense, seems to
me other databases ought to have a similar restriction.
