### PR TITLE
Changed SqlExpression.VisitUnary ExpressionType.Not => do not generat…

### DIFF
--- a/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
@@ -1169,7 +1169,7 @@ namespace ServiceStack.OrmLite
                         return !((bool)o);
 
                     if (IsFieldName(o))
-                        o = o + "=" + GetQuotedTrueValue();
+                        return new PartialSqlString(o + "=" + GetQuotedFalseValue());
 
                     return new PartialSqlString("NOT (" + o + ")");
                 case ExpressionType.Convert:

--- a/tests/ServiceStack.OrmLite.Tests/Expression/SqlExpressionTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Expression/SqlExpressionTests.cs
@@ -396,31 +396,63 @@ namespace ServiceStack.OrmLite.Tests.Expression
                 db.DropAndCreateTable<TableB>();
 
                 db.Insert(new TableA { Id = 1, Bool = false });
+                db.Insert(new TableA { Id = 2, Bool = true });
                 db.Insert(new TableB { Id = 1, TableAId = 1 });
+                db.Insert(new TableB { Id = 2, TableAId = 2 });
 
                 var q = db.From<TableA>()
                     .LeftJoin<TableB>((a, b) => a.Id == b.Id)
                     .Where(a => !a.Bool);
 
                 var result = db.Single(q);
-                db.GetLastSql().Print();
+                var lastSql = db.GetLastSql();
+                lastSql.Print();
                 Assert.That(result.Id, Is.EqualTo(1));
+                Assert.That(lastSql, Is.Not.StringContaining("NOT"));
 
                 q = db.From<TableA>()
                     .Where(a => !a.Bool)
                     .LeftJoin<TableB>((a, b) => a.Id == b.Id);
 
                 result = db.Single(q);
-                db.GetLastSql().Print();
+                lastSql = db.GetLastSql();
+                lastSql.Print();
                 Assert.That(result.Id, Is.EqualTo(1));
+                Assert.That(lastSql, Is.Not.StringContaining("NOT"));
 
 
                 q = db.From<TableA>()
                     .Where(a => !a.Bool);
 
                 result = db.Single(q);
-                db.GetLastSql().Print();
+                lastSql = db.GetLastSql();
+                lastSql.Print();
                 Assert.That(result.Id, Is.EqualTo(1));
+                Assert.That(lastSql, Is.Not.StringContaining("NOT"));
+
+                q = db.From<TableA>()
+                    .LeftJoin<TableB>((a, b) => a.Id == b.Id)
+                    .Where(a => a.Bool);
+
+                result = db.Single(q);
+                db.GetLastSql().Print();
+                Assert.That(result.Id, Is.EqualTo(2));
+
+                q = db.From<TableA>()
+                    .Where(a => a.Bool)
+                    .LeftJoin<TableB>((a, b) => a.Id == b.Id);
+
+                result = db.Single(q);
+                db.GetLastSql().Print();
+                Assert.That(result.Id, Is.EqualTo(2));
+
+
+                q = db.From<TableA>()
+                    .Where(a => a.Bool);
+
+                result = db.Single(q);
+                db.GetLastSql().Print();
+                Assert.That(result.Id, Is.EqualTo(2));
             }
         }
 


### PR DESCRIPTION
…e "NOT(BoolCol = TRUE)" instead generate "BoolCol = FALSE"
- UnitTest adjusted to check for that

---
When doing "NOT(a = TRUE)" in MySql, it is an exclusion, which is not very efficient when using an index. It is better to compare to FALSE.

Of course in my expressions I could write ".Where(e => e.BoolCol == false)" instead of ".Where(e => !e.BoolCol)", but this is annoying :-)

May you take it into consideration.....