### PR TITLE
Fix for updating entities on PostgresSQL with DateTimeOffsets and mixed cultures

### DIFF
--- a/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
@@ -164,6 +164,12 @@ namespace ServiceStack.OrmLite.PostgreSQL
                 const string iso8601Format = "yyyy-MM-dd HH:mm:ss.fff";
                 return base.GetQuotedValue(dateValue.ToString(iso8601Format), typeof(string));
             }
+            if (fieldType == typeof(DateTimeOffset))
+            {
+                var dateValue = (DateTimeOffset)value;
+                const string iso8601Format = "yyyy-MM-dd HH:mm:ss.fff zzz";
+                return base.GetQuotedValue(dateValue.ToString(iso8601Format), typeof(string));
+            }
             if (fieldType == typeof(Guid))
             {
                 var guidValue = (Guid)value;


### PR DESCRIPTION
We found this issue when using a date time offset to update an entity.

This feels like a straightforward fix, but let me know if I missed anything. 
Also, signed the CLA as requested on CONTRIBUTING.md.
