### PR TITLE
Fix dumb threading issue and dumb usage of OracleExecFilter other places...

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle/OracleExecFilter.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleExecFilter.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Data;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -18,7 +18,7 @@ namespace ServiceStack.OrmLite.Oracle
             return command;
         }
 
-        private static readonly Dictionary<Type, Action<IDbCommand, bool>> Cache = new Dictionary<Type, Action<IDbCommand, bool>>();
+        private static readonly ConcurrentDictionary<Type, Action<IDbCommand, bool>> Cache = new ConcurrentDictionary<Type, Action<IDbCommand, bool>>();
         private static Action<IDbCommand, bool> GetBindByNameSetter(Type commandType)
         {
             if (commandType == null) return null;
@@ -41,7 +41,7 @@ namespace ServiceStack.OrmLite.Oracle
                 il.Emit(OpCodes.Ret);
                 action = (Action<IDbCommand, bool>)method.CreateDelegate(typeof(Action<IDbCommand, bool>));
             }
-            Cache.Add(commandType, action);
+            Cache.TryAdd(commandType, action);
             return action;
         }
 

--- a/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
@@ -31,7 +31,12 @@ namespace ServiceStack.OrmLite.Oracle
         protected const int MaxNameLength = 30;
         protected const int MaxStringColumnLength = 4000;
 
-        public static OracleOrmLiteDialectProvider Instance = new OracleOrmLiteDialectProvider();
+        private static OracleOrmLiteDialectProvider _instance;
+        public static OracleOrmLiteDialectProvider Instance
+        {
+            // Constructing extras if we happen to hit this concurrently on separate threads is harmless enough
+            get { return _instance ?? (_instance = new OracleOrmLiteDialectProvider()); }
+        }
 
         internal long LastInsertId { get; set; }
         protected bool CompactGuid;
@@ -67,6 +72,8 @@ namespace ServiceStack.OrmLite.Oracle
             ParamString = ":";
 
             NamingStrategy = new OracleNamingStrategy(MaxNameLength);
+            // Beware, this is setting a static filter which can get used by other providers if multiple concurrent different
+            // providers. That should be harmless as the filter will no-op fairly cheaply for non-Oracle situations.
             OrmLiteConfig.ExecFilter = new OracleExecFilter();
         }
 


### PR DESCRIPTION
Hi Demis,
The problems this fixes is occasional ArgumentException "An item with the same key has already been added" errors, and the OracleExecFilter getting used for non-Oracle databases.
This fix is good enough, but it would IMO be better to make the ExecFilter dependent on the provider. Toss it back if you want me to do that fix also.
