### PR TITLE
Fixinf VistaDB assembly discovery

### DIFF
--- a/src/ServiceStack.OrmLite.VistaDB.Tests/App.config
+++ b/src/ServiceStack.OrmLite.VistaDB.Tests/App.config
@@ -10,7 +10,7 @@
       <remove invariant="System.Data.VistaDB5" />
       <add invariant="System.Data.VistaDB5" name="VistaDB 5 Data Provider"
            description="VistaDB 5 ADO.NET Provider for .Net"
-            type="VistaDB.Provider.VistaDBProviderFactory, VistaDB.5.NET40" />
+            type="VistaDB.Provider.VistaDBProviderFactory, VistaDB.5.NET40, Version=5.0.0.0, Culture=neutral, PublicKeyToken=dfc935afe2125461" />
     </DbProviderFactories>
   </system.data>
 </configuration>

--- a/src/ServiceStack.OrmLite.VistaDB.Tests/OrmLiteTestBase.cs
+++ b/src/ServiceStack.OrmLite.VistaDB.Tests/OrmLiteTestBase.cs
@@ -17,18 +17,12 @@ namespace ServiceStack.OrmLite.VistaDB.Tests
         {
             LogManager.LogFactory = new ConsoleLogFactory();
 
+            VistaDbDialect.Provider.UseLibraryFromGac = true;
             OrmLiteConfig.DialectProvider = VistaDbDialect.Provider;
 
-            var dataFileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".vdb5");
-            var sourceStream = typeof(OrmLiteTestBase).Assembly
-                .GetManifestResourceStream("ServiceStack.OrmLite.VistaDB.Tests.Resources.test.vdb5");
+            DataFileName = TestVistaDb.ExtractTestDatabaseFileToTempFile();
 
-            using (sourceStream)
-            using (var destStream = File.Create(dataFileName))
-                sourceStream.CopyTo(destStream);
-
-            DataFileName = dataFileName;
-            ConnectionString = "Data Source=" + dataFileName + ";";
+            ConnectionString = "Data Source=" + DataFileName + ";";
         }
 
         [TestFixtureTearDown]

--- a/src/ServiceStack.OrmLite.VistaDB.Tests/TestVistaDb.cs
+++ b/src/ServiceStack.OrmLite.VistaDB.Tests/TestVistaDb.cs
@@ -1,5 +1,8 @@
-﻿using System.Data;
+﻿using System;
+using System.Configuration;
+using System.Data;
 using System.Data.Common;
+using System.IO;
 using NUnit.Framework;
 
 namespace ServiceStack.OrmLite.VistaDB.Tests
@@ -7,6 +10,35 @@ namespace ServiceStack.OrmLite.VistaDB.Tests
     [TestFixture]
     public class TestVistaDb
     {
+        public static string ExtractTestDatabaseFileToTempFile()
+        {
+            var dataFileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".vdb5");
+
+            ExtractTestDatabaseFile(dataFileName);
+
+            return dataFileName;
+        }
+
+        public static void ExtractTestDatabaseFile(string dataFileName)
+        {
+            var sourceStream = typeof(OrmLiteTestBase).Assembly
+                .GetManifestResourceStream("ServiceStack.OrmLite.VistaDB.Tests.Resources.test.vdb5");
+
+            using (sourceStream)
+            using (var destStream = File.Create(dataFileName))
+                sourceStream.CopyTo(destStream);
+        }
+
+        public static void CreateDatabase(DbProviderFactory factory)
+        {
+            using (var conn = factory.CreateConnection())
+            using (var comm = conn.CreateCommand())
+            {
+                comm.CommandText = @"CREATE DATABASE '|DataDirectory|\Database.vdb5', PAGE SIZE 4, LCID 1033, CASE SENSITIVE FALSE;";
+                comm.ExecuteNonQuery();
+            }
+        }
+
         [Test]
         public void TestVistaDB()
         {
@@ -24,8 +56,24 @@ namespace ServiceStack.OrmLite.VistaDB.Tests
                 VersionInfo = "Failed to load connectionString from config file";
                 Assert.Fail(VersionInfo);
             }
+
+            DbProviderFactory factory = null;
             // Loads the factory
