### PR TITLE
Fix Oracle dialect provider problems with paging, expressions, nullable ...

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle.Tests/ServiceStack.OrmLite.Oracle.Tests.csproj
+++ b/src/ServiceStack.OrmLite.Oracle.Tests/ServiceStack.OrmLite.Oracle.Tests.csproj
@@ -123,6 +123,9 @@
     <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\Expression\SelectExpressionTests.cs">
       <Link>Expression\SelectExpressionTests.cs</Link>
     </Compile>
+    <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\Expression\SqlExpressionTests.cs">
+      <Link>Expression\SqlExpressionTests.cs</Link>
+    </Compile>
     <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\Expression\StringFunctionTests.cs">
       <Link>Expression\StringFunctionTests.cs</Link>
     </Compile>
@@ -134,6 +137,9 @@
     </Compile>
     <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\JoinSqlBuilderTests.cs">
       <Link>JoinSqlBuilderTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\LoadReferencesJoinTests.cs">
+      <Link>LoadReferencesJoinTests.cs</Link>
     </Compile>
     <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\LoadReferencesTests.cs">
       <Link>LoadReferencesTests.cs</Link>
@@ -317,6 +323,9 @@
     </Compile>
     <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\UseCase\CustomerOrdersUseCase.cs">
       <Link>UseCase\CustomerOrdersUseCase.cs</Link>
+    </Compile>
+    <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\UseCase\FieldFromInterfaceImplementationUseCase.cs">
+      <Link>UseCase\FieldFromInterfaceImplementationUseCase.cs</Link>
     </Compile>
     <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\UseCase\ImageBlobDto.cs">
       <Link>UseCase\ImageBlobDto.cs</Link>

--- a/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
@@ -268,10 +268,13 @@ namespace ServiceStack.OrmLite.Oracle
             var sql = new StringBuilder();
             const string selectStatement = "SELECT ";
             var modelDef = GetModel(tableType);
-            var isFullSelectStatement =
-                !string.IsNullOrEmpty(sqlFilter)
-                && sqlFilter.Trim().Length > selectStatement.Length
-                && sqlFilter.Trim().Substring(0, selectStatement.Length).ToUpper().Equals(selectStatement);
+            var isFullSelectStatement = false;
+            if (!string.IsNullOrEmpty(sqlFilter))
+            {
+                var cleanFilter = sqlFilter.Trim().Replace('\r', ' ').Replace('\n', ' ').ToUpperInvariant();
+                isFullSelectStatement = cleanFilter.Length > selectStatement.Length
+                    && cleanFilter.Substring(0, selectStatement.Length).Equals(selectStatement);
+            }
 
             if (isFullSelectStatement)
             {
@@ -369,11 +372,11 @@ namespace ServiceStack.OrmLite.Oracle
                                               pi.GetValue(obj, new object[] { }), isInsert);
                     if (pi.PropertyType == typeof(String))
                         pi.SetProperty(obj, result.ToString());
-                    else if (pi.PropertyType == typeof(Int16))
+                    else if (pi.PropertyType == typeof(Int16) || pi.PropertyType == typeof(Int16?))
                         pi.SetProperty(obj, Convert.ToInt16(result));
-                    else if (pi.PropertyType == typeof(Int32))
+                    else if (pi.PropertyType == typeof(Int32) || pi.PropertyType == typeof(Int32?))
                         pi.SetProperty(obj, Convert.ToInt32(result));
-                    else if (pi.PropertyType == typeof(Guid))
+                    else if (pi.PropertyType == typeof(Guid) || pi.PropertyType == typeof(Guid?))
                         pi.SetProperty(obj, result);
                     else
                         pi.SetProperty(obj, Convert.ToInt64(result));
@@ -1122,13 +1125,11 @@ namespace ServiceStack.OrmLite.Oracle
             var sbInner = new StringBuilder(selectExpression);
             sbInner.Append(bodyExpression);
 
-            if (!rows.HasValue)
-                return sbInner + orderByExpression;
+            if (!rows.HasValue && !offset.HasValue)
+                return sbInner + " " + orderByExpression;
 
             if (!offset.HasValue)
-            {
                 offset = 0;
-            }
 
             if (string.IsNullOrEmpty(orderByExpression))
             {
@@ -1138,7 +1139,7 @@ namespace ServiceStack.OrmLite.Oracle
                 orderByExpression = string.Format("ORDER BY {0}",
                     OrmLiteConfig.DialectProvider.GetQuotedColumnName(modelDef.PrimaryKey.FieldName));
             }
