### PR TITLE
Allow optional parameter list of reference field names to include in LoadSelect()

### DIFF
--- a/src/ServiceStack.OrmLite/Expressions/ReadExpressionCommandExtensions.cs
+++ b/src/ServiceStack.OrmLite/Expressions/ReadExpressionCommandExtensions.cs
@@ -126,27 +126,27 @@ namespace ServiceStack.OrmLite
             return dbCmd.Scalar<long>(dbCmd.GetDialectProvider().ToRowCountStatement(sql));
         }
 
-        internal static List<T> LoadSelect<T>(this IDbCommand dbCmd, Func<SqlExpression<T>, SqlExpression<T>> expression)
+        internal static List<T> LoadSelect<T>(this IDbCommand dbCmd, Func<SqlExpression<T>, SqlExpression<T>> expression, string[] include = null)
         {
             var expr = dbCmd.GetDialectProvider().SqlExpression<T>();
             expr = expression(expr);
-            return dbCmd.LoadListWithReferences<T, T>(expr);
+            return dbCmd.LoadListWithReferences<T, T>(expr, include);
         }
 
-        internal static List<T> LoadSelect<T>(this IDbCommand dbCmd, SqlExpression<T> expression = null)
+        internal static List<T> LoadSelect<T>(this IDbCommand dbCmd, SqlExpression<T> expression = null, string[] include = null)
         {
-            return dbCmd.LoadListWithReferences<T, T>(expression);
+            return dbCmd.LoadListWithReferences<T, T>(expression, include);
         }
 
-        internal static List<Into> LoadSelect<Into, From>(this IDbCommand dbCmd, SqlExpression<From> expression)
+        internal static List<Into> LoadSelect<Into, From>(this IDbCommand dbCmd, SqlExpression<From> expression, string[] include = null)
         {
-            return dbCmd.LoadListWithReferences<Into, From>(expression);
+            return dbCmd.LoadListWithReferences<Into, From>(expression, include);
         }
 
-        internal static List<T> LoadSelect<T>(this IDbCommand dbCmd, Expression<Func<T, bool>> predicate)
+        internal static List<T> LoadSelect<T>(this IDbCommand dbCmd, Expression<Func<T, bool>> predicate, string[] include = null)
         {
             var expr = dbCmd.GetDialectProvider().SqlExpression<T>().Where(predicate);
-            return dbCmd.LoadListWithReferences<T, T>(expr);
+            return dbCmd.LoadListWithReferences<T, T>(expr, include);
         }
     }
 }

--- a/src/ServiceStack.OrmLite/OrmLiteReadExpressionsApi.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadExpressionsApi.cs
@@ -254,35 +254,35 @@ namespace ServiceStack.OrmLite
         /// Returns results with references from using a LINQ Expression. E.g:
         /// <para>db.LoadSelect&lt;Person&gt;(x =&gt; x.Age &gt; 40)</para>
         /// </summary>
-        public static List<T> LoadSelect<T>(this IDbConnection dbConn, Expression<Func<T, bool>> predicate)
+        public static List<T> LoadSelect<T>(this IDbConnection dbConn, Expression<Func<T, bool>> predicate, params string[] include)
         {
-            return dbConn.Exec(dbCmd => dbCmd.LoadSelect(predicate));
+            return dbConn.Exec(dbCmd => dbCmd.LoadSelect(predicate, include));
         }
 
         /// <summary>
         /// Returns results with references from using an SqlExpression lambda. E.g:
         /// <para>db.LoadSelect&lt;Person&gt;(q =&gt; q.Where(x =&gt; x.Age &gt; 40))</para>
         /// </summary>
-        public static List<T> LoadSelect<T>(this IDbConnection dbConn, Func<SqlExpression<T>, SqlExpression<T>> expression)
+        public static List<T> LoadSelect<T>(this IDbConnection dbConn, Func<SqlExpression<T>, SqlExpression<T>> expression, params string[] include)
         {
-            return dbConn.Exec(dbCmd => dbCmd.LoadSelect(expression));
+            return dbConn.Exec(dbCmd => dbCmd.LoadSelect(expression, include));
         }
 
         /// <summary>
         /// Returns results with references from using an SqlExpression lambda. E.g:
         /// <para>db.LoadSelect(db.From&lt;Person&gt;().Where(x =&gt; x.Age &gt; 40))</para>
         /// </summary>
-        public static List<T> LoadSelect<T>(this IDbConnection dbConn, SqlExpression<T> expression = null)
+        public static List<T> LoadSelect<T>(this IDbConnection dbConn, SqlExpression<T> expression = null, params string[] include)
         {
-            return dbConn.Exec(dbCmd => dbCmd.LoadSelect(expression));
+            return dbConn.Exec(dbCmd => dbCmd.LoadSelect(expression, include));
         }
 
         /// <summary>
         /// Project results with references from a number of joined tables into a different model
         /// </summary>
-        public static List<Into> LoadSelect<Into, From>(this IDbConnection dbConn, SqlExpression<From> expression)
+        public static List<Into> LoadSelect<Into, From>(this IDbConnection dbConn, SqlExpression<From> expression, params string[] include)
         {
-            return dbConn.Exec(dbCmd => dbCmd.LoadSelect<Into, From>(expression));
+            return dbConn.Exec(dbCmd => dbCmd.LoadSelect<Into, From>(expression, include));
         }
     }
 }


### PR DESCRIPTION
Added additional optional string params to LoadSelect methods to allow for selective reference loading.

Example:

    var dbCustomers = db.LoadSelect<Customer>(q => q.Id == customer.Id, "PrimaryAddress");

This is in response to [this UserVoice request](http://servicestack.uservoice.com/forums/176786-feature-requests/suggestions/6656885-allow-loadselect-to-selectively-load-references)