-            DbProviderFactory factory = DbProviderFactories.GetFactory(connectionString.ProviderName);
+            try
+            {
+                factory = DbProviderFactories.GetFactory(connectionString.ProviderName);
+            }
+            catch
+            {
+                Assert.Fail("VistaDB library should be copied locally or installed into GAC.");
+            }
+
+            try
+            {
+                CreateDatabase(factory);
+            }
+            catch { }
+
             // After this it looks pretty normal
             using (DbConnection connection = factory.CreateConnection())
             {

--- a/src/ServiceStack.OrmLite.VistaDB/VistaDBExpression.cs
+++ b/src/ServiceStack.OrmLite.VistaDB/VistaDBExpression.cs
@@ -36,43 +36,6 @@ namespace ServiceStack.OrmLite.VistaDB
                 dialectProvider.GetQuotedTableName(ModelDef), setFields, WhereExpression);
         }
 
-        protected virtual string BuildOrderByIdExpression()
-        {
-            if (ModelDef.PrimaryKey == null)
-                throw new ApplicationException("Malformed model, no PrimaryKey defined");
-
-            return String.Format("ORDER BY {0}", OrmLiteConfig.DialectProvider.GetQuotedColumnName(ModelDef.PrimaryKey.FieldName));
-        }
-
-        protected virtual string BuildWhereIdGTEFirstId()
-        {
-            if (ModelDef.PrimaryKey == null)
-                throw new ApplicationException("Malformed model, no PrimaryKey defined");
-
-            var where = String.IsNullOrWhiteSpace(WhereExpression)
-                ? String.Format("{0} > @first_id", OrmLiteConfig.DialectProvider.GetQuotedColumnName(ModelDef.PrimaryKey.FieldName))
-                : String.Format("({0}) AND {1} > @first_id", WhereExpression.Trim().Substring("WHERE".Length), OrmLiteConfig.DialectProvider.GetQuotedColumnName(ModelDef.PrimaryKey.FieldName));
-            
-            return "WHERE " + where;
-        }
-
-        protected virtual string BuildSelectTopNIdExpression(int skip)
-        {
-            if (ModelDef.PrimaryKey == null)
-                throw new ApplicationException("Malformed model, no PrimaryKey defined");
-            
-            return String.Format("SELECT TOP {0} @first_id = {1} ", skip, OrmLiteConfig.DialectProvider.GetQuotedColumnName(ModelDef.PrimaryKey.FieldName));
-        }
-
-        protected virtual string BuildDeclareFirstIdExpression()
-        {
-            if (ModelDef.PrimaryKey == null)
-                throw new ApplicationException("Malformed model, no PrimaryKey defined");
-
-            return String.Format("DECLARE @first_id {0};",
-                OrmLiteConfig.DialectProvider.GetColumnTypeDefinition(ModelDef.PrimaryKey.FieldType));
-        }
-
         protected override object VisitColumnAccessMethod(MethodCallExpression m)
         {
             if (m.Arguments.Count == 1 && m.Method.Name == "Equals")

--- a/src/ServiceStack.OrmLite.VistaDB/VistaDbDialect.cs
+++ b/src/ServiceStack.OrmLite.VistaDB/VistaDbDialect.cs
@@ -4,6 +4,6 @@ namespace ServiceStack.OrmLite
 {
     public static class VistaDbDialect
     {
-        public static IOrmLiteDialectProvider Provider { get { return VistaDbDialectProvider.Instance; } }
+        public static VistaDbDialectProvider Provider { get { return VistaDbDialectProvider.Instance; } }
     }
 }


### PR DESCRIPTION
Hi, Demis,
I have fixed and refactored code towards fixing your problems with loading VistaDB assembly discovery.
Now it is possible to configure the provider either to use a local assembly or one from GAC,
All tests pass now with the assembly in GAC. Please have a look if it works for you.

What about optimistic locking support, VistaDB doesn't support ROWVERSION type and the implementation of triggers  requires additional effort to make this provider feature work. Now VistaDB supports only CLR triggers, which means that we must create an assembly. Here its sample code:

```
VistaDBConnection conn = new VistaDBConnection("Context Connection = true");
// update MyTable Set Version = Version + 1 from MyTable inner join inserted on MyTable.ID = inserted.ID
```

A little bit awkward, but it is the only solution I see by now and if you are not against it I will try to implement it.
