### PR TITLE
Added new static method Sql.InExpression to support sub-query SqlExpressions

### DIFF
--- a/src/ServiceStack.OrmLite.Sqlite/SqliteExpression.cs
+++ b/src/ServiceStack.OrmLite.Sqlite/SqliteExpression.cs
@@ -45,14 +45,13 @@ namespace ServiceStack.OrmLite.Sqlite
             args.RemoveAt(0);
 
             var statement = "";
+            var member = Expression.Convert(m.Arguments[1], typeof(object));
+            var lambda = Expression.Lambda<Func<object>>(member);
+            var getter = lambda.Compile();
 
             switch (m.Method.Name)
             {
                 case "In":
-                    var member = Expression.Convert(m.Arguments[1], typeof(object));
-                    var lambda = Expression.Lambda<Func<object>>(member);
-                    var getter = lambda.Compile();
-
                     var inArgs = Sql.Flatten(getter() as IEnumerable);
 
                     var sIn = new StringBuilder();
@@ -63,6 +62,12 @@ namespace ServiceStack.OrmLite.Sqlite
                             base.DialectProvider.GetQuotedValue(e, e.GetType()));
                     }
                     statement = string.Format("{0} {1} ({2})", quotedColName, m.Method.Name, sIn);
+                    break;
+                case "InExpression":
+                    var sqlExpression = getter() as ISqlExpression;
+                    var subSelect = sqlExpression.ToSelectStatement();
+
+                    statement = string.Format("{0} {1} ({2})", quotedColName, "IN", subSelect);
                     break;
                 case "Desc":
                     statement = string.Format("{0} DESC", quotedColName);

--- a/src/ServiceStack.OrmLite/Expressions/Sql.cs
+++ b/src/ServiceStack.OrmLite/Expressions/Sql.cs
@@ -11,6 +11,11 @@ namespace ServiceStack.OrmLite
             return value != null && Flatten(list).Any(obj => obj.ToString() == value.ToString());
         }
 
+        public static bool InExpression<T, TItem>(T value, SqlExpression<TItem> query)
+        {
+            return value != null && query != null;
+        }
+
         public static List<object> Flatten(IEnumerable list)
         {
             var ret = new List<object>();

--- a/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
@@ -1492,14 +1492,13 @@ namespace ServiceStack.OrmLite
 
             string statement;
 
+            var member = Expression.Convert(m.Arguments[1], typeof(object));
+            var lambda = Expression.Lambda<Func<object>>(member);
+            var getter = lambda.Compile();
+
             switch (m.Method.Name)
             {
                 case "In":
-
-                    var member = Expression.Convert(m.Arguments[1], typeof(object));
-                    var lambda = Expression.Lambda<Func<object>>(member);
-                    var getter = lambda.Compile();
-
                     var inArgs = Sql.Flatten(getter() as IEnumerable);
 
                     var sIn = new StringBuilder();
@@ -1527,6 +1526,14 @@ namespace ServiceStack.OrmLite
 
                     statement = string.Format("{0} {1} ({2})", quotedColName, m.Method.Name, sIn.ToString());
                     break;
+
+                case "InExpression":
+                    var sqlExpression = getter() as ISqlExpression;
+                    var subSelect = sqlExpression.ToSelectStatement();
+
+                    statement = string.Format("{0} {1} ({2})", quotedColName, "IN", subSelect);
+                    break;
+
                 case "Desc":
                     statement = string.Format("{0} DESC", quotedColName);
                     break;


### PR DESCRIPTION
Allows much more robust Select filtering.  Sub-expression must return a single column.

Can use like this:

    var customersSubFilter = db.From<Customer>().Select(c => c.Id);
    var orderQuery = db.From<Order>().Where(q => Sql.InExpression(q.CustomerId, customersSubFilter));
    var dbOrders = db.Select(orderQuery);

To generate SQL like this:

    SELECT * FROM Orders WHERE CustomerId IN (SELECT Id From Customers)