### PR TITLE
fixes for oracle provider

### DIFF
--- a/src/ServiceStack.OrmLite/Expressions/ParameterizedSqlExpression.cs
+++ b/src/ServiceStack.OrmLite/Expressions/ParameterizedSqlExpression.cs
@@ -59,7 +59,7 @@ namespace ServiceStack.OrmLite
             ConvertToPlaceholderAndParameter(ref right);
         }
 
-        protected virtual void OnVisitMemberType(Type modelType)
+        protected override void OnVisitMemberType(Type modelType)
         {
             var tableDef = modelType.GetModelDefinition();
             if (tableDef != null)

--- a/tests/ServiceStack.OrmLite.Tests/CaptureSqlFilterTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/CaptureSqlFilterTests.cs
@@ -69,7 +69,8 @@ namespace ServiceStack.OrmLite.Tests
                 i++; db.Select<Person>(x => x.Age > 40);
 
                 Assert.That(captured.SqlStatements.Last().NormalizeSql(),
-                    Is.EqualTo("select id, firstname, lastname, age  from person where (age > 40)"));
+                    Is.EqualTo("select id, firstname, lastname, age  from person where (age > 40)").
+                    Or.EqualTo("select id, firstname, lastname, age  from person where (age > @0)"));
 
                 i++; db.Select<Person>(q => q.Where(x => x.Age > 40));
                 i++; db.Select(db.From<Person>().Where(x => x.Age > 40));
@@ -120,7 +121,9 @@ namespace ServiceStack.OrmLite.Tests
                     Is.EqualTo("select id, firstname, lastname, age  from person where (age = 42) limit 1").
                     Or.EqualTo("select top 1 id, firstname, lastname, age  from person where (age = 42)").
                     Or.EqualTo("select id, firstname, lastname, age  from person where (age = 42) order by 1 offset 0 rows fetch next 1 rows only"). //VistaDB
-                    Or.EqualTo("select * from (\r select ssormlite1.*, rownum rnum from (\r select id, firstname, lastname, age  from person where (age = 42) order by person.id) ssormlite1\r where rownum <= 0 + 1) ssormlite2 where ssormlite2.rnum > 0")); //Oracle
+                    Or.EqualTo("select * from (\r select ssormlite1.*, rownum rnum from (\r select id, firstname, lastname, age  from person where (age = 42) order by person.id) ssormlite1\r where rownum <= 0 + 1) ssormlite2 where ssormlite2.rnum > 0").  //Oracle
+                    Or.EqualTo("select * from (\r select ssormlite1.*, rownum rnum from (\r select id, firstname, lastname, age  from person where (age = @0) order by person.id) ssormlite1\r where rownum <= 0 + 1) ssormlite2 where ssormlite2.rnum > 0")   //Oracle with UseParameterizeSqlExpressions
+                    );
 
                 i++; db.ExistsFmt<Person>("Age = {0}", 42);
                 i++; db.Single(db.From<Person>().Where(x => x.Age == 42));

