### PR TITLE
T4 schema attribute

### DIFF
--- a/src/T4/OrmLite.Poco.tt
+++ b/src/T4/OrmLite.Poco.tt
@@ -60,7 +60,7 @@ manager.StartNewFile(tbl.Name + ".cs");
 <# if (MakeSingular) {#>
 	[Alias("<#=tbl.Name#>")]
 <#}#>
-<# if (UseSchemaAttribute && tbl.Schema != null && tbl.Schema.Length > 0) {#>
+<# if (UseSchemaAttribute && !string.IsNullOrEmpty(tbl.Schema)) {#>
 	[Schema("<#=tbl.Schema#>")]
 <#}#>
     public partial class <#=tbl.ClassName#><#if (tbl.HasPK() && UseIdAsPK) { #> : IHasId<<#=tbl.PK.PropertyType#>><#}#> 


### PR DESCRIPTION
Added use of [Schema] attribute to all tables, including "dbo" schema. Does make the code that is generated a bit larger for dbo only schemas, but if templates are used against dbs with use of schemas, access failed at run-time due error:"Invalid object name '<insert table alias>'.

If template fails to populate schema value from db it will also be omitted.