-            sbInner.Append(orderByExpression);
+            sbInner.Append(" " + orderByExpression);
 
             var sql = sbInner.ToString();
 
@@ -1147,7 +1148,10 @@ namespace ServiceStack.OrmLite.Oracle
             sb.AppendLine("SELECT \"_ss_ormlite_1_\".*, ROWNUM RNUM FROM (");
             sb.Append(sql);
             sb.AppendLine(") \"_ss_ormlite_1_\"");
-            sb.AppendFormat("WHERE ROWNUM <= {0} + {1}) \"_ss_ormlite_2_\" ", offset.Value, rows.Value);
+            if (rows.HasValue)
+                sb.AppendFormat("WHERE ROWNUM <= {0} + {1}) \"_ss_ormlite_2_\" ", offset.Value, rows.Value);
+            else
+                sb.Append(") \"_ss_ormlite_2_\" ");
             sb.AppendFormat("WHERE \"_ss_ormlite_2_\".RNUM > {0}", offset.Value);
 
             return sb.ToString();

--- a/tests/ServiceStack.OrmLite.Tests/JoinSqlBuilderTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/JoinSqlBuilderTests.cs
@@ -123,8 +123,9 @@ namespace ServiceStack.OrmLite.Tests
                 var tmpl = sb.AddTemplate("SELECT * FROM {0} u INNER JOIN {1} a on a.{2} = u.Id /**where**/"
                     .Fmt("User".SqlTable(), "Addresses".SqlTable(), "UserId".SqlColumn()));
 
-                sb.Where("Age > @age", new { age = 18 });
-                sb.Where("Countryalias = @country", new { country = "Italy" });
+                var paramString = OrmLiteConfig.DialectProvider.ParamString;
+                sb.Where("Age > " + paramString + "age", new { age = 18 });
+                sb.Where("Countryalias = " + paramString + "country", new { country = "Italy" });
 
                 var userId = db.Insert(new User { Age = 27, Name = "Foo" }, selectIdentity: true);
                 db.Insert(new WithAliasAddress { City = "Rome", Country = "Italy", UserId = (int)userId });

--- a/tests/ServiceStack.OrmLite.Tests/LoadReferencesJoinTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/LoadReferencesJoinTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Data;
+﻿using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using NUnit.Framework;
 using ServiceStack.OrmLite.Tests.UseCase;
@@ -194,7 +195,8 @@ namespace ServiceStack.OrmLite.Tests
             var costs = results.ConvertAll(x => x.Cost);
             Assert.That(costs, Is.EquivalentTo(new[] { 1.99m, 1.49m, 9.99m }));
             var orderIds = results.ConvertAll(x => x.OrderId);
