### PR TITLE
Extended OrmLiteResultsFilter to filter on IDbCommand.

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteResultsFilter.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteResultsFilter.cs
@@ -68,6 +68,8 @@ namespace ServiceStack.OrmLite
         public Func<IDbCommand, long> LastInsertIdFn { get; set; }
 
         public Action<string> SqlFilter { get; set; }
+        public Action<IDbCommand> SqlCommandFilter { get; set; }
+
         public bool PrintSql { get; set; }
 
         private readonly IOrmLiteResultsFilter previousFilter;
@@ -85,6 +87,11 @@ namespace ServiceStack.OrmLite
             if (SqlFilter != null)
             {
                 SqlFilter(dbCmd.CommandText);
+            }
+
+            if (SqlCommandFilter != null)
+            {
+                SqlCommandFilter(dbCmd);
             }
 
             if (PrintSql)
@@ -325,5 +332,43 @@ namespace ServiceStack.OrmLite
         }
 
         public List<string> SqlStatements { get; set; }
+    }
+
+    public class CaptureSqlCommandFilter : OrmLiteResultsFilter
+    {
+        public CaptureSqlCommandFilter()
+        {
+            SqlCommandFilter = CaptureSqlCommand;
+            SqlCommandHistory = new List<SqlCommandDetails>();
+        }
+
+        private void CaptureSqlCommand(IDbCommand command)
+        {
+            SqlCommandHistory.Add(new SqlCommandDetails(command));
+        }
+
+        public List<SqlCommandDetails> SqlCommandHistory { get; set; }
+    }
+
+    public class SqlCommandDetails
+    {
+        public SqlCommandDetails(IDbCommand command)
+        {
+            if (command != null)
+            {
+                Sql = command.CommandText;
+                if(command.Parameters.Count > 0)
+                {
+                    Parameters = new Dictionary<string, object>();
+
+                    foreach (IDataParameter parameter in command.Parameters)
+                        if (!Parameters.ContainsKey(parameter.ParameterName))
+                            Parameters.Add(parameter.ParameterName, parameter.Value);
+                }
+            }
+        }
+
+        public string Sql { get; set; }
+        public Dictionary<string, object> Parameters { get; set; }
     }
 }

