### PR TITLE
issue with SqlServerDialectProvider CustomSelect with dots and commas and paging

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
@@ -403,8 +403,7 @@ namespace ServiceStack.OrmLite.SqlServer
             }
 
             var ret = string.Format(
-                "{0} FROM (SELECT ROW_NUMBER() OVER ({2}) As RowNum, {1} {3}) AS RowConstrainedResult WHERE RowNum > {4} AND RowNum <= {5}",
-                UseAliasesOrStripTablePrefixes(selectExpression), 
+                "SELECT * FROM (SELECT {0}, ROW_NUMBER() OVER ({1}) As RowNum {2}) AS RowConstrainedResult WHERE RowNum > {3} AND RowNum <= {4}",
                 selectExpression.Substring(selectType.Length),
                 orderByExpression,
                 bodyExpression,

--- a/src/ServiceStack.OrmLite.SqlServerTests/Issues/CustomSelectWithPagingIssue.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/Issues/CustomSelectWithPagingIssue.cs
@@ -1,0 +1,41 @@
+﻿using NUnit.Framework;
+using ServiceStack.Text;
+
+namespace ServiceStack.OrmLite.SqlServerTests.Issues
+{
+    public class SimpleModel
+    {
+        public int Id { get; set; }
+        public int Foo { get; set; }
+        public int Bar { get; set; }
+    }
+
+    [TestFixture]
+    public class CustomSelectWithPagingIssue
+        : OrmLiteTestBase
+    {
+        [Test]
+        public void Can_CustomSelect_With_Paging()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<SimpleModel>();
+
+                db.InsertAll(new[] {
+                    new SimpleModel { Id = 1, Foo = 1, Bar = 42 },
+                    new SimpleModel { Id = 2, Foo = 2, Bar = 55 },
+                });
+
+                var q = db.From<SimpleModel>()
+                    .UnsafeSelect("SimpleModel.Id, CASE WHEN Foo IN (1,3) THEN 1 ELSE 0 END AS Foo, Bar")
+                    .Take(1)
+                    .Skip(1);
+
+                var result = db.Select<SimpleModel>(q);
+                db.GetLastSql().Print();
+
+                Assert.That(result.Count, Is.EqualTo(1));
+            }
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
+++ b/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="DateTimeOffsetTests.cs" />
     <Compile Include="EnsureUtcTest.cs" />
     <Compile Include="InsertParam_GetLastInsertId.cs" />
+    <Compile Include="Issues\CustomSelectWithPagingIssue.cs" />
     <Compile Include="Issues\SerializationTests.cs" />
     <Compile Include="NestedTransactions.cs" />
     <Compile Include="EnumTests.cs" />


### PR DESCRIPTION
UseAliasesOrStripTablePrefixes function in SqlServerOrmLiteDialectProvider is not handling well custom selects with commas in it, eg ( SELECT DATEADD(d,1,GETDATE()) AS tommorow, CASE WHEN foo IN (1,2) THEN ...). It breaks the sql. 
Simple solution is to use all fields from subquery (with additional RowNum field last as last). That makes UseAliasesOrStripTablePrefixes obsolete.