### PR TITLE
Test for bad RowCount SQL statement generated by dialect provider if expression has ORDER BY

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
@@ -409,6 +409,16 @@ namespace ServiceStack.OrmLite.SqlServer
             return ret;
         }
 
+        public override string ToRowCountStatement(string innerSql)
+        {
+            //Remove ORDER BY because SqlServer won't allow it in the subquery
+            var orderByPos = innerSql.LastIndexOf("ORDER BY ");
+            if (orderByPos > -1)
+                innerSql = innerSql.Substring(0, orderByPos);
+
+            return base.ToRowCountStatement(innerSql);
+        }
+
         //SELECT without RowNum and prefer aliases to be able to use in SELECT IN () Reference Queries
         public static string UseAliasesOrStripTablePrefixes(string selectExpression)
         {

--- a/src/ServiceStack.OrmLite.SqlServerTests/CountTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/CountTests.cs
@@ -1,0 +1,31 @@
+﻿using System.Linq;
+using NUnit.Framework;
+
+namespace ServiceStack.OrmLite.SqlServerTests
+{
+    public class CountTests : OrmLiteTestBase
+    {
+        [Test]
+        public void Can_get_RowCount_if_expression_has_OrderBy()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<LetterFrequency>();
+
+                db.Insert(new LetterFrequency { Letter = "A" });
+                db.Insert(new LetterFrequency { Letter = "B" });
+                db.Insert(new LetterFrequency { Letter = "B" });
+
+                var query = db.From<LetterFrequency>()
+                    .Select(x => x.Letter)
+                    .OrderBy(x => x.Id);
+
+                var rowCount = db.RowCount(query);
+                Assert.That(rowCount, Is.EqualTo(3));
+
+                rowCount = db.Select(query).Count;
+                Assert.That(rowCount, Is.EqualTo(3));
+            }
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
+++ b/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="CountTests.cs" />
     <Compile Include="CustomSqlTests.cs" />
     <Compile Include="Datetime2Tests.cs" />
     <Compile Include="DateTimeOffsetTests.cs" />
@@ -121,6 +122,9 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Test and fix for issue ServiceStack/Issues#269