--- a/tests/ServiceStack.OrmLite.Tests/CaptureSqlCommandFilterTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/CaptureSqlCommandFilterTests.cs
@@ -1,0 +1,286 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using ServiceStack.OrmLite.Tests.Shared;
+using ServiceStack.Text;
+
+namespace ServiceStack.OrmLite.Tests
+{
+    [TestFixture]
+    public class CaptureSqlCommandFilterTests
+        : OrmLiteTestBase
+    {
+        [Test]
+        public void Can_capture_command_each_type_of_API()
+        {
+            using (var captured = new CaptureSqlCommandFilter())
+            using (var db = OpenDbConnection())
+            {
+                db.CreateTable<Person>();
+                db.Select<Person>(x => x.Age > 40);
+                db.Single<Person>(x => x.Age == 42);
+                db.Count<Person>(x => x.Age < 50);
+                db.Insert(new Person { Id = 7, FirstName = "Amy", LastName = "Winehouse" });
+                db.Update(new Person { Id = 1, FirstName = "Jimi", LastName = "Hendrix" });
+                db.Delete<Person>(new { FirstName = "Jimi", Age = 27 });
+                db.SqlColumn<string>("SELECT LastName FROM Person WHERE Age < @age", 
+                    new { age = 50 });
+                db.SqlList<Person>("exec sp_name @firstName, @age", 
+                    new { firstName = "aName", age = 1 });
+                db.ExecuteNonQuery("UPDATE Person SET LastName={0} WHERE Id={1}"
+                    .SqlFmt("WaterHouse", 7));
+
+                captured.SqlCommandHistory.PrintDump();
+            }
+        }
+
+        [Test]
+        public void Can_capture_command_CreateTable_APIs()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropTable<Person>();
+            }
+
+            using (var captured = new CaptureSqlCommandFilter())
+            using (var db = OpenDbConnection())
+            {
+                int i = 0;
+                i++; db.CreateTable<Person>();
+
+                Assert.That(captured.SqlCommandHistory.Last().Sql.NormalizeSql(),
+                            Is.StringStarting("create table person"));
+
+                Assert.That(captured.SqlCommandHistory.Count, Is.EqualTo(i));
+
+                captured.SqlCommandHistory.PrintDump();
+
+            }
+        }
+
+        [Test]
+        public void Can_capture_command_Select_APIs()
+        {
+            using (var captured = new CaptureSqlCommandFilter())
+            using (var db = OpenDbConnection())
+            {
+                int i = 0;
+                i++; db.Select<Person>(x => x.Age > 40);
+
+                Assert.That(captured.SqlCommandHistory.Last().Sql.NormalizeSql(),
+                    Is.EqualTo("select id, firstname, lastname, age  from person where (age > 40)"));
+
+                i++; db.Select<Person>(q => q.Where(x => x.Age > 40));
+                i++; db.Select(db.From<Person>().Where(x => x.Age > 40));
+                i++; db.Select<Person>("Age > 40");
+                i++; db.Select<Person>("SELECT * FROM Person WHERE Age > 40");
+                i++; db.Select<Person>("Age > @age", new { age = 40 });
+                i++; db.Select<Person>("SELECT * FROM Person WHERE Age > @age", new { age = 40 });
+                i++; db.Select<Person>("Age > @age", new Dictionary<string, object> { { "age", 40 } });
+                i++; db.SelectFmt<Person>("Age > {0}", 40);
+                i++; db.SelectFmt<Person>("SELECT * FROM Person WHERE Age > {0}", 40);
+                i++; db.Where<Person>("Age", 27);
+                i++; db.Where<Person>(new { Age = 27 });
+                i++; db.SelectByIds<Person>(new[] { 1, 2, 3 });
+                i++; db.SelectByIds<Person>(new[] { 1, 2, 3 });
+                i++; db.SelectNonDefaults(new Person { Id = 1 });
+                i++; db.SelectNonDefaults("Age > @Age", new Person { Age = 40 });
+                i++; db.SelectLazy<Person>().ToList();
+                i++; db.WhereLazy<Person>(new { Age = 27 }).ToList();
+                i++; db.Select<Person>();
+                i++; db.Single<Person>(x => x.Age == 42);
+                i++; db.Single(db.From<Person>().Where(x => x.Age == 42));
+                i++; db.Single<Person>(new { Age = 42 });
+                i++; db.Single<Person>("Age = @age", new { age = 42 });
+                i++; db.SingleById<Person>(1);
+                i++; db.SingleWhere<Person>("Age", 42);
+                i++; db.Exists<Person>(new { Age = 42 });
+                i++; db.Exists<Person>("SELECT * FROM Person WHERE Age = @age", new { age = 42 });
+                i++; db.ExistsFmt<Person>("Age = {0}", 42);
+                i++; db.ExistsFmt<Person>("SELECT * FROM Person WHERE Age = {0}", 42);
+
+                Assert.That(captured.SqlCommandHistory.Count, Is.EqualTo(i));
+
+                captured.SqlCommandHistory.PrintDump();
+
+            }
+        }
+
+        [Test]
+        public void Can_capture_command_all_Single_Apis()
+        {
+            using (var captured = new CaptureSqlCommandFilter())
+            using (var db = OpenDbConnection())
+            {
+                int i = 0;
+                i++; db.Single<Person>(x => x.Age == 42);
+
+                Assert.That(captured.SqlCommandHistory.Last().Sql.NormalizeSql(),
+                    Is.EqualTo("select id, firstname, lastname, age  from person where (age = 42) limit 1").
+                    Or.EqualTo("select top 1 id, firstname, lastname, age  from person where (age = 42)"));
+
+                i++; db.ExistsFmt<Person>("Age = {0}", 42);
+                i++; db.Single(db.From<Person>().Where(x => x.Age == 42));
+                i++; db.Single<Person>(new { Age = 42 });
+                i++; db.Single<Person>("Age = @age", new { age = 42 });
+                i++; db.SingleFmt<Person>("Age = {0}", 42);
+                i++; db.SingleById<Person>(1);
+                i++; db.ExistsFmt<Person>("Age = {0}", 42);
+                i++; db.SingleWhere<Person>("Age", 42);
+
+                Assert.That(captured.SqlCommandHistory.Count, Is.EqualTo(i));
+
+                captured.SqlCommandHistory.PrintDump();
+
+            }
+        }
+
+        [Test]
+        public void Can_capture_command_all_Scalar_Apis()
+        {
+            using (var captured = new CaptureSqlCommandFilter())
+            using (var db = OpenDbConnection())
+            {
+                int i = 0;
+                i++; db.Scalar<Person, int>(x => Sql.Max(x.Age));
+
+                Assert.That(captured.SqlCommandHistory.Last().Sql.NormalizeSql(),
+                    Is.EqualTo("select max(age)  from person"));
+
+                i++; db.Scalar<Person, int>(x => Sql.Max(x.Age));
+                i++; db.Scalar<Person, int>(x => Sql.Max(x.Age), x => x.Age < 50);
+                i++; db.Count<Person>(x => x.Age < 50);
+                i++; db.Count(db.From<Person>().Where(x => x.Age < 50));
+                i++; db.Scalar<int>("SELECT COUNT(*) FROM Person WHERE Age > @age", new { age = 40 });
+                i++; db.ScalarFmt<int>("SELECT COUNT(*) FROM Person WHERE Age > {0}", 40);
+
+                i++; db.SqlScalar<int>("SELECT COUNT(*) FROM Person WHERE Age < @age", new { age = 50 });
+                i++; db.SqlScalar<int>("SELECT COUNT(*) FROM Person WHERE Age < @age", new Dictionary<string, object> { { "age", 50 } });
+
+                Assert.That(captured.SqlCommandHistory.Count, Is.EqualTo(i));
+
+                captured.SqlCommandHistory.PrintDump();
+
+            }
+        }
+
+
+        [Test]
+        public void Can_capture_command_Update_Apis()
+        {
+            using (var captured = new CaptureSqlCommandFilter())
+            using (var db = OpenDbConnection())
+            {
+                int i = 0;
+                i++; db.Update(new Person { Id = 1, FirstName = "Jimi", LastName = "Hendrix", Age = 27 });
+
+                Assert.That(captured.SqlCommandHistory.Last().Sql.NormalizeSql(),
+                    Is.StringStarting("update person set firstname=@firstname, lastname=@lastname"));
+
+                i++; db.Update(new[] { new Person { Id = 1, FirstName = "Jimi", LastName = "Hendrix", Age = 27 } });
+                i++; db.UpdateAll(new[] { new Person { Id = 1, FirstName = "Jimi", LastName = "Hendrix", Age = 27 } });
+                i++; db.Update(new Person { Id = 1, FirstName = "JJ", Age = 27 }, p => p.LastName == "Hendrix");
+                i++; db.Update<Person>(new { FirstName = "JJ" }, p => p.LastName == "Hendrix");
+                i++; db.UpdateNonDefaults(new Person { FirstName = "JJ" }, p => p.LastName == "Hendrix");
+                i++; db.UpdateOnly(new Person { FirstName = "JJ" }, p => p.FirstName);
+                i++; db.UpdateOnly(new Person { FirstName = "JJ" }, p => p.FirstName, p => p.LastName == "Hendrix");
+                i++; db.UpdateOnly(new Person { FirstName = "JJ", LastName = "Hendo" }, ev => ev.Update(p => p.FirstName));
+                i++; db.UpdateOnly(new Person { FirstName = "JJ" }, ev => ev.Update(p => p.FirstName).Where(x => x.FirstName == "Jimi"));
+                i++; db.UpdateFmt<Person>(set: "FirstName = {0}".SqlFmt("JJ"), where: "LastName = {0}".SqlFmt("Hendrix"));
+                i++; db.UpdateFmt(table: "Person", set: "FirstName = {0}".SqlFmt("JJ"), where: "LastName = {0}".SqlFmt("Hendrix"));
+
+                Assert.That(captured.SqlCommandHistory.Count, Is.EqualTo(i));
+
+                captured.SqlCommandHistory.PrintDump();
+
+            }
+        }
+
+        [Test]
+        public void Can_capture_command_Delete_Apis()
+        {
+            using (var captured = new CaptureSqlCommandFilter())
+            using (var db = OpenDbConnection())
+            {
+                int i = 0;
+                i++; db.Delete<Person>(new { FirstName = "Jimi", Age = 27 });
+
+                Assert.That(captured.SqlCommandHistory.Last().Sql.NormalizeSql(),
+                    Is.EqualTo("delete from person where firstname=@firstname and age=@age"));
+
+                i++; db.Delete<Person>(new { FirstName = "Jimi", Age = 27 });
+                i++; db.Delete(new Person { Id = 1, FirstName = "Jimi", LastName = "Hendrix", Age = 27 });
+                i++; db.DeleteNonDefaults(new Person { FirstName = "Jimi", Age = 27 });
+                i++; db.DeleteById<Person>(1);
+                i++; db.DeleteByIds<Person>(new[] { 1, 2, 3 });
+                i++; db.DeleteFmt<Person>("Age = {0}", 27);
+                i++; db.DeleteFmt(typeof(Person), "Age = {0}", 27);
+                i++; db.Delete<Person>(p => p.Age == 27);
+                i++; db.Delete<Person>(ev => ev.Where(p => p.Age == 27));
+                i++; db.Delete(db.From<Person>().Where(p => p.Age == 27));
+                i++; db.DeleteFmt<Person>(where: "Age = {0}".SqlFmt(27));
+                i++; db.DeleteFmt(table: "Person", where: "Age = {0}".SqlFmt(27));
+
+                Assert.That(captured.SqlCommandHistory.Count, Is.EqualTo(i));
+
+                captured.SqlCommandHistory.PrintDump();
+
+            }
+        }
+
+        [Test]
+        public void Can_capture_command_CustomSql_Apis()
+        {
+            using (var captured = new CaptureSqlCommandFilter())
+            using (var db = OpenDbConnection())
+            {
+                int i = 0;
+                i++; db.SqlColumn<string>("SELECT LastName FROM Person WHERE Age < @age", new { age = 50 });
+
+                Assert.That(captured.SqlCommandHistory.Last().Sql.NormalizeSql(),
+                    Is.EqualTo("select lastname from person where age < @age"));
+
+                i++; db.SqlColumn<string>("SELECT LastName FROM Person WHERE Age < @age", new { age = 50 });
+                i++; db.SqlColumn<string>("SELECT LastName FROM Person WHERE Age < @age", new Dictionary<string, object> { { "age", 50 } });
+                i++; db.SqlScalar<int>("SELECT COUNT(*) FROM Person WHERE Age < @age", new { age = 50 });
+                i++; db.SqlScalar<int>("SELECT COUNT(*) FROM Person WHERE Age < @age", new Dictionary<string, object> { { "age", 50 } });
+
+                i++; db.ExecuteNonQuery("UPDATE Person SET LastName={0} WHERE Id={1}".SqlFmt("WaterHouse", 7));
+                i++; db.ExecuteNonQuery("UPDATE Person SET LastName=@name WHERE Id=@id", new { name = "WaterHouse", id = 7 });
+
+                i++; db.SqlList<Person>("exec sp_name @firstName, @age", new { firstName = "aName", age = 1 });
+                i++; db.SqlScalar<Person>("exec sp_name @firstName, @age", new { firstName = "aName", age = 1 });
+
+                Assert.That(captured.SqlCommandHistory.Count, Is.EqualTo(i));
+
+                captured.SqlCommandHistory.PrintDump();
+
+            }
+        }
+
+        [Test]
+        public void Can_capture_command_Insert_Apis()
+        {
+            using (var captured = new CaptureSqlCommandFilter())
+            using (var db = OpenDbConnection())
+            {
+                int i = 0;
+                i++; db.Insert(new Person { Id = 7, FirstName = "Amy", LastName = "Winehouse", Age = 27 });
+
+                Assert.That(captured.SqlCommandHistory.Last().Sql.NormalizeSql(),
+                    Is.StringStarting("insert into person (id,firstname,lastname,age) values"));
+
+                i++; db.Insert(new Person { Id = 7, FirstName = "Amy", LastName = "Winehouse", Age = 27 });
+                i++; db.InsertAll(new[] { new Person { Id = 10, FirstName = "Biggie", LastName = "Smalls", Age = 24 } });
+                i++; db.InsertOnly(new PersonWithAutoId { FirstName = "Amy", Age = 27 }, ev => ev.Insert(p => new { p.FirstName, p.Age }));
+                i++; db.InsertOnly(new PersonWithAutoId { FirstName = "Amy", Age = 27 }, ev => db.From<PersonWithAutoId>().Insert(p => new { p.FirstName, p.Age }));
+
+                Assert.That(captured.SqlCommandHistory.Count, Is.EqualTo(i));
+
+                captured.SqlCommandHistory.PrintDump();
+
+            }
+        }
+
+    }
+}