-            Assert.That(orderIds, Is.EquivalentTo(new[] { 1, 3, 5 }));
+            var expectedOrderIds = new []{customers[0].Orders[0].Id, customers[0].Orders[2].Id, customers[0].Orders[4].Id};
+            Assert.That(orderIds, Is.EquivalentTo(expectedOrderIds));
 
             //Same as above using using db.From<Customer>()
             results = db.Select<FullCustomerInfo>(db.From<Customer>()
@@ -375,17 +377,19 @@ namespace ServiceStack.OrmLite.Tests
             db.DropAndCreateTable<CustomerAddress>();
             db.DropAndCreateTable<Customer>();
 
-            AddCustomerWithOrders();
+            var customer = AddCustomerWithOrders();
 
             var results = db.Select<FullCustomerInfo, Customer>(q => q
                 .Join<Customer, CustomerAddress>()
                 .Join<Customer, Order>());
 
             var addressIds = results.ConvertAll(x => x.CustomerAddressId);
-            Assert.That(addressIds, Is.EquivalentTo(new[] { 1, 1 }));
+            var expectedAddressIds = new[] { customer.PrimaryAddress.Id, customer.PrimaryAddress.Id };
+            Assert.That(addressIds, Is.EquivalentTo(expectedAddressIds));
 
             var orderIds = results.ConvertAll(x => x.OrderId);
-            Assert.That(orderIds, Is.EquivalentTo(new[] { 1, 2 }));
+            var expectedOrderIds = new[] {customer.Orders[0].Id, customer.Orders[1].Id};
+            Assert.That(orderIds, Is.EquivalentTo(expectedOrderIds));
 
             var customerNames = results.ConvertAll(x => x.CustomerName);
             Assert.That(customerNames, Is.EquivalentTo(new[] { "Customer 1", "Customer 1" }));
@@ -401,10 +405,10 @@ namespace ServiceStack.OrmLite.Tests
             results = db.Select<FullCustomerInfo>(expr);
 
             addressIds = results.ConvertAll(x => x.CustomerAddressId);
-            Assert.That(addressIds, Is.EquivalentTo(new[] { 1 }));
+            Assert.That(addressIds, Is.EquivalentTo(new[] { customer.PrimaryAddress.Id }));
 
             orderIds = results.ConvertAll(x => x.OrderId);
-            Assert.That(orderIds, Is.EquivalentTo(new[] { 2 }));
+            Assert.That(orderIds, Is.EquivalentTo(new[] { customer.Orders[1].Id }));
 
             customerNames = results.ConvertAll(x => x.CustomerName);
             Assert.That(customerNames, Is.EquivalentTo(new[] { "Customer 1" }));

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableWithIndexesTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableWithIndexesTests.cs
@@ -18,10 +18,17 @@ namespace ServiceStack.OrmLite.Tests
 
 				var sql = OrmLiteConfig.DialectProvider.ToCreateIndexStatements(typeof(ModelWithIndexFields)).Join();
 
-                SuppressIfOracle("Assert comparisons don't work with Oracle provider because it had to squash names to satisfy length restrictions");
+			    var indexName = "idx_modelwithindexfields_name";
+			    var uniqueName = "uidx_modelwithindexfields_uniquename";
 
-                Assert.IsTrue(sql.Contains("idx_modelwithindexfields_name"));
-				Assert.IsTrue(sql.Contains("uidx_modelwithindexfields_uniquename"));
+			    if (Dialect == Dialect.Oracle)
+			    {
+			        indexName = OrmLiteConfig.DialectProvider.NamingStrategy.ApplyNameRestrictions(indexName);
+                    uniqueName = OrmLiteConfig.DialectProvider.NamingStrategy.ApplyNameRestrictions(uniqueName);
+			    }
+
+                Assert.IsTrue(sql.Contains(indexName));
+				Assert.IsTrue(sql.Contains(uniqueName));
 			}
 		}
 
@@ -36,10 +43,17 @@ namespace ServiceStack.OrmLite.Tests
 
 				var sql = OrmLiteConfig.DialectProvider.ToCreateIndexStatements(typeof(ModelWithCompositeIndexFields)).Join();
 
-                SuppressIfOracle("Assert comparisons don't work with Oracle provider because it had to squash names to satisfy length restrictions");
+                var indexName = "idx_modelwithcompositeindexfields_name";
+                var compositeName = "idx_modelwithcompositeindexfields_composite1_composite2";
 
-                Assert.IsTrue(sql.Contains("idx_modelwithcompositeindexfields_name"));
-				Assert.IsTrue(sql.Contains("idx_modelwithcompositeindexfields_composite1_composite2"));
+                if (Dialect == Dialect.Oracle)
+                {
+                    indexName = OrmLiteConfig.DialectProvider.NamingStrategy.ApplyNameRestrictions(indexName);
+                    compositeName = OrmLiteConfig.DialectProvider.NamingStrategy.ApplyNameRestrictions(compositeName);
+                }
+
+                Assert.IsTrue(sql.Contains(indexName));
+				Assert.IsTrue(sql.Contains(compositeName));
 			}
 		}
 
@@ -54,11 +68,18 @@ namespace ServiceStack.OrmLite.Tests
 
                 var sql = OrmLiteConfig.DialectProvider.ToCreateIndexStatements(typeof(ModelWithNamedCompositeIndex)).Join();
 
-                SuppressIfOracle("Assert comparisons don't work with Oracle provider because it had to squash names to satisfy length restrictions");
+                var indexName = "idx_modelwithnamedcompositeindex_name";
+                var compositeName = "uidx_modelwithnamedcompositeindexfields_composite1_composite2";
 
-                Assert.IsTrue(sql.Contains("idx_modelwithnamedcompositeindex_name"));
+                if (Dialect == Dialect.Oracle)
+                {
+                    indexName = OrmLiteConfig.DialectProvider.NamingStrategy.ApplyNameRestrictions(indexName);
+                    compositeName = OrmLiteConfig.DialectProvider.NamingStrategy.ApplyNameRestrictions(compositeName);
+                }
+
+                Assert.IsTrue(sql.Contains(indexName));
                 Assert.IsTrue(sql.Contains("custom_index_name"));
