### PR TITLE
Allow Nullable AutoIncrementId

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteWriteExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteWriteExtensions.cs
@@ -602,7 +602,7 @@ namespace ServiceStack.OrmLite
         internal static bool Save<T>(this IDbCommand dbCmd, T obj)
         {
             var id = obj.GetId();
-            var existingRow = dbCmd.SingleById<T>(id);
+            var existingRow = id != null ? dbCmd.SingleById<T>(id) : default(T);
             if (Equals(existingRow, default(T)))
             {
                 var modelDef = typeof(T).GetModelDefinition();
@@ -636,7 +636,8 @@ namespace ServiceStack.OrmLite
             var firstRow = saveRows.FirstOrDefault();
             if (Equals(firstRow, default(T))) return 0;
 
-            var defaultIdValue = firstRow.GetId().GetType().GetDefaultValue();
+            var firstRowId = firstRow.GetId();
+            var defaultIdValue = firstRowId != null ? firstRowId.GetType().GetDefaultValue() : null;
 
             var idMap = defaultIdValue != null
                 ? saveRows.Where(x => !defaultIdValue.Equals(x.GetId())).ToSafeDictionary(x => x.GetId())

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteSaveTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteSaveTests.cs
@@ -27,6 +27,7 @@ namespace ServiceStack.OrmLite.Tests
                 db.Save(row);
 
                 Assert.That(row.Id, Is.Not.EqualTo(0));
+                Assert.That(row.Id, Is.Not.Null);
             }
         }
 
@@ -54,6 +55,56 @@ namespace ServiceStack.OrmLite.Tests
 
                 Assert.That(rows[0].Id, Is.Not.EqualTo(0));
                 Assert.That(rows[1].Id, Is.Not.EqualTo(0));
+                Assert.That(rows[0].Id, Is.Not.EqualTo(rows[1].Id));
+            }
+        }
+
+        [Test]
+        public void Save_populates_NullableAutoIncrementId()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.CreateTable<PersonWithNullableAutoId>(overwrite: true);
+
+                var row = new PersonWithNullableAutoId
+                {
+                    FirstName = "Jimi",
+                    LastName = "Hendrix",
+                    Age = 27
+                };
+
+                db.Save(row);
+
+                Assert.That(row.Id, Is.Not.EqualTo(0));
+            }
+        }
+
+        [Test]
+        public void SaveAll_populates_NullableAutoIncrementId()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.CreateTable<PersonWithNullableAutoId>(overwrite: true);
+
+                var rows = new[] {
+                    new PersonWithNullableAutoId {
+                        FirstName = "Jimi",
+                        LastName = "Hendrix",
+                        Age = 27
+                    },
+                    new PersonWithNullableAutoId {
+                        FirstName = "Kurt",
+                        LastName = "Cobain",
+                        Age = 27
+                    },
+                };
+
+                db.Save(rows);
+
+                Assert.That(rows[0].Id, Is.Not.EqualTo(0));
+                Assert.That(rows[0].Id, Is.Not.Null);
+                Assert.That(rows[1].Id, Is.Not.EqualTo(0));
+                Assert.That(rows[1].Id, Is.Not.Null);
                 Assert.That(rows[0].Id, Is.Not.EqualTo(rows[1].Id));
             }
         }

--- a/tests/ServiceStack.OrmLite.Tests/Shared/Person.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Shared/Person.cs
@@ -37,6 +37,15 @@ namespace ServiceStack.OrmLite.Tests.Shared
         public int Age { get; set; }
     }
 
+    public class PersonWithNullableAutoId
+    {
+        [AutoIncrement]
+        public int? Id { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public int Age { get; set; }
+    }
+
     public class EntityWithId
     {
         public int Id { get; set; }


### PR DESCRIPTION
Tried to re-use a Service DTO for a quick OrmLite demo today with a colleague.  By chance, the DTO had `public int? Id { get; set; }`  that I applied `[AutoIncrement]` to.  Was throwing `NullReferenceException` due to `default(T)` of `int?` being `null`.

I realise it's not a typical use-case to have `int?` as a key and that it's better to have a separate objects for the ORM, but here's a quick fix and tests anyway.
