### PR TITLE
Corrected UpperCaseNamingStrategy inheritance

### DIFF
--- a/src/ServiceStack.OrmLite/UpperCaseNamingStrategy.cs
+++ b/src/ServiceStack.OrmLite/UpperCaseNamingStrategy.cs
@@ -7,12 +7,12 @@ namespace ServiceStack.OrmLite
 {
     public class UpperCaseNamingStrategy : OrmLiteNamingStrategyBase
     {
-        public virtual string GetTableName(string name)
+        public override string GetTableName(string name)
         {
             return name.ToUpper();
         }
 
-        public virtual string GetColumnName(string name)
+        public override string GetColumnName(string name)
         {
             return name.ToUpper();
         }


### PR DESCRIPTION
UpperCaseNamingStrategy methods should override methods from base class.
