### PR TITLE
support multiple DialectProvider and ExecFilter of database access

### DIFF
--- a/src/ServiceStack.OrmLite.Firebird/FirebirdSqlExpression.cs
+++ b/src/ServiceStack.OrmLite.Firebird/FirebirdSqlExpression.cs
@@ -39,7 +39,7 @@ namespace ServiceStack.OrmLite.Firebird
                 if (left as PartialSqlString == null && right as PartialSqlString == null)
                 {
                     var result = Expression.Lambda(b).Compile().DynamicInvoke();
-                    return new PartialSqlString(OrmLiteConfig.DialectProvider.GetQuotedValue(result, result.GetType()));
+                    return new PartialSqlString(base.DialectProvider.GetQuotedValue(result, result.GetType()));
                 }
 
                 if (left as PartialSqlString == null)
@@ -59,10 +59,10 @@ namespace ServiceStack.OrmLite.Firebird
                     //enum value was returned by Visit(b.Right)
                     long numvericVal;
                     if (Int64.TryParse(right.ToString(), out numvericVal))
-                        right = OrmLiteConfig.DialectProvider.GetQuotedValue(Enum.ToObject(enumType, numvericVal).ToString(),
+                        right = base.DialectProvider.GetQuotedValue(Enum.ToObject(enumType, numvericVal).ToString(),
                                                                      typeof(string));
                     else
-                        right = OrmLiteConfig.DialectProvider.GetQuotedValue(right, right.GetType());
+                        right = base.DialectProvider.GetQuotedValue(right, right.GetType());
                 }
                 else if (right as EnumMemberAccess != null)
                 {
@@ -71,10 +71,10 @@ namespace ServiceStack.OrmLite.Firebird
                     //enum value was returned by Visit(b.Left)
                     long numvericVal;
                     if (Int64.TryParse(left.ToString(), out numvericVal))
-                        left = OrmLiteConfig.DialectProvider.GetQuotedValue(Enum.ToObject(enumType, numvericVal).ToString(),
+                        left = base.DialectProvider.GetQuotedValue(Enum.ToObject(enumType, numvericVal).ToString(),
                                                                      typeof(string));
                     else
-                        left = OrmLiteConfig.DialectProvider.GetQuotedValue(left, left.GetType());
+                        left = base.DialectProvider.GetQuotedValue(left, left.GetType());
                 }
                 else if (left as PartialSqlString == null && right as PartialSqlString == null)
                 {
@@ -82,9 +82,9 @@ namespace ServiceStack.OrmLite.Firebird
                     return result;
                 }
                 else if (left as PartialSqlString == null)
-                    left = OrmLiteConfig.DialectProvider.GetQuotedValue(left, left != null ? left.GetType() : null);
+                    left = base.DialectProvider.GetQuotedValue(left, left != null ? left.GetType() : null);
                 else if (right as PartialSqlString == null)
-                    right = OrmLiteConfig.DialectProvider.GetQuotedValue(right, right != null ? right.GetType() : null);
+                    right = base.DialectProvider.GetQuotedValue(right, right != null ? right.GetType() : null);
 
             }
 
@@ -117,7 +117,7 @@ namespace ServiceStack.OrmLite.Firebird
 
             if (c.Value is bool)
             {
-                object o = OrmLiteConfig.DialectProvider.GetQuotedValue(c.Value, c.Value.GetType());
+                object o = base.DialectProvider.GetQuotedValue(c.Value, c.Value.GetType());
                 return new PartialSqlString(string.Format("({0}={1})", GetQuotedTrueValue(), o));
             }
 

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerExpression.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerExpression.cs
@@ -10,7 +10,6 @@ namespace ServiceStack.OrmLite.SqlServer
         public override string ToUpdateStatement(T item, bool excludeDefaults = false)
         {
             var setFields = new StringBuilder();
-            var dialectProvider = OrmLiteConfig.DialectProvider;
 
             foreach (var fieldDef in ModelDef.FieldDefinitions)
             {
@@ -27,12 +26,12 @@ namespace ServiceStack.OrmLite.SqlServer
                     setFields.Append(", ");
 
                 setFields.AppendFormat("{0}={1}",
-                    dialectProvider.GetQuotedColumnName(fieldDef.FieldName),
-                    dialectProvider.GetQuotedValue(value, fieldDef.FieldType));
+                    base.DialectProvider.GetQuotedColumnName(fieldDef.FieldName),
+                    base.DialectProvider.GetQuotedValue(value, fieldDef.FieldType));
             }
 
             return string.Format("UPDATE {0} SET {1} {2}",
-                dialectProvider.GetQuotedTableName(ModelDef), setFields, WhereExpression);
+                base.DialectProvider.GetQuotedTableName(ModelDef), setFields, WhereExpression);
         }
 	}
 }

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
@@ -409,7 +409,7 @@ namespace ServiceStack.OrmLite.SqlServer
                     throw new ApplicationException("Malformed model, no PrimaryKey defined");
 
                 orderByExpression = string.Format("ORDER BY {0}",
-                    OrmLiteConfig.DialectProvider.GetQuotedColumnName(modelDef, modelDef.PrimaryKey));
+                    this.GetQuotedColumnName(modelDef, modelDef.PrimaryKey));
             }
 
             var ret = string.Format(

--- a/src/ServiceStack.OrmLite.Sqlite/SqliteExpression.cs
+++ b/src/ServiceStack.OrmLite.Sqlite/SqliteExpression.cs
@@ -60,7 +60,7 @@ namespace ServiceStack.OrmLite.Sqlite
                     {
                         sIn.AppendFormat("{0}{1}",
                             sIn.Length > 0 ? "," : "",
-                            OrmLiteConfig.DialectProvider.GetQuotedValue(e, e.GetType()));
+                            base.DialectProvider.GetQuotedValue(e, e.GetType()));
                     }
                     statement = string.Format("{0} {1} ({2})", quotedColName, m.Method.Name, sIn);
                     break;