--- a/tests/ServiceStack.OrmLite.Tests/MockAllApiTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/MockAllApiTests.cs
@@ -132,9 +132,11 @@ namespace ServiceStack.OrmLite.Tests
         public void Can_trace_all_generated_sql()
         {
             var sqlStatements = new List<string>();
+            var sqlCommandStatements = new List<SqlCommandDetails>();
             using (new OrmLiteResultsFilter
             {
                 SqlFilter = sql => sqlStatements.Add(sql),
+                SqlCommandFilter = sql => sqlCommandStatements.Add(new SqlCommandDetails(sql)),
                 ResultsFn = (dbCmd, type) => new[] { new Person { Id = 1, FirstName = "Mocked", LastName = "Person", Age = 100 } },
                 SingleResultFn = (dbCmd, type) => new Person { Id = 1, FirstName = "MockedSingle", LastName = "Person", Age = 100 },
                 ScalarResultFn = (dbCmd, type) => 1000,
@@ -145,9 +147,12 @@ namespace ServiceStack.OrmLite.Tests
                 Assert.That(db.Single<Person>(x => x.Age == 42).FirstName, Is.EqualTo("MockedSingle"));
 
                 Assert.That(db.Scalar<Person, int>(x => Sql.Max(x.Age)), Is.EqualTo(1000));
+                
+                Assert.That(sqlStatements.Count, Is.EqualTo(3));
+                Assert.That(sqlCommandStatements.Count, Is.EqualTo(3));
 
                 sqlStatements.Each(x => x.Print());
-                Assert.That(sqlStatements.Count, Is.EqualTo(3));
+                sqlCommandStatements.Each(x => x.PrintDump());
             }
         }
 
@@ -311,26 +316,34 @@ namespace ServiceStack.OrmLite.Tests
             //we count the number of sql statements generated instead.
 
             var sqlStatements = new List<string>();
+            var sqlCommandStatements = new List<SqlCommandDetails>();
             using (new OrmLiteResultsFilter
             {
                 SqlFilter = sql => sqlStatements.Add(sql),
+                SqlCommandFilter = sql => sqlCommandStatements.Add(new SqlCommandDetails(sql)),
             })
             {
                 int i = 0;
 
                 i++; db.Insert(new Person { Id = 7, FirstName = "Amy", LastName = "Winehouse", Age = 27 });
                 Assert.That(sqlStatements.Count, Is.EqualTo(i));
+                Assert.That(sqlCommandStatements.Count, Is.EqualTo(i));
+
 
                 i++; db.InsertAll(new[] { new Person { Id = 10, FirstName = "Biggie", LastName = "Smalls", Age = 24 } });
                 Assert.That(sqlStatements.Count, Is.EqualTo(i));
+                Assert.That(sqlCommandStatements.Count, Is.EqualTo(i));
 
                 i++; db.InsertOnly(new PersonWithAutoId { FirstName = "Amy", Age = 27 }, ev => ev.Insert(p => new { p.FirstName, p.Age }));
                 Assert.That(sqlStatements.Count, Is.EqualTo(i));
+                Assert.That(sqlCommandStatements.Count, Is.EqualTo(i));
 
                 i++; db.InsertOnly(new PersonWithAutoId { FirstName = "Amy", Age = 27 }, ev => db.From<PersonWithAutoId>().Insert(p => new { p.FirstName, p.Age }));
                 Assert.That(sqlStatements.Count, Is.EqualTo(i));
+                Assert.That(sqlCommandStatements.Count, Is.EqualTo(i));
 
                 sqlStatements.Each(x => x.Print());
+                sqlCommandStatements.Each(x => x.PrintDump());
 
             }
         }
