### PR TITLE
Fix Reference attribute usage with tables that have alias names.

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteReadExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadExtensions.cs
@@ -842,7 +842,7 @@ namespace ServiceStack.OrmLite
         private static FieldDefinition GetRefFieldDef(ModelDefinition modelDef, ModelDefinition refModelDef, Type refType)
         {
             var refNameConvention = modelDef.ModelName + "Id";
-            var refField = refModelDef.FieldDefinitions.FirstOrDefault(x => x.Name == refNameConvention);
+            var refField = refModelDef.FieldDefinitions.FirstOrDefault(x => x.FieldName == refNameConvention);
             if (refField == null)
                 throw new ArgumentException("Cant find '{0}' Property on Type '{1}'".Fmt(refNameConvention, refType.Name));
             return refField;


### PR DESCRIPTION
Hi Demis,

This PR fixes the problem I emailed you about and it maintains compatibility with the old way of doing it for the most common case of no alias on the foreign key property. If someone previously used an alias on the foreign key property that does not match the expected value, then LoadReferences/SaveReferences etc. will fail. That seems good enough to me, but obviously the code in OrmLiteReadExtensions could be changed to do a FieldName query and if that fails then try a Name query before giving up.

Cheers, Bruce
