### PR TITLE
Update OrmLiteConnection.cs

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteConnection.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConnection.cs
@@ -63,6 +63,7 @@ namespace ServiceStack.OrmLite
         public void Close()
         {
             DbConnection.Close();
+            isOpen = false;
         }
 
         public void ChangeDatabase(string databaseName)


### PR DESCRIPTION
The connection cannot be reopened after it has been closed. This seems weird. I think the main problem is because by the time it Open, it will check whether isOpen == true then skip the process. However, it is always true because Close method doesn't mark isOpen = false.