@@ -69,7 +69,7 @@ namespace ServiceStack.OrmLite.Sqlite
                     break;
                 case "As":
                     statement = string.Format("{0} As {1}", quotedColName,
-                        OrmLiteConfig.DialectProvider.GetQuotedColumnName(RemoveQuoteFromAlias(args[0].ToString())));
+                        base.DialectProvider.GetQuotedColumnName(RemoveQuoteFromAlias(args[0].ToString())));
                     break;
                 case "Sum":
                 case "Count":

--- a/src/ServiceStack.OrmLite/Async/OrmLiteResultsFilterExtensionsAsync.cs
+++ b/src/ServiceStack.OrmLite/Async/OrmLiteResultsFilterExtensionsAsync.cs
@@ -23,7 +23,7 @@ namespace ServiceStack.OrmLite
             if (OrmLiteConfig.ResultsFilter != null)
                 return OrmLiteConfig.ResultsFilter.ExecuteSql(dbCmd).InTask();
 
-            return OrmLiteConfig.DialectProvider.ExecuteNonQueryAsync(dbCmd, token);
+            return dbCmd.GetDialectProvider().ExecuteNonQueryAsync(dbCmd, token);
         }
 
         internal static Task<int> ExecNonQueryAsync(this IDbCommand dbCmd, string sql, IDictionary<string, object> dict, CancellationToken token)
@@ -36,7 +36,7 @@ namespace ServiceStack.OrmLite
             if (OrmLiteConfig.ResultsFilter != null)
                 return OrmLiteConfig.ResultsFilter.ExecuteSql(dbCmd).InTask();
 
-            return OrmLiteConfig.DialectProvider.ExecuteNonQueryAsync(dbCmd, token);
+            return dbCmd.GetDialectProvider().ExecuteNonQueryAsync(dbCmd, token);
         }
 
         internal static Task<int> ExecNonQueryAsync(this IDbCommand dbCmd, CancellationToken token)
@@ -44,7 +44,7 @@ namespace ServiceStack.OrmLite
             if (OrmLiteConfig.ResultsFilter != null)
                 return OrmLiteConfig.ResultsFilter.ExecuteSql(dbCmd).InTask();
 
-            return OrmLiteConfig.DialectProvider.ExecuteNonQueryAsync(dbCmd, token);
+            return dbCmd.GetDialectProvider().ExecuteNonQueryAsync(dbCmd, token);
         }
 
         public static Task<List<T>> ConvertToListAsync<T>(this IDbCommand dbCmd, string sql, CancellationToken token)
@@ -136,7 +136,7 @@ namespace ServiceStack.OrmLite
             if (OrmLiteConfig.ResultsFilter != null)
                 return OrmLiteConfig.ResultsFilter.GetScalar(dbCmd).InTask();
 
-            return OrmLiteConfig.DialectProvider.ExecuteScalarAsync(dbCmd, token);
+            return dbCmd.GetDialectProvider().ExecuteScalarAsync(dbCmd, token);
         }
 
         internal static Task<long> ExecLongScalarAsync(this IDbCommand dbCmd, string sql, CancellationToken token)

