### PR TITLE
Fix insert/update of Nullable DateTimeOffset in POCO

### DIFF
--- a/src/ServiceStack.OrmLite.Sqlite/SqliteOrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite.Sqlite/SqliteOrmLiteDialectProviderBase.cs
@@ -212,7 +212,7 @@ namespace ServiceStack.OrmLite.Sqlite
         protected override object GetValueOrDbNull<T>(FieldDefinition fieldDef, object obj)
         {
             var value = GetValue<T>(fieldDef, obj);
-            if (fieldDef.FieldType == typeof(DateTimeOffset))
+            if (fieldDef.FieldType == typeof(DateTimeOffset) && value != null)
             {
                 var dateTimeOffsetValue = (DateTimeOffset)value;
                 return dateTimeOffsetValue.ToString("o");

--- a/tests/ServiceStack.OrmLite.Sqlite.Windows.Tests/ServiceStack.OrmLite.Sqlite.Windows.Tests.csproj
+++ b/tests/ServiceStack.OrmLite.Sqlite.Windows.Tests/ServiceStack.OrmLite.Sqlite.Windows.Tests.csproj
@@ -67,6 +67,7 @@
       <Link>UseCase\SimpleUseCase.cs</Link>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UseCase\NullableDateTimeOffset.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tests/ServiceStack.OrmLite.Sqlite.Windows.Tests/UseCase/NullableDateTimeOffset.cs
+++ b/tests/ServiceStack.OrmLite.Sqlite.Windows.Tests/UseCase/NullableDateTimeOffset.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using NUnit.Framework;
+using ServiceStack.OrmLite.Sqlite;
+using ServiceStack.DataAnnotations;
+
+namespace ServiceStack.OrmLite.Tests.UseCase
+{
+    [TestFixture]
+    public class NullableDateTimeOffset
+    {
+        [TestFixtureSetUp]
+        public void TestFixtureSetUp()
+        {
+            //Inject your database provider here
+            OrmLiteConfig.DialectProvider = new SqliteOrmLiteDialectProvider();
+        }
+
+        public class Record
+        {
+            [AutoIncrement]
+            public long Id { get; set; }
+
+            public DateTimeOffset CreatedDate { get; set; }
+
+            public DateTimeOffset? ModifiedDate { get; set; }
+        }
+
+        [Test]
+        public void Can_Insert_RecordWithNullable_DateTimeOffset()
+        {
+            var path = Config.SqliteFileDb;
+            if (File.Exists(path))
+                File.Delete(path);
+            
+            using (IDbConnection db = path.OpenDbConnection())
+            {
+                db.CreateTable<OrmLite.Tests.UseCase.NullableDateTimeOffset.Record>(true);
+
+                Assert.DoesNotThrow(() => db.Insert(new OrmLite.Tests.UseCase.NullableDateTimeOffset.Record() { Id = 1, CreatedDate = DateTime.Now }));
+            }
+
+            File.Delete(path);
+        }
+
+        [Test]
+        public void Can_Update_RecordWithNullable_DateTimeOffset()
+        {
+            var path = Config.SqliteFileDb;
+            if (File.Exists(path))
+                File.Delete(path);
+
+            using (IDbConnection db = path.OpenDbConnection())
+            {
+                db.CreateTable<OrmLite.Tests.UseCase.NullableDateTimeOffset.Record>(true);
+
+                db.Insert(new OrmLite.Tests.UseCase.NullableDateTimeOffset.Record() {Id = 1, CreatedDate = DateTime.Now });
+
+                var record = db.LoadSingleById<OrmLite.Tests.UseCase.NullableDateTimeOffset.Record>(1);
+                record.ModifiedDate = DateTimeOffset.Now;
+
+                Assert.DoesNotThrow(() => db.Update(record));
+            }
+
+            File.Delete(path);
+        }
+
+        [Test]
+        public void Can_UpdateWithNull_RecordWithNullable_DateTimeOffset()
+        {
+            var path = Config.SqliteFileDb;
+            if (File.Exists(path))
+                File.Delete(path);
+
+            using (IDbConnection db = path.OpenDbConnection())
+            {
+                db.CreateTable<OrmLite.Tests.UseCase.NullableDateTimeOffset.Record>(true);
+
+                db.Insert(new OrmLite.Tests.UseCase.NullableDateTimeOffset.Record() { Id = 1, CreatedDate = DateTime.Now, ModifiedDate = DateTimeOffset.Now });
+
+                var record = db.LoadSingleById<OrmLite.Tests.UseCase.NullableDateTimeOffset.Record>(1);
+                record.ModifiedDate = null;
+
+                Assert.DoesNotThrow(() => db.Update(record));
+            }
+
+            File.Delete(path);
+        }
+    }
+}


### PR DESCRIPTION
Includes a null check to avoid a NullReferenceException if the POCO includes a Nullable&lt;DateTimeOffset&gt; field that is null. 