-                Assert.IsFalse(sql.Contains("uidx_modelwithnamedcompositeindexfields_composite1_composite2"));
+                Assert.IsFalse(sql.Contains(compositeName));
             }
         }
 

--- a/tests/ServiceStack.OrmLite.Tests/SqlBuilderTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/SqlBuilderTests.cs
@@ -64,10 +64,8 @@ namespace ServiceStack.OrmLite.Tests
         [Test]
         public void BuilderTemplateWOComposition()
         {
-            SuppressIfOracle("Oracle provider is not smart enough to replace '@' parameter delimiter with ':'");
-
             var builder = new SqlBuilder();
-            var template = builder.AddTemplate("SELECT COUNT(*) FROM Users WHERE Age = @age", new { age = 5 });
+            var template = builder.AddTemplate("SELECT COUNT(*) FROM Users WHERE Age = {0}age".Fmt(OrmLiteConfig.DialectProvider.ParamString), new { age = 5 });
 
             if (template.RawSql == null) throw new Exception("RawSql null");
             if (template.Parameters == null) throw new Exception("Parameters null");

--- a/tests/ServiceStack.OrmLite.Tests/TestHelpers.cs
+++ b/tests/ServiceStack.OrmLite.Tests/TestHelpers.cs
@@ -19,7 +19,8 @@ namespace ServiceStack.OrmLite.Tests
                 .Replace("`", "")
                 .Replace("_", "")
                 .Replace(":", "@")   //postgresql
-                .Replace("\n", " "); 
+                .Replace("\n", " ")
+                .TrimEnd(); 
         }
     }
 }

--- a/tests/ServiceStack.OrmLite.Tests/TypeWithByteArrayFieldTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/TypeWithByteArrayFieldTests.cs
@@ -55,7 +55,7 @@ namespace ServiceStack.OrmLite.Tests
         [Test, Explicit]
         public void Can_upload_attachment_via_sp()
         {
-            SuppressIfOracle("Oracle provider is not smart enough to replace parameter delimiter '@' with ':'");
+            SuppressIfOracle("Oracle does not like this procedure definition");
 
             using (var db = OpenDbConnection())
             {
@@ -75,8 +75,8 @@ CREATE PROCEDURE dbo.[SP_upload_file](
 AS
 begin
 INSERT INTO [Attachment]([FileName], [Type], [Data], [Description])
-VALUES (@filename, @filetype, @filecontent, @filename) 
-end");
+VALUES ({0}filename, {0}filetype, {0}filecontent, {0}filename) 
+end".Fmt(OrmLiteConfig.DialectProvider.ParamString));
                 var bytes = "https://www.google.com/images/srpr/logo11w.png".GetBytesFromUrl();
 
                 db.ExecuteNonQuery("EXEC SP_upload_file @filename, @filetype, @filecontent", 
@@ -95,7 +95,7 @@ end");
         [Test, Explicit]
         public void Can_upload_attachment_via_sp_with_ADONET()
         {
-            SuppressIfOracle("Oracle provider is not smart enough to replace parameter delimiter '@' with ':'");
+            SuppressIfOracle("Oracle does not like this procedure definition");
 
             using (var db = OpenDbConnection())
             {
@@ -115,8 +115,8 @@ CREATE PROCEDURE dbo.[SP_upload_file](
 AS
 begin
 INSERT INTO [Attachment]([FileName], [Type], [Data], [Description])
-VALUES (@filename, @filetype, @filecontent, @filename) 
-end");
+VALUES ({0}filename, {0}filetype, {0}filecontent, {0}filename) 
+end".Fmt(OrmLiteConfig.DialectProvider.ParamString));
                 var bytes = "https://www.google.com/images/srpr/logo11w.png".GetBytesFromUrl();
 
                 using (var dbCmd = db.CreateCommand())


### PR DESCRIPTION
...ids.

Add new tests to Oracle test project.
Make TestHelper strip trailing whitespace for better comparisons.
JoinSqlBuilderTests, OrmLiteQueryTests, SqlBuilderTests, and
TypeWithByteArrayFieldTests now handle parameter string differences.
LoadReferencesJoinTests, OrmLiteQueryTests are not sensitive to ids inserted.
OrmLiteCreateTableWithIndexesTests handles Oracle name munging.
