### PR TITLE
Add test to confirm ExprConvertTo<T> bug

### DIFF
--- a/tests/ServiceStack.OrmLite.Tests/UseCase/AliasedFieldUseCase.cs
+++ b/tests/ServiceStack.OrmLite.Tests/UseCase/AliasedFieldUseCase.cs
@@ -82,5 +82,27 @@ namespace ServiceStack.OrmLite.Tests.UseCase
             }
         }
 
+        [Test]
+        public void CanResolveAliasedFieldNameInJoinedTable2()
+        {
+            using (IDbConnection db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<Foo>();
+                db.DropAndCreateTable<User>();
+
+                db.Insert(new User { UserName = "Peter" });
+                db.Insert(new Foo { Bar = "Peter" });
+
+                var ev = db.From<Foo>()
+                    .Join<User>((x, y) => x.Bar == y.UserName)
+                    .Where<User>(x => x.Id > 0);
+
+                var foo = db.Single<Foo>(ev);
+
+                Assert.That(foo, Is.Not.Null);
+                Assert.That(foo.Bar, Is.EqualTo("Peter"));
+
+            }
+        }
     }
 }


### PR DESCRIPTION
This test confirms bug in 4.0.32 related to column matching in db.Single
It has been already fixed with refactoring of db.Single in bfe881 so just please release 4.0.33 asap. 