--- a/src/ServiceStack.OrmLite/Async/OrmLiteUtilExtensionsAsync.cs
+++ b/src/ServiceStack.OrmLite/Async/OrmLiteUtilExtensionsAsync.cs
@@ -23,7 +23,7 @@ namespace ServiceStack.OrmLite
             var fieldDefs = ModelDefinition<T>.Definition.AllFieldDefinitionsArray;
             using (dataReader)
             {
-                return OrmLiteConfig.DialectProvider.ReaderRead(dataReader, () =>
+                return dialectProvider.ReaderRead(dataReader, () =>
                 {
                     var row = CreateInstance<T>();
                     var indexCache = dataReader.GetIndexFieldsCache(ModelDefinition<T>.Definition);
@@ -39,7 +39,7 @@ namespace ServiceStack.OrmLite
             using (dataReader)
             {
                 var indexCache = dataReader.GetIndexFieldsCache(ModelDefinition<T>.Definition);
-                return OrmLiteConfig.DialectProvider.ReaderEach(dataReader, () =>
+                return dialectProvider.ReaderEach(dataReader, () =>
                 {
                     var row = CreateInstance<T>();
                     row.PopulateWithSqlReader(dialectProvider, dataReader, fieldDefs, indexCache);
@@ -55,7 +55,7 @@ namespace ServiceStack.OrmLite
 
             using (dataReader)
             {
-                return OrmLiteConfig.DialectProvider.ReaderRead(dataReader, () =>
+                return dialectProvider.ReaderRead(dataReader, () =>
                 {
                     var row = type.CreateInstance();
                     var indexCache = dataReader.GetIndexFieldsCache(modelDef);
@@ -73,7 +73,7 @@ namespace ServiceStack.OrmLite
             using (dataReader)
             {
                 var indexCache = dataReader.GetIndexFieldsCache(modelDef);
-                return OrmLiteConfig.DialectProvider.ReaderEach(dataReader, () =>
+                return dialectProvider.ReaderEach(dataReader, () =>
                 {
                     var row = type.CreateInstance();
                     row.PopulateWithSqlReader(dialectProvider, dataReader, fieldDefs, indexCache);

--- a/src/ServiceStack.OrmLite/Async/OrmLiteWriteCommandExtensionsAsync.cs
+++ b/src/ServiceStack.OrmLite/Async/OrmLiteWriteCommandExtensionsAsync.cs
@@ -33,7 +33,7 @@ namespace ServiceStack.OrmLite
             if (OrmLiteConfig.ResultsFilter != null)
                 return OrmLiteConfig.ResultsFilter.ExecuteSql(dbCmd).InTask();
 
-            return OrmLiteConfig.DialectProvider.ExecuteNonQueryAsync(dbCmd);
+            return dbCmd.GetDialectProvider().ExecuteNonQueryAsync(dbCmd);
         }
 
         internal static Task<int> UpdateAsync<T>(this IDbCommand dbCmd, T obj, CancellationToken token)
@@ -70,7 +70,7 @@ namespace ServiceStack.OrmLite
             if (dbCmd.Transaction == null)
                 dbCmd.Transaction = dbTrans = dbCmd.Connection.BeginTransaction();
 
-            var dialectProvider = OrmLiteConfig.DialectProvider;
+            var dialectProvider = dbCmd.GetDialectProvider();
 
             var hadRowVersion = dialectProvider.PrepareParameterizedUpdateStatement<T>(dbCmd);
             if (string.IsNullOrEmpty(dbCmd.CommandText))
@@ -116,18 +116,20 @@ namespace ServiceStack.OrmLite
 
         internal static Task<int> DeleteAsync<T>(this IDbCommand dbCmd, object anonType, CancellationToken token)
         {
-            var hadRowVersion = OrmLiteConfig.DialectProvider.PrepareParameterizedDeleteStatement<T>(dbCmd, anonType.AllFields<T>());
+            var dialectProvider = dbCmd.GetDialectProvider();
+            var hadRowVersion = dialectProvider.PrepareParameterizedDeleteStatement<T>(dbCmd, anonType.AllFields<T>());
 
-            OrmLiteConfig.DialectProvider.SetParameterValues<T>(dbCmd, anonType);
+            dialectProvider.SetParameterValues<T>(dbCmd, anonType);
 
             return AssertRowsUpdatedAsync(dbCmd, hadRowVersion, token);
         }
 
         internal static Task<int> DeleteNonDefaultsAsync<T>(this IDbCommand dbCmd, T filter, CancellationToken token)
         {
-            var hadRowVersion = OrmLiteConfig.DialectProvider.PrepareParameterizedDeleteStatement<T>(dbCmd, filter.NonDefaultFields<T>());
+            var dialectProvider = dbCmd.GetDialectProvider();
+            var hadRowVersion = dialectProvider.PrepareParameterizedDeleteStatement<T>(dbCmd, filter.NonDefaultFields<T>());
 
-            OrmLiteConfig.DialectProvider.SetParameterValues<T>(dbCmd, filter);
+            dialectProvider.SetParameterValues<T>(dbCmd, filter);
 
             return AssertRowsUpdatedAsync(dbCmd, hadRowVersion, token);
         }
@@ -156,7 +158,7 @@ namespace ServiceStack.OrmLite
             if (dbCmd.Transaction == null)
                 dbCmd.Transaction = dbTrans = dbCmd.Connection.BeginTransaction();
 
-            var dialectProvider = OrmLiteConfig.DialectProvider;
+            var dialectProvider = dbCmd.GetDialectProvider();
             dialectProvider.PrepareParameterizedDeleteStatement<T>(dbCmd, deleteFields);
 
             return objs.EachAsync((obj, i) =>
@@ -212,7 +214,8 @@ namespace ServiceStack.OrmLite
 
         internal static Task<int> DeleteAllAsync(this IDbCommand dbCmd, Type tableType, CancellationToken token)
         {
-            return dbCmd.ExecuteSqlAsync(OrmLiteConfig.DialectProvider.ToDeleteStatement(tableType, null), token);
+            var dialectProvider = dbCmd.GetDialectProvider();
+            return dbCmd.ExecuteSqlAsync(dialectProvider.ToDeleteStatement(tableType, null), token);
         }
 
         internal static Task<int> DeleteFmtAsync<T>(this IDbCommand dbCmd, CancellationToken token, string sqlFilter, params object[] filterParams)
@@ -222,7 +225,8 @@ namespace ServiceStack.OrmLite
 
         internal static Task<int> DeleteFmtAsync(this IDbCommand dbCmd, CancellationToken token, Type tableType, string sqlFilter, params object[] filterParams)
         {
-            return dbCmd.ExecuteSqlAsync(OrmLiteConfig.DialectProvider.ToDeleteStatement(tableType, sqlFilter, filterParams), token);
+            var dialectProvider = dbCmd.GetDialectProvider();
+            return dbCmd.ExecuteSqlAsync(dialectProvider.ToDeleteStatement(tableType, sqlFilter, filterParams), token);
         }
 
         internal static Task<long> InsertAsync<T>(this IDbCommand dbCmd, T obj, bool selectIdentity, CancellationToken token)
@@ -230,11 +234,13 @@ namespace ServiceStack.OrmLite
             if (OrmLiteConfig.InsertFilter != null)
                 OrmLiteConfig.InsertFilter(dbCmd, obj);
 
-            OrmLiteConfig.DialectProvider.PrepareParameterizedInsertStatement<T>(dbCmd);
-            OrmLiteConfig.DialectProvider.SetParameterValues<T>(dbCmd, obj);
+            var dialectProvider = dbCmd.GetDialectProvider();
+
+            dialectProvider.PrepareParameterizedInsertStatement<T>(dbCmd);
+            dialectProvider.SetParameterValues<T>(dbCmd, obj);
 
             if (selectIdentity)
-                return OrmLiteConfig.DialectProvider.InsertAndGetLastInsertIdAsync<T>(dbCmd, token);
+                return dialectProvider.InsertAndGetLastInsertIdAsync<T>(dbCmd, token);
 
             return dbCmd.ExecNonQueryAsync(token).Then(i => (long)i);
         }
@@ -251,7 +257,7 @@ namespace ServiceStack.OrmLite
             if (dbCmd.Transaction == null)
                 dbCmd.Transaction = dbTrans = dbCmd.Connection.BeginTransaction();
 
-            var dialectProvider = OrmLiteConfig.DialectProvider;
+            var dialectProvider = dbCmd.GetDialectProvider();
 
             dialectProvider.PrepareParameterizedInsertStatement<T>(dbCmd);
 
@@ -290,8 +296,9 @@ namespace ServiceStack.OrmLite
             {
                 if (modelDef.HasAutoIncrementId)
                 {
+
                     var newId = await dbCmd.InsertAsync(obj, selectIdentity: true, token:token);
-                    var safeId = OrmLiteConfig.DialectProvider.ConvertDbValue(newId, modelDef.PrimaryKey.FieldType);
+                    var safeId = dbCmd.GetDialectProvider().ConvertDbValue(newId, modelDef.PrimaryKey.FieldType);
                     modelDef.PrimaryKey.SetValueFn(obj, safeId);
                     id = newId;
                 }
@@ -339,6 +346,8 @@ namespace ServiceStack.OrmLite
             if (dbCmd.Transaction == null)
                 dbCmd.Transaction = dbTrans = dbCmd.Connection.BeginTransaction();
 
+            var dialectProvider = dbCmd.GetDialectProvider();
+
             try
             {
                 foreach (var row in saveRows)
@@ -356,7 +365,7 @@ namespace ServiceStack.OrmLite
                         if (modelDef.HasAutoIncrementId)
                         {
                             var newId = await dbCmd.InsertAsync(row, selectIdentity: true, token:token);
-                            var safeId = OrmLiteConfig.DialectProvider.ConvertDbValue(newId, modelDef.PrimaryKey.FieldType);
+                            var safeId = dialectProvider.ConvertDbValue(newId, modelDef.PrimaryKey.FieldType);
                             modelDef.PrimaryKey.SetValueFn(row, safeId);
                             id = newId;
                         }
@@ -482,7 +491,8 @@ namespace ServiceStack.OrmLite
         // Procedures
         internal static Task ExecuteProcedureAsync<T>(this IDbCommand dbCommand, T obj, CancellationToken token)
         {
-            string sql = OrmLiteConfig.DialectProvider.ToExecuteProcedureStatement(obj);
+            var dialectProvider = dbCommand.GetDialectProvider();
+            string sql = dialectProvider.ToExecuteProcedureStatement(obj);
             dbCommand.CommandType = CommandType.StoredProcedure;
             return dbCommand.ExecuteSqlAsync(sql, token);
         }

--- a/src/ServiceStack.OrmLite/Async/ReadExpressionCommandExtensionsAsync.cs
+++ b/src/ServiceStack.OrmLite/Async/ReadExpressionCommandExtensionsAsync.cs
@@ -16,14 +16,14 @@ namespace ServiceStack.OrmLite
     {
         internal static Task<List<T>> SelectAsync<T>(this IDbCommand dbCmd, Func<SqlExpression<T>, SqlExpression<T>> expression, CancellationToken token)
         {
-            var expr = OrmLiteConfig.DialectProvider.SqlExpression<T>();
+            var expr = dbCmd.GetDialectProvider().SqlExpression<T>();
             var sql = expression(expr).SelectInto<T>();
             return dbCmd.ExprConvertToListAsync<T>(sql, token);
         }
 
         internal static Task<List<Into>> SelectAsync<Into, From>(this IDbCommand dbCmd, Func<SqlExpression<From>, SqlExpression<From>> expression, CancellationToken token)
         {
-            var expr = OrmLiteConfig.DialectProvider.SqlExpression<From>();
+            var expr = dbCmd.GetDialectProvider().SqlExpression<From>();
             string sql = expression(expr).SelectInto<Into>();
             return dbCmd.ExprConvertToListAsync<Into>(sql, token);
         }
@@ -42,7 +42,7 @@ namespace ServiceStack.OrmLite
 
         internal static Task<List<T>> SelectAsync<T>(this IDbCommand dbCmd, Expression<Func<T, bool>> predicate, CancellationToken token)
         {
-            var expr = OrmLiteConfig.DialectProvider.SqlExpression<T>();
+            var expr = dbCmd.GetDialectProvider().SqlExpression<T>();
             string sql = expr.Where(predicate).SelectInto<T>();
 
             return dbCmd.ExprConvertToListAsync<T>(sql, token);
@@ -50,13 +50,13 @@ namespace ServiceStack.OrmLite
 
         internal static Task<T> SingleAsync<T>(this IDbCommand dbCmd, Func<SqlExpression<T>, SqlExpression<T>> expression, CancellationToken token)
         {
-            var expr = OrmLiteConfig.DialectProvider.SqlExpression<T>();
+            var expr = dbCmd.GetDialectProvider().SqlExpression<T>();
             return dbCmd.SingleAsync(expression(expr), token);
         }
 
         internal static Task<T> SingleAsync<T>(this IDbCommand dbCmd, Expression<Func<T, bool>> predicate, CancellationToken token)
         {
-            var ev = OrmLiteConfig.DialectProvider.SqlExpression<T>();
+            var ev = dbCmd.GetDialectProvider().SqlExpression<T>();
 
             return SingleAsync(dbCmd, ev.Where(predicate), token);
         }
@@ -65,7 +65,7 @@ namespace ServiceStack.OrmLite
         {
             string sql = expression.Limit(1).SelectInto<T>();
 
-            return dbCmd.ExprConvertToAsync<T>(sql, token);
+            return dbCmd.ConvertToAsync<T>(sql, token);
         }
 
         public static Task<TKey> ScalarAsync<T, TKey>(this IDbCommand dbCmd, Expression<Func<T, TKey>> field, CancellationToken token)
@@ -131,7 +131,7 @@ namespace ServiceStack.OrmLite
 
         internal static Task<List<T>> LoadSelectAsync<T>(this IDbCommand dbCmd, Func<SqlExpression<T>, SqlExpression<T>> expression, CancellationToken token = default(CancellationToken))
         {
-            var expr = OrmLiteConfig.DialectProvider.SqlExpression<T>();
+            var expr = dbCmd.GetDialectProvider().SqlExpression<T>();
             expr = expression(expr);
             return dbCmd.LoadListWithReferences<T, T>(expr, token);
         }
@@ -148,7 +148,7 @@ namespace ServiceStack.OrmLite
 
         internal static Task<List<T>> LoadSelectAsync<T>(this IDbCommand dbCmd, Expression<Func<T, bool>> predicate, CancellationToken token = default(CancellationToken))
         {
-            var expr = OrmLiteConfig.DialectProvider.SqlExpression<T>().Where(predicate);
+            var expr = dbCmd.GetDialectProvider().SqlExpression<T>().Where(predicate);
             return dbCmd.LoadListWithReferences<T, T>(expr, token);
         }
 
@@ -174,7 +174,7 @@ namespace ServiceStack.OrmLite
 
         internal static Task<List<T>> Select<T>(this IDbCommand dbCmd, Expression<Func<T, bool>> predicate, CancellationToken token)
         {
-            var expr = OrmLiteConfig.DialectProvider.SqlExpression<T>();
+            var expr = dbCmd.GetDialectProvider().SqlExpression<T>();
             string sql = expr.Where(predicate).SelectInto<T>();
 
             return dbCmd.ExprConvertToListAsync<T>(sql, token);

--- a/src/ServiceStack.OrmLite/Async/WriteExpressionCommandExtensionsAsync.cs
+++ b/src/ServiceStack.OrmLite/Async/WriteExpressionCommandExtensionsAsync.cs
@@ -11,7 +11,7 @@ namespace ServiceStack.OrmLite
     {
         internal static Task<int> UpdateOnlyAsync<T>(this IDbCommand dbCmd, T model, Func<SqlExpression<T>, SqlExpression<T>> onlyFields, CancellationToken token)
         {
-            return dbCmd.UpdateOnlyAsync(model, onlyFields(OrmLiteConfig.DialectProvider.SqlExpression<T>()), token);
+            return dbCmd.UpdateOnlyAsync(model, onlyFields(dbCmd.GetDialectProvider().SqlExpression<T>()), token);
         }
 
         internal static Task<int> UpdateOnlyAsync<T>(this IDbCommand dbCmd, T model, SqlExpression<T> onlyFields, CancellationToken token)
@@ -28,7 +28,7 @@ namespace ServiceStack.OrmLite
             if (onlyFields == null)
                 throw new ArgumentNullException("onlyFields");
 
-            var q = OrmLiteConfig.DialectProvider.SqlExpression<T>();
+            var q = dbCmd.GetDialectProvider().SqlExpression<T>();
             q.Update(onlyFields);
             q.Where(where);
             return dbCmd.UpdateOnlyAsync(obj, q, token);
@@ -39,7 +39,7 @@ namespace ServiceStack.OrmLite
             if (OrmLiteConfig.UpdateFilter != null)
                 OrmLiteConfig.UpdateFilter(dbCmd, item);
 
-            var q = OrmLiteConfig.DialectProvider.SqlExpression<T>();
+            var q = dbCmd.GetDialectProvider().SqlExpression<T>();
             q.Where(obj);
             var sql = q.ToUpdateStatement(item, excludeDefaults: true);
             return dbCmd.ExecuteSqlAsync(sql, token);
@@ -50,7 +50,7 @@ namespace ServiceStack.OrmLite
             if (OrmLiteConfig.UpdateFilter != null)
                 OrmLiteConfig.UpdateFilter(dbCmd, item);
 
-            var q = OrmLiteConfig.DialectProvider.SqlExpression<T>();
+            var q = dbCmd.GetDialectProvider().SqlExpression<T>();
             q.Where(expression);
             var sql = q.ToUpdateStatement(item);
             return dbCmd.ExecuteSqlAsync(sql, token);
@@ -75,7 +75,7 @@ namespace ServiceStack.OrmLite
 
         internal static Task InsertOnlyAsync<T>(this IDbCommand dbCmd, T obj, Func<SqlExpression<T>, SqlExpression<T>> onlyFields, CancellationToken token)
         {
-            return dbCmd.InsertOnlyAsync(obj, onlyFields(OrmLiteConfig.DialectProvider.SqlExpression<T>()), token);
+            return dbCmd.InsertOnlyAsync(obj, onlyFields(dbCmd.GetDialectProvider().SqlExpression<T>()), token);
         }
 
         internal static Task InsertOnlyAsync<T>(this IDbCommand dbCmd, T obj, SqlExpression<T> onlyFields, CancellationToken token)
@@ -83,20 +83,20 @@ namespace ServiceStack.OrmLite
             if (OrmLiteConfig.InsertFilter != null)
                 OrmLiteConfig.InsertFilter(dbCmd, obj);
 
-            var sql = OrmLiteConfig.DialectProvider.ToInsertRowStatement(dbCmd, obj, onlyFields.InsertFields);
+            var sql = dbCmd.GetDialectProvider().ToInsertRowStatement(dbCmd, obj, onlyFields.InsertFields);
             return dbCmd.ExecuteSqlAsync(sql, token);
         }
 
         internal static Task<int> DeleteAsync<T>(this IDbCommand dbCmd, Expression<Func<T, bool>> where, CancellationToken token)
         {
-            var ev = OrmLiteConfig.DialectProvider.SqlExpression<T>();
+            var ev = dbCmd.GetDialectProvider().SqlExpression<T>();
             ev.Where(where);
             return dbCmd.DeleteAsync(ev, token);
         }
 
         internal static Task<int> DeleteAsync<T>(this IDbCommand dbCmd, Func<SqlExpression<T>, SqlExpression<T>> where, CancellationToken token)
         {
-            return dbCmd.DeleteAsync(where(OrmLiteConfig.DialectProvider.SqlExpression<T>()), token);
+            return dbCmd.DeleteAsync(where(dbCmd.GetDialectProvider().SqlExpression<T>()), token);
         }
 
         internal static Task<int> DeleteAsync<T>(this IDbCommand dbCmd, SqlExpression<T> where, CancellationToken token)

--- a/src/ServiceStack.OrmLite/OrmLiteConfig.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConfig.cs
@@ -70,6 +70,28 @@ namespace ServiceStack.OrmLite
                 : DialectProvider;
         }
 
+        public static IOrmLiteExecFilter GetExecFilter(this IOrmLiteDialectProvider dialectProvider) {
+            return dialectProvider != null
+                    ? dialectProvider.ExecFilter ?? ExecFilter
+                    : ExecFilter;
+        }
+
+        public static IOrmLiteExecFilter GetExecFilter(this IDbCommand dbCmd) {
+            var ormLiteCmd = dbCmd as OrmLiteCommand;
+            var dialectProvider = ormLiteCmd != null
+                ? ormLiteCmd.DialectProvider
+                : DialectProvider;
+            return dialectProvider.GetExecFilter();
+        }
+
+        public static IOrmLiteExecFilter GetExecFilter(this IDbConnection db) {
+            var ormLiteConn = db as OrmLiteConnection;
+            var dialectProvider = ormLiteConn != null
+                ? ormLiteConn.DialectProvider
+                : DialectProvider;
+            return dialectProvider.GetExecFilter();
+        }
+
         public static void SetLastCommandText(this IDbConnection db, string sql)
         {
             var ormLiteConn = db as OrmLiteConnection;

--- a/src/ServiceStack.OrmLite/OrmLiteReadExpressionsApi.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadExpressionsApi.cs
@@ -10,37 +10,37 @@ namespace ServiceStack.OrmLite
     {
         public static T Exec<T>(this IDbConnection dbConn, Func<IDbCommand, T> filter)
         {
-            return OrmLiteConfig.ExecFilter.Exec(dbConn, filter);
+            return dbConn.GetExecFilter().Exec(dbConn, filter);
         }
 
         public static void Exec(this IDbConnection dbConn, Action<IDbCommand> filter)
         {
-            OrmLiteConfig.ExecFilter.Exec(dbConn, filter);
+            dbConn.GetExecFilter().Exec(dbConn, filter);
         }
 
         public static Task<T> Exec<T>(this IDbConnection dbConn, Func<IDbCommand, Task<T>> filter)
         {
-            return OrmLiteConfig.ExecFilter.Exec(dbConn, filter);
+            return dbConn.GetExecFilter().Exec(dbConn, filter);
         }
 
         public static Task Exec(this IDbConnection dbConn, Func<IDbCommand, Task> filter)
         {
-            return OrmLiteConfig.ExecFilter.Exec(dbConn, filter);
+            return dbConn.GetExecFilter().Exec(dbConn, filter);
         }
 
         public static IEnumerable<T> ExecLazy<T>(this IDbConnection dbConn, Func<IDbCommand, IEnumerable<T>> filter)
         {
-            return OrmLiteConfig.ExecFilter.ExecLazy(dbConn, filter);
+            return dbConn.GetExecFilter().ExecLazy(dbConn, filter);
         }
 
         public static IDbCommand Exec(this IDbConnection dbConn, Func<IDbCommand, IDbCommand> filter)
         {
-            return OrmLiteConfig.ExecFilter.Exec(dbConn, filter);
+            return dbConn.GetExecFilter().Exec(dbConn, filter);
         }
 
         public static Task<IDbCommand> Exec(this IDbConnection dbConn, Func<IDbCommand, Task<IDbCommand>> filter)
         {
-            return OrmLiteConfig.ExecFilter.Exec(dbConn, filter);
+            return dbConn.GetExecFilter().Exec(dbConn, filter);
         }
 
 
@@ -50,7 +50,7 @@ namespace ServiceStack.OrmLite
         [Obsolete("Use From<T>")]
         public static SqlExpression<T> SqlExpression<T>(this IDbConnection dbConn)
         {
-            return OrmLiteConfig.ExecFilter.SqlExpression<T>(dbConn);
+            return dbConn.GetExecFilter().SqlExpression<T>(dbConn);
         }
 
         /// <summary>
@@ -59,12 +59,12 @@ namespace ServiceStack.OrmLite
         /// </summary>
         public static SqlExpression<T> From<T>(this IDbConnection dbConn)
         {
-            return OrmLiteConfig.ExecFilter.SqlExpression<T>(dbConn);
+            return dbConn.GetExecFilter().SqlExpression<T>(dbConn);
         }
 
         public static SqlExpression<T> From<T, JoinWith>(this IDbConnection dbConn, Expression<Func<T, JoinWith, bool>> joinExpr=null)
         {
-            var sql = OrmLiteConfig.ExecFilter.SqlExpression<T>(dbConn);
+            var sql = dbConn.GetExecFilter().SqlExpression<T>(dbConn);
             sql.Join<T,JoinWith>(joinExpr);
             return sql;
         }
@@ -74,7 +74,7 @@ namespace ServiceStack.OrmLite
         /// </summary>
         public static SqlExpression<T> From<T>(this IDbConnection dbConn, string fromExpression)
         {
-            var expr = OrmLiteConfig.ExecFilter.SqlExpression<T>(dbConn);
+            var expr = dbConn.GetExecFilter().SqlExpression<T>(dbConn);
             expr.From(fromExpression);
             return expr;
         }
@@ -100,7 +100,7 @@ namespace ServiceStack.OrmLite
         /// </summary>
         public static IDbCommand OpenCommand(this IDbConnection dbConn)
         {
-            return OrmLiteConfig.ExecFilter.CreateCommand(dbConn);
+            return dbConn.GetExecFilter().CreateCommand(dbConn);
         }
 
         /// <summary>

--- a/src/ServiceStack.OrmLite/OrmLiteReadExpressionsApiAsync.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadExpressionsApiAsync.cs
@@ -140,7 +140,7 @@ namespace ServiceStack.OrmLite
 
         public static Task<long> CountAsync<T>(this IDbConnection dbConn, CancellationToken token = default(CancellationToken))
         {
-            var expression = OrmLiteConfig.DialectProvider.SqlExpression<T>();
+            var expression = dbConn.GetDialectProvider().SqlExpression<T>();
             return dbConn.Exec(dbCmd => dbCmd.CountAsync(expression, token));
         }
 

--- a/src/ServiceStack.OrmLite/OrmLiteSPStatement.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteSPStatement.cs
@@ -153,7 +153,7 @@ namespace ServiceStack.OrmLite
 
         public void Dispose()
         {
-            OrmLiteConfig.ExecFilter.DisposeCommand(this.dbCmd, this.db);
+            dialectProvider.GetExecFilter().DisposeCommand(this.dbCmd, this.db);
         }
     }
 }

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteMultipleDialectProviderTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteMultipleDialectProviderTests.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics;
+using NUnit.Framework;
+using ServiceStack.OrmLite.Sqlite;
+using ServiceStack.Text;
+
+namespace ServiceStack.OrmLite.Tests
+{
+    [TestFixture]
+    public class OrmLiteMultipleDialectProviderTests
+    {
+        public class Person
+        {
+            public int Id { get; set; }
+
+            public string Name { get; set; }
+        }
+
+        [Test]
+        public void Can_open_multiple_dialectprovider_with_execfilter() {
+            //global
+            OrmLiteConfig.DialectProvider = new SqliteOrmLiteDialectProvider();
+            var factory = new OrmLiteConnectionFactory(Config.SqliteMemoryDb);
+
+            var sqlServerDialectProvider = SqlServerDialect.Provider;
+            sqlServerDialectProvider.ExecFilter = new MockExecFilter1();
+            factory.RegisterConnection("sqlserver", Config.SqlServerBuildDb, sqlServerDialectProvider);
+
+            var sqliteDialectProvider = SqliteDialect.Provider;
+            sqliteDialectProvider.ExecFilter = new MockExecFilter2();
+            factory.RegisterConnection("sqlite-file", Config.SqliteFileDb, sqliteDialectProvider);
+
+            var results = new List<Person>();
+            using (var db = factory.OpenDbConnection()) {
+                db.DropAndCreateTable<Person>();
+                db.Insert(new Person { Id = 1, Name = "1) :memory:" });
+                db.Insert(new Person { Id = 2, Name = "2) :memory:" });
+
+                using (var db2 = factory.OpenDbConnection("sqlserver")) {
+                    db2.CreateTable<Person>(true);
+                    db2.Insert(new Person { Id = 3, Name = "3) Database1.mdf" });
+                    db2.Insert(new Person { Id = 4, Name = "4) Database1.mdf" });
+
+                    using (var db3 = factory.OpenDbConnection("sqlite-file")) {
+                        db3.CreateTable<Person>(true);
+                        db3.Insert(new Person { Id = 5, Name = "5) db.sqlite" });
+                        db3.Insert(new Person { Id = 6, Name = "6) db.sqlite" });
+
+                        results.AddRange(db.Select<Person>());
+                        results.AddRange(db2.Select<Person>());
+                        results.AddRange(db3.Select<Person>());
+
+                        Assert.AreEqual(db.GetLastSql(), "SELECT \"Id\", \"Name\" FROM \"Person\"");
+                        Assert.AreEqual(db2.GetLastSql(), "MockExecFilter1");
+                        Assert.AreEqual(db3.GetLastSql(), "MockExecFilter2");
+                    }
+                }
+            }
+
+            results.PrintDump();
+            var ids = results.ConvertAll(x => x.Id);
+            Assert.AreEqual(new[] { 1, 2, 3, 4, 5, 6 }, ids);
+        }
+
+        public class MockExecFilter1 : OrmLiteExecFilter
+        {
+            public override T Exec<T>(IDbConnection dbConn, Func<IDbCommand, T> filter) {
+                var isCmd = typeof(IDbCommand).IsAssignableFrom(typeof(T));
+                var dbCmd = CreateCommand(dbConn);
+                Stopwatch watch = Stopwatch.StartNew();
+                try {
+                    var ret = filter(dbCmd);
+                    return ret;
+                } finally {
+                    if (!isCmd) {
+                        watch.Stop();
+                        DisposeCommand(dbCmd, dbConn);
+                        dbConn.SetLastCommandText("MockExecFilter1");
+                    }
+                }
+            }
+        }
+
+        public class MockExecFilter2 : OrmLiteExecFilter
+        {
+            public override T Exec<T>(IDbConnection dbConn, Func<IDbCommand, T> filter) {
+                var isCmd = typeof(IDbCommand).IsAssignableFrom(typeof(T));
+                var dbCmd = CreateCommand(dbConn);
+                Stopwatch watch = Stopwatch.StartNew();
+                try {
+                    var ret = filter(dbCmd);
+                    return ret;
+                } finally {
+                    if (!isCmd) {
+                        watch.Stop();
+                        DisposeCommand(dbCmd, dbConn);
+                        dbConn.SetLastCommandText("MockExecFilter2");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
+++ b/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
@@ -144,6 +144,7 @@
     <Compile Include="OrmLiteContextTests.cs" />
     <Compile Include="OrmLiteExecFilterTests.cs" />
     <Compile Include="OrmLiteFiltersTests.cs" />
+    <Compile Include="OrmLiteMultipleDialectProviderTests.cs" />
     <Compile Include="PerfTests.cs" />
     <Compile Include="RowVersionTests.cs" />
     <Compile Include="Shared\ModelWithNumerics.cs" />


### PR DESCRIPTION
Hello, I found that Global Singleton DialectProvider and ExecFilter under the same application does not support a variety of types of database access, such as mysql and MSSQL. To support multiple types of database access, I changed the implementation, also retained the whole Global Singleton. Hope you can adopt and support as soon as possible