@@ -342,28 +355,36 @@ namespace ServiceStack.OrmLite.Tests
             //we count the number of sql statements generated instead.
 
             var sqlStatements = new List<string>();
+            var sqlCommandStatements = new List<SqlCommandDetails>();
             using (new OrmLiteResultsFilter
             {
                 SingleResult = new Person { Id = 1, FirstName = "Mocked", LastName = "Person", Age = 100 },
                 SqlFilter = sql => sqlStatements.Add(sql),
+                SqlCommandFilter = sql => sqlCommandStatements.Add(new SqlCommandDetails(sql)),
             })
             {
                 int i = 0;
 
                 //Force Insert by returning null for existingRow
-                using (new OrmLiteResultsFilter { SqlFilter = sql => sqlStatements.Add(sql) })
+                using (new OrmLiteResultsFilter {   
+                    SqlFilter = sql => sqlStatements.Add(sql),
+                    SqlCommandFilter = sql => sqlCommandStatements.Add(new SqlCommandDetails(sql))
+                })
                 {
                     i += 2; db.Save(new Person { Id = 11, FirstName = "Amy", LastName = "Winehouse", Age = 27 }); //1 Read + 1 Insert
                 }
 
                 i += 2; db.Save(new Person { Id = 11, FirstName = "Amy", LastName = "Winehouse", Age = 27 }); //1 Read + 1 Update
                 Assert.That(sqlStatements.Count, Is.EqualTo(i));
+                Assert.That(sqlCommandStatements.Count, Is.EqualTo(i));
 
                 i += 3; db.SaveAll(new[]{ new Person { Id = 14, FirstName = "Amy", LastName = "Winehouse", Age = 27 },
                                         new Person { Id = 15, FirstName = "Amy", LastName = "Winehouse", Age = 27 } }); //1 Read + 2 Update
                 Assert.That(sqlStatements.Count, Is.EqualTo(i));
+                Assert.That(sqlCommandStatements.Count, Is.EqualTo(i));
 
                 sqlStatements.Each(x => x.Print());
+                sqlCommandStatements.Each(x => x.PrintDump());
             }
         }
 