--- a/tests/ServiceStack.OrmLite.Tests/Expression/SqlExpressionTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Expression/SqlExpressionTests.cs
@@ -35,6 +35,17 @@ namespace ServiceStack.OrmLite.Tests.Expression
 
     public class SqlExpressionTests : ExpressionsTestBase
     {
+        private int letterFrequenceMaxId;
+        private int letterFrequencyMinId;
+        private int letterFrequencySumId;
+
+        private void GetIdStats(IDbConnection db)
+        {
+            letterFrequenceMaxId = db.Scalar<int>(db.From<LetterFrequency>().Select(Sql.Max("Id")));
+            letterFrequencyMinId = db.Scalar<int>(db.From<LetterFrequency>().Select(Sql.Min("Id")));
+            letterFrequencySumId = db.Scalar<int>(db.From<LetterFrequency>().Select(Sql.Sum("Id")));
+        }
+
         public static void InitLetters(IDbConnection db)
         {
             db.DropAndCreateTable<LetterFrequency>();
@@ -96,6 +107,7 @@ namespace ServiceStack.OrmLite.Tests.Expression
             using (var db = OpenDbConnection())
             {
                 InitLetters(db);
+                GetIdStats(db);
 
                 var query = db.From<LetterFrequency>()
                   .Select("COUNT(*), MAX(Id), MIN(Id), Sum(Id)");
@@ -107,10 +119,10 @@ namespace ServiceStack.OrmLite.Tests.Expression
                 Assert.That(results.Count, Is.EqualTo(1));
 
                 var result = results[0];
-                Assert.That(result[0], Is.EqualTo(10));
-                Assert.That(result[1], Is.EqualTo(10));
-                Assert.That(result[2], Is.EqualTo(1));
-                Assert.That(result[3], Is.EqualTo(55));
+                Assert.That(Convert.ToInt64(result[0]), Is.EqualTo(10));
+                Assert.That(Convert.ToInt64(result[1]), Is.EqualTo(letterFrequenceMaxId));
+                Assert.That(Convert.ToInt64(result[2]), Is.EqualTo(letterFrequencyMinId));
+                Assert.That(Convert.ToInt64(result[3]), Is.EqualTo(letterFrequencySumId));
 
                 results.PrintDump();
             }
@@ -122,9 +134,10 @@ namespace ServiceStack.OrmLite.Tests.Expression
             using (var db = OpenDbConnection())
             {
                 InitLetters(db);
+                GetIdStats(db);
 
                 var query = db.From<LetterFrequency>()
-                  .Select("COUNT(*) Count, MAX(Id) Max, MIN(Id) Min, Sum(Id) Sum");
+                  .Select("COUNT(*) \"Count\", MAX(Id) \"Max\", MIN(Id) \"Min\", Sum(Id) \"Sum\"");
 
                 query.ToSelectStatement().Print();
 
@@ -133,10 +146,10 @@ namespace ServiceStack.OrmLite.Tests.Expression
                 Assert.That(results.Count, Is.EqualTo(1));
 
                 var result = results[0];
-                Assert.That(result["Count"], Is.EqualTo(10));
-                Assert.That(result["Max"], Is.EqualTo(10));
-                Assert.That(result["Min"], Is.EqualTo(1));
-                Assert.That(result["Sum"], Is.EqualTo(55));
+                Assert.That(Convert.ToInt64(result["Count"]), Is.EqualTo(10));
+                Assert.That(Convert.ToInt64(result["Max"]), Is.EqualTo(letterFrequenceMaxId));
+                Assert.That(Convert.ToInt64(result["Min"]), Is.EqualTo(letterFrequencyMinId));
+                Assert.That(Convert.ToInt64(result["Sum"]), Is.EqualTo(letterFrequencySumId));
 
                 results.PrintDump();
             }

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteExecFilterTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteExecFilterTests.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Linq;
 using NUnit.Framework;
 using ServiceStack.Common.Tests.Models;
+using ServiceStack.OrmLite.Tests.Expression;
 using ServiceStack.OrmLite.Tests.Shared;
 using ServiceStack.Text;
 
@@ -120,11 +121,11 @@ namespace ServiceStack.OrmLite.Tests
 
             using (var db = OpenDbConnection())
             {
-                db.DropAndCreateTable<Poco>();
+                db.DropAndCreateTable<ModelWithIdAndName>();
 
-                db.Insert(new Poco { Name = null });
-                var row = db.Select<Poco>().First();
-                
+                db.Insert(new ModelWithIdAndName { Name = null });
+                var row = db.Select<ModelWithIdAndName>().First();
+
                 Assert.That(row.Name, Is.EqualTo("NULL"));
             }
 


### PR DESCRIPTION
first commit is a small fix for the refactoring into ParameterizedSqlExpression
second commit contains fixes for some unit tests (mostly unrelated to parameterization) that were failing for oracle