### PR TITLE
Demonstrate System.InvalidOperationException caused by the SqlList and SqlProc APIs

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServerTests/CustomSqlTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/CustomSqlTests.cs
@@ -1,0 +1,93 @@
+﻿using System.Data;
+using NUnit.Framework;
+using ServiceStack.DataAnnotations;
+
+namespace ServiceStack.OrmLite.SqlServerTests
+{
+    public class LetterFrequency
+    {
+        [AutoIncrement]
+        public int Id { get; set; }
+
+        public string Letter { get; set; }
+    }
+
+    [TestFixture]
+    public class CustomSqlTests : OrmLiteTestBase
+    {
+        private const string DropProcedureSql = @"
+            IF OBJECT_ID('spSearchLetters') IS NOT NULL
+                    DROP PROCEDURE spSearchLetters";
+
+        private const string CreateProcedureSql = @"
+            CREATE PROCEDURE spSearchLetters 
+            (
+                @pLetter varchar(10),
+                @pTotal int OUT
+            )
+            AS
+            BEGIN
+                SELECT @pTotal = COUNT(*) FROM LetterFrequency WHERE Letter = @pLetter
+                SELECT * FROM LetterFrequency WHERE Letter = @pLetter
+            END";
+
+        [Test]
+        public void Can_execute_stored_procedure_using_SqlList_with_out_params()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<LetterFrequency>();
+
+                var rows = "A,B,B,C,C,C,D,D,E".Split(',').Map(x => new LetterFrequency { Letter = x });
+                db.InsertAll(rows);
+
+                db.ExecuteSql(DropProcedureSql);
+                db.ExecuteSql(CreateProcedureSql);
+
+                IDbDataParameter pTotal = null;
+                var results = db.SqlList<LetterFrequency>("spSearchLetters",
+                    cmd =>
+                    {
+                        cmd.CommandType = CommandType.StoredProcedure;
+                        cmd.AddParam("pLetter", "C");
+                        // Replace above line with the following two lines
+                        // var pLetter = cmd.AddParam("pLetter", "C");
+                        // pLetter.Size = 10;
+                        pTotal = cmd.AddParam("pTotal", direction: ParameterDirection.Output);
+                        // Add the following line
+                        // pTotal.Size = 10;
+                    });
+
+                Assert.That(results.Count, Is.EqualTo(3));
+                Assert.That(pTotal.Value, Is.EqualTo("3"));
+            }
+        }
+
+        [Test]
+        public void Can_execute_stored_procedure_using_SqlProc_with_out_params()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<LetterFrequency>();
+
+                var rows = "A,B,B,C,C,C,D,D,E".Split(',').Map(x => new LetterFrequency { Letter = x });
+                db.InsertAll(rows);
+
+                db.ExecuteSql(DropProcedureSql);
+                db.ExecuteSql(CreateProcedureSql);
+
+                var cmd = db.SqlProc("spSearchLetters", new { pLetter = "C" });
+                // Add the following two lines
+                // var pLetter = (IDbDataParameter)cmd.Parameters["pLetter"];
+                // pLetter.Size = 10;
+                var pTotal = cmd.AddParam("pTotal", direction: ParameterDirection.Output);
+                // Add the following line
+                // pTotal.Size = 10;
+                var results = cmd.ConvertToList<LetterFrequency>();
+
+                Assert.That(results.Count, Is.EqualTo(3));
+                Assert.That(pTotal.Value, Is.EqualTo("3"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Modified version of ServiceStack.OrmLite.MySql.Tests.CustomSqlTests for SQL Server
- All tests fail due to the parameter size being set to 0 by default
- All tests will pass if modified according to the comments in each test 
