### PR TITLE
Update GetTableName Function

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle/OracleNamingStrategy.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleNamingStrategy.cs
@@ -41,8 +41,8 @@ namespace ServiceStack.OrmLite.Oracle
         public override string GetTableName(ModelDefinition modelDef)
         {
             return modelDef.IsInSchema
-                       ? ApplyNameRestrictions(modelDef.Schema
-                            + "_" + GetTableName(modelDef.ModelName))
+                       ? ApplyNameRestrictions(modelDef.Schema)
+                            + "." + ApplyNameRestrictions(GetTableName(modelDef.ModelName))
                        : GetTableName(modelDef.ModelName);
         }
 


### PR DESCRIPTION
1. Schema name and table name should be separated by "." instead of "_".
2. Each portion of the identifier (eg schema name, table name, column name) should be a maximum of 30 bytes.

Source: http://docs.oracle.com/cd/B28359_01/server.111/b28286/sql_elements008.htm#SQLRF00223