### PR TITLE
LoadSelect fails with column name conflict on join

### DIFF
--- a/src/ServiceStack.OrmLite/Support/LoadList.cs
+++ b/src/ServiceStack.OrmLite/Support/LoadList.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -89,7 +90,11 @@ namespace ServiceStack.OrmLite.Support
         protected string GetRefSelfSql(FieldDefinition refSelf, ModelDefinition refModelDef)
         {
             //Load Self Table.RefTableId PK
-            expr.Select(dialectProvider.GetQuotedColumnName(refSelf));
+            StringBuilder sbSelect = new StringBuilder();
+            sbSelect.AppendFormat("{0}.{1}",
+                                dialectProvider.GetQuotedTableName(refModelDef),
+                                refSelf.GetQuotedName(dialectProvider));
+            expr.Select(sbSelect.ToString());
             var subSqlRef = expr.ToSelectStatement();
 
             var sqlRef = "SELECT {0} FROM {1} WHERE {2} IN ({3})".Fmt(

--- a/tests/ServiceStack.OrmLite.Tests/LoadReferencesJoinTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/LoadReferencesJoinTests.cs
@@ -628,6 +628,69 @@ namespace ServiceStack.OrmLite.Tests
         }
 
         [Test]
+        public void Can_load_select_with_join()
+        {
+            // Drop tables in order that FK allows
+            db.DropTable<TABLE_3>();
+            db.DropTable<TABLE_2>();
+            db.DropTable<TABLE_1>();
+            db.CreateTable<TABLE_1>();
+            db.CreateTable<TABLE_2>();
+            db.CreateTable<TABLE_3>();
+
+            var id1 = db.Insert(new TABLE_1 { One = "A" }, selectIdentity: true);
+            var id2 = db.Insert(new TABLE_1 { One = "B" }, selectIdentity: true);
+
+            db.Insert(new TABLE_2 { Three = "C", TableOneKey = (int)id1 });
+
+            var q = db.From<TABLE_1>()
+                      .Join<TABLE_2>();
+            var results = db.LoadSelect(q);
+
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results[0].One, Is.EqualTo("A"));
+
+            var row3 = new TABLE_3
+            {
+                Three = "3a",
+                TableTwo = new TABLE_2
+                {
+                    Three = "3b",
+                    TableOneKey = (int)id1,
+                }
+            };
+            db.Save(row3, references: true);
+
+            Assert.That(row3.TableTwoKey, Is.EqualTo(row3.TableTwo.Id));
+
+            row3 = db.LoadSingleById<TABLE_3>(row3.Id);
+            Assert.That(row3.TableTwoKey, Is.EqualTo(row3.TableTwo.Id));
+        }
+
+        [Test]
+        public void Can_load_select_with_join_and_same_name_columns()
+        {
+            // Drop tables in order that FK allows
+            db.DropTable<ProjectTask>();
+            db.DropTable<Project>();
+            db.CreateTable<Project>();
+            db.CreateTable<ProjectTask>();
+
+            db.Insert(new Project {Val = "test"});
+            db.Insert(new ProjectTask {Val = "testTask", ProjectId = 1});
+
+            var query = db.From<ProjectTask>()
+                .Join<ProjectTask, Project>((pt, p) => pt.ProjectId == p.Id);
+
+            var selectResults = db.Select(query);
+
+            var results = db.LoadSelect(query);
+
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results[0].Val, Is.EqualTo("testTask"));
+        }
+
+        [Test]
         public void Can_load_references_with_OrderBy_and_Paging()
         {
             //This version of MariaDB doesn't yet support 'LIMIT & IN/ALL/ANY/SOME subquery'
@@ -726,5 +789,36 @@ namespace ServiceStack.OrmLite.Tests
 
         [Reference]
         public TABLE_2 TableTwo { get; set; }
+    }
+
+    [Schema("dbo")]
+    [Alias("ProjectTask")]
+    public class ProjectTask : IHasId<int>
+    {
+        [Alias("ProjectTaskId")]
+        [Index(Unique = true)]
+        [AutoIncrement]
+        public int Id { get; set; }
+
+        [References(typeof (Project))]
+        public int ProjectId { get; set; }
+
+        [Reference]
+        public Project Project { get; set; }
+
+        public string Val { get; set; }
+    }
+
+    [Schema("dbo")]
+    [Alias("Project")]
+    public class Project : IHasId<int>
+    {
+        [Alias("ProjectId")]
+        [Index(Unique = true)]
+        [AutoIncrement]
+        public int Id { get; set; }
+
+        public string Val { get; set; }
+
     }
 }


### PR DESCRIPTION
Added table names to generated join statement to address [issue 275](https://github.com/ServiceStack/Issues/issues/275)

Could you please have a review @mythz ?