### PR TITLE
to be consistent with base method and what the method name implies, O…

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
@@ -300,9 +300,6 @@ namespace ServiceStack.OrmLite.Oracle
 
         public override object GetParamValue(object value, Type fieldType)
         {
-            if (!OrmLiteConfig.UseParameterizeSqlExpressions)
-                return GetQuotedValue(value, fieldType);
-
             if (value == null) return DBNull.Value;
 
             if (fieldType == typeof(Guid))

--- a/src/ServiceStack.OrmLite/Expressions/ParameterizedSqlExpression.cs
+++ b/src/ServiceStack.OrmLite/Expressions/ParameterizedSqlExpression.cs
@@ -34,7 +34,7 @@ namespace ServiceStack.OrmLite
 
         public override object GetValue(object value, Type type)
         {
-            return SkipParameterizationForThisExpression
+            return ((!OrmLiteConfig.UseParameterizeSqlExpressions) || SkipParameterizationForThisExpression)
                 ? DialectProvider.GetQuotedValue(value, type)
                 : DialectProvider.GetParamValue(value, type);
         }


### PR DESCRIPTION
…racleDialectProvider's

GetParameterValue method should not return quoted values.  move logic for returning either bare or
quoted values into the GetValue method.