@@ -388,9 +409,11 @@ namespace ServiceStack.OrmLite.Tests
             };
 
             var sqlStatements = new List<string>();
+            var sqlCommandStatements = new List<SqlCommandDetails>();
             using (new OrmLiteResultsFilter
-                {
+            {
                     SqlFilter = sql => sqlStatements.Add(sql),
+                SqlCommandFilter = sql => sqlCommandStatements.Add(new SqlCommandDetails(sql)),
                     SingleResult = customer,
                     RefSingleResultFn = (dbCmd, refType) => customer.PrimaryAddress,
                     RefResultsFn = (dbCmd, refType) => customer.Orders,
@@ -405,14 +428,18 @@ namespace ServiceStack.OrmLite.Tests
 
                 i += 1; db.SaveReferences(customer, customer.PrimaryAddress);
                 Assert.That(sqlStatements.Count, Is.EqualTo(i));
+                Assert.That(sqlCommandStatements.Count, Is.EqualTo(i));
 
                 i += 2; db.SaveReferences(customer, customer.Orders);
                 Assert.That(sqlStatements.Count, Is.EqualTo(i));
+                Assert.That(sqlCommandStatements.Count, Is.EqualTo(i));
 
                 i += 3; var dbCustomer = db.LoadSingleById<Customer>(customer.Id);
                 Assert.That(sqlStatements.Count, Is.EqualTo(i));
+                Assert.That(sqlCommandStatements.Count, Is.EqualTo(i));
 
                 sqlStatements.Each(x => x.Print());
+                sqlCommandStatements.Each(x => x.PrintDump());
             }
         }
 

--- a/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
+++ b/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
@@ -117,6 +117,7 @@
     <Compile Include="AdoNetDataAccessTests.cs" />
     <Compile Include="ApiSqlServerTests.cs" />
     <Compile Include="ApiSqliteTests.cs" />
+    <Compile Include="CaptureSqlCommandFilterTests.cs" />
     <Compile Include="CaptureSqlFilterTests.cs" />
     <Compile Include="CompositeKeyTests.cs" />
     <Compile Include="CustomSqlTests.cs" />


### PR DESCRIPTION
OrmLiteResultsFilter now has a SqlCommandFilter action similar to
SqlFilter. This allows you to filter on the actual SqlCommand instead of
just the sql statement itself. This can be useful especially if you are
trying to troubleshoot the values that are being inserted as parameters.

I created a basic result filter similar to the existing CaptureSqlFilter
called CaptureSqlCommandFilter. This attempts to preserve the command data
as a new SqlCommandDetails object with parameter values stored in a
Dictionary along with the Sql string.

I created unit tests for the SqlCommandFilter similar to those for
SqlFilter and added similar checks for existing tests that use SqlFilter.

--

This is a product of me digging into OrmLite to discover why SqlGeography
types weren't being inserted into the database. I've build this
SqlCommandFilter as an alternative to the debugging that I did to track
down my issue, hopefully this will help someone in the future figuring out
exactly what values are being added to the IDbCommand parameters.