### PR TITLE
Fix compact guid option in Oracle provider to do searches correctly

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
@@ -238,7 +238,7 @@ namespace ServiceStack.OrmLite.Oracle
             if (fieldType == typeof(Guid))
             {
                 var guid = (Guid)value;
-                return CompactGuid ? "'" + BitConverter.ToString(guid.ToByteArray()).Replace("-", "") + "'"
+                return CompactGuid ? string.Format("CAST('{0}' AS {1})", BitConverter.ToString(guid.ToByteArray()).Replace("-", ""), CompactGuidDefinition)
                                    : string.Format("CAST('{0}' AS {1})", guid, StringGuidDefinition);
             }
 

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableTests.cs
@@ -189,6 +189,12 @@ namespace ServiceStack.OrmLite.Tests
                 newModel = db.Single<ModelWithGuid>(q => q.Guid == models[0].Guid);
 
                 Assert.That(newModel.Guid, Is.EqualTo(models[0].Guid));
+
+                var newGuid = Guid.NewGuid();
+                db.Update(new ModelWithGuid {Id = models[0].Id, Guid = newGuid});
+                db.GetLastSql().Print();
+                newModel = db.Single<ModelWithGuid>(q => q.Id == models[0].Id);
+                Assert.That(newModel.Guid, Is.EqualTo(newGuid));
             }
         }
 
@@ -210,12 +216,16 @@ namespace ServiceStack.OrmLite.Tests
 
                 db.GetLastSql().Print();
 
-                db.Insert(new ModelWithOddIds { Id = 1, Guid = Guid.NewGuid() });
+                var guid1 = Guid.NewGuid();
+                db.Insert(new ModelWithOddIds { Id = 1, Guid = guid1 });
                 db.Insert(new ModelWithOddIds { Id = 1, Guid = Guid.NewGuid() });
 
                 var rows = db.Select<ModelWithOddIds>(q => q.Id == 1);
 
                 Assert.That(rows.Count, Is.EqualTo(2));
+
+                rows = db.Select<ModelWithOddIds>(q => q.Guid == guid1);
+                Assert.That(rows, Has.Count.EqualTo(1));
             }
         }
 


### PR DESCRIPTION
Before this change the select would ignore the index because it forced Oracle to convert the key value to a string. Ouch.