### PR TITLE
adding support for RowVersion  as byte[] and with custom name

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
@@ -102,7 +102,7 @@ namespace ServiceStack.OrmLite.SqlServer
 
         public override void SetDbValue(FieldDefinition fieldDef, IDataReader reader, int colIndex, object instance)
         {
-            if (fieldDef.IsRowVersion)
+            if (fieldDef.IsRowVersion && fieldDef.FieldType != typeof(byte[]))
             {
                 var bytes = reader.GetValue(colIndex) as byte[];
                 if (bytes != null)

--- a/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
@@ -103,6 +103,8 @@ namespace ServiceStack.OrmLite
                 var isRowVersion = propertyInfo.Name == ModelDefinition.RowVersionName
                     && propertyInfo.PropertyType == typeof(ulong);
 
+                isRowVersion = isRowVersion || propertyInfo.FirstAttribute<RowVersionAttribute>() != null;
+
                 var isNullableType = IsNullableType(propertyInfo.PropertyType);
 
                 var isNullable = (!propertyInfo.PropertyType.IsValueType


### PR DESCRIPTION
the only tiny change in core is this line 

isRowVersion = isRowVersion || propertyInfo.FirstAttribute<RowVersionAttribute>() != null;

hope this makes sense for you, as I do not want to maintain my branch but would prefer to use yours, if you do not want to use it, I will then refacture my solution, to obey your pattern

hope you like it
a
