### PR TITLE
Fix OracleOrmLiteDialectProvider to read large double values correctly

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle/OracleDoubleConverter.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleDoubleConverter.cs
@@ -1,0 +1,30 @@
+﻿using System.Data;
+using System.Data.Common;
+using System.Globalization;
+using System.Reflection;
+
+namespace ServiceStack.OrmLite.Oracle
+{
+    public class OracleDoubleConverter
+    {
+        public Assembly OracleAssembly { get; set; }
+        private MethodInfo GetOracleValue { get; set; }
+
+        public OracleDoubleConverter(DbProviderFactory factory)
+        {
+            OracleAssembly = factory.GetType().Assembly;
+            var readerType = OracleAssembly.GetType("Oracle.DataAccess.Client.OracleDataReader");
+            GetOracleValue = readerType.GetMethod("GetOracleValue", BindingFlags.Public | BindingFlags.Instance);
+        }
+
+        public double ConvertToDouble(IDataReader dataReader, int colIndex)
+        {
+            object value;
+            if (GetOracleValue == null)
+                value = dataReader.GetValue(colIndex);
+            else
+                value = GetOracleValue.Invoke(dataReader, new object[] {colIndex});
+            return double.Parse(value.ToString(), CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite.Oracle/ServiceStack.OrmLite.Oracle.csproj
+++ b/src/ServiceStack.OrmLite.Oracle/ServiceStack.OrmLite.Oracle.csproj
@@ -65,6 +65,7 @@
     <Compile Include="DbSchema\PocoCreator.cs" />
     <Compile Include="DbSchema\ProcedureType.cs" />
     <Compile Include="OracleDialect.cs" />
+    <Compile Include="OracleDoubleConverter.cs" />
     <Compile Include="OracleExecFilter.cs" />
     <Compile Include="OracleNamingStrategy.cs" />
     <Compile Include="OracleTimestampConverter.cs" />

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteSelectTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteSelectTests.cs
@@ -410,5 +410,20 @@ namespace ServiceStack.OrmLite.Tests
             }
         }
 
+	    [TestCase(1E125)]
+	    [TestCase(-1E125)]
+	    public void Does_return_large_double_values(double value)
+	    {
+	        using (var db = OpenDbConnection())
+	        {
+	            db.DropAndCreateTable<ModelWithDifferentNumTypes>();
+	            var expected = new ModelWithDifferentNumTypes {Double = value};
+
+	            var id = db.Insert(expected, true);
+	            var actual = db.SingleById<ModelWithDifferentNumTypes>(id);
+
+	            Assert.That(expected.Double, Is.EqualTo(actual.Double));
+	        }
+	    }
 	}
 }


### PR DESCRIPTION
- OracleOrmLiteDialectProvider currently can not read large double values such as 1E100
- Implemented a converter (OracleDoubleConverter) similar to OracleTimestampConverter
- OracleOrmLiteDialectProvider can now read values as large as Oracle FLOAT datatype's maximum value
