### PR TITLE
Added support for CROSS JOIN in SqlExpression

### DIFF
--- a/src/ServiceStack.OrmLite/Expressions/SqlExpression.Join.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpression.Join.cs
@@ -65,7 +65,17 @@ namespace ServiceStack.OrmLite
             return InternalJoin("FULL JOIN", joinExpr);
         }
 
-        private SqlExpression<T> InternalJoin<Source, Target>(string joinType,
+        public SqlExpression<T> CrossJoin<Target>(Expression<Func<T, Target, bool>> joinExpr = null)
+        {
+            return InternalJoin("CROSS JOIN", joinExpr);
+        }
+
+        public SqlExpression<T> CrossJoin<Source, Target>(Expression<Func<Source, Target, bool>> joinExpr = null)
+        {
+            return InternalJoin("CROSS JOIN", joinExpr);
+        }
+
+        private SqlExpression<T> InternalJoin<Source, Target>(string joinType, 
             Expression<Func<Source, Target, bool>> joinExpr)
         {
             var sourceDef = typeof(Source).GetModelDefinition();
@@ -74,59 +84,56 @@ namespace ServiceStack.OrmLite
             return InternalJoin(joinType, joinExpr, sourceDef, targetDef);
         }
 
+        private string InternalCreateSqlFromExpression(Expression joinExpr) 
+        {
+            return "ON {0}".Fmt(Visit(joinExpr).ToString());
+        }
+
+        private string InternalCreateSqlFromDefinitions(ModelDefinition sourceDef, ModelDefinition targetDef, bool allowMissingOnClause) 
+        {
+            var parentDef = sourceDef;
+            var childDef = targetDef;
+
+            var refField = OrmLiteReadCommandExtensions.GetRefFieldDefIfExists(parentDef, childDef);
+            if (refField == null) 
+            {
+                parentDef = targetDef;
+                childDef = sourceDef;
+                refField = OrmLiteReadCommandExtensions.GetRefFieldDefIfExists(parentDef, childDef);
+            }
+
+            if (refField == null) 
+            {
+                if(!allowMissingOnClause)
+                    throw new ArgumentException("Could not infer relationship between {0} and {1}".Fmt(sourceDef.ModelName, targetDef.ModelName));
+
+                return string.Empty;
+            }
+
+            return "ON\n({0}.{1} = {2}.{3})".Fmt(
+                DialectProvider.GetQuotedTableName(parentDef),
+                SqlColumn(parentDef.PrimaryKey.FieldName),
+                DialectProvider.GetQuotedTableName(childDef),
+                SqlColumn(refField.FieldName));
+        }
+
         private SqlExpression<T> InternalJoin(string joinType, 
             Expression joinExpr, ModelDefinition sourceDef, ModelDefinition targetDef)
         {
             PrefixFieldWithTableName = true;
 
-            var fromExpr = FromExpression;
-            var sbJoin = new StringBuilder();
-
-            string sqlExpr;
-
             //Changes how Sql Expressions are generated.
             useFieldName = true;
             sep = " ";
 
-            if (joinExpr != null)
-            {
-                sqlExpr = Visit(joinExpr).ToString();
-            }
-            else
-            {
-                var parentDef = sourceDef;
-                var childDef = targetDef;
-
-                var refField = OrmLiteReadCommandExtensions.GetRefFieldDefIfExists(parentDef, childDef);
-                if (refField == null)
-                {
-                    parentDef = targetDef;
-                    childDef = sourceDef;
-                    refField = OrmLiteReadCommandExtensions.GetRefFieldDefIfExists(parentDef, childDef);
-                }
-
-                if (refField == null)
-                {
-                    throw new ArgumentException("Could not infer relationship between {0} and {1}"
-                                                    .Fmt(sourceDef.ModelName, targetDef.ModelName));
-                }
-
-                sqlExpr = "\n({0}.{1} = {2}.{3})".Fmt(
-                    DialectProvider.GetQuotedTableName(parentDef),
-                    SqlColumn(parentDef.PrimaryKey.FieldName),
-                    DialectProvider.GetQuotedTableName(childDef),
-                    SqlColumn(refField.FieldName));
-            }
+            string sqlExpr = joinExpr != null ? InternalCreateSqlFromExpression(joinExpr) 
+                                              : InternalCreateSqlFromDefinitions(sourceDef, targetDef, "CROSS JOIN".Equals(joinType));
 
             var joinDef = tableDefs.Contains(targetDef) && !tableDefs.Contains(sourceDef)
                               ? sourceDef
                               : targetDef;
 
-            sbJoin.Append(" {0} {1} ".Fmt(joinType, SqlTable(joinDef)));
-            sbJoin.Append(" ON ");
-            sbJoin.Append(sqlExpr);
-
-            FromExpression = fromExpr + sbJoin;
+            FromExpression += " {0} {1} {2}".Fmt(joinType, SqlTable(joinDef), sqlExpr);
 
             if (!tableDefs.Contains(sourceDef))
                 tableDefs.Add(sourceDef);


### PR DESCRIPTION
While CROSS JOIN is generally something you'd like to avoid to use - there are cases where it is the right tool for the job. So I wrote some code to add support for that :)

Cross joins are however a bit different than the other types since it's quite valid to just do an empty "CROSS JOIN TableName" without any ON clauses, so I also had to go in and do some changes in InternalJoin. I'm not entirely happy with checking against the string "CROSS JOIN" in that method at one place though...but I figured it should probably be OK since the method is only called internally.

I also added two unit tests for using this functionality.
