### PR TITLE
Make updating blobs work for Oracle and SQLite.

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
@@ -278,6 +278,11 @@ namespace ServiceStack.OrmLite.Oracle
                     : enumValue;
             }
 
+            if (fieldType == typeof(byte[]))
+            {
+                return "hextoraw('" + BitConverter.ToString((byte[])value).Replace("-", "") + "')";
+            }
+
             return base.GetQuotedValue(value, fieldType);
         }
 

--- a/src/ServiceStack.OrmLite.Sqlite/SqliteOrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite.Sqlite/SqliteOrmLiteDialectProviderBase.cs
@@ -220,6 +220,11 @@ namespace ServiceStack.OrmLite.Sqlite
                 return base.GetQuotedValue(dateTimeOffsetValue.ToString("o"), typeof (string));
             }
 
+            if (fieldType == typeof(byte[]))
+            {
+                return "x'" + BitConverter.ToString((byte[])value).Replace("-", "") + "'";
+            }
+
             return base.GetQuotedValue(value, fieldType);
         }
 


### PR DESCRIPTION
Updating blobs was failing because the data was written converted to a base64
string and read as binary.