### PR TITLE
Added test project demoing the use of Spatials

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServerSpatialsTest/Properties/AssemblyInfo.cs
+++ b/src/ServiceStack.OrmLite.SqlServerSpatialsTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ServiceStack.OrmLite.SqlServerTests.Spatials")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("ServiceStack")]
+[assembly: AssemblyProduct("ServiceStack.OrmLite.SqlServerTests.Spatials")]
+[assembly: AssemblyCopyright("Copyright © ServiceStack 2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2b366503-ecfc-4783-afb6-900f1364ea7b")]
+

--- a/src/ServiceStack.OrmLite.SqlServerSpatialsTest/ServiceStack.OrmLite.SqlServerTests.Spatials.csproj
+++ b/src/ServiceStack.OrmLite.SqlServerSpatialsTest/ServiceStack.OrmLite.SqlServerTests.Spatials.csproj
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{2B366503-ECFC-4783-AFB6-900F1364EA7B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ServiceStack.OrmLite.SqlServerTests.Spatials</RootNamespace>
+    <AssemblyName>ServiceStack.OrmLite.SqlServerTests.Spatials</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Signed|AnyCPU'">
+    <OutputPath>bin\Signed\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.SqlServer.Types, Version=11.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.SqlServer.Types.11.0.2\lib\net20\Microsoft.SqlServer.Types.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework">
+      <HintPath>..\..\lib\tests\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.Client">
+      <HintPath>..\..\lib\ServiceStack.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.Common">
+      <HintPath>..\..\lib\ServiceStack.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.Interfaces">
+      <HintPath>..\..\lib\ServiceStack.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.Text">
+      <HintPath>..\..\lib\ServiceStack.Text.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="SqlServerSpatialsOrmLiteTestBase.cs" />
+    <Compile Include="SqlServerSpatialsTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SqlServerGeographyTypeConverter.cs" />
+    <Compile Include="SqlServerGeometryTypeConverter.cs" />
+    <Compile Include="SqlServerTypes\Loader.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ServiceStack.OrmLite.SqlServer\ServiceStack.OrmLite.SqlServer.csproj">
+      <Project>{1887DC99-9139-43E3-A7AA-6D74714B3A5D}</Project>
+      <Name>ServiceStack.OrmLite.SqlServer</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ServiceStack.OrmLite\ServiceStack.OrmLite.csproj">
+      <Project>{96179AC6-F6F1-40C3-9FDD-4F6582F54C5C}</Project>
+      <Name>ServiceStack.OrmLite</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="SqlServerTypes\readme.htm" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="SqlServerTypes\x64\" />
+    <Folder Include="SqlServerTypes\x86\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/ServiceStack.OrmLite.SqlServerSpatialsTest/SqlServerGeographyTypeConverter.cs
+++ b/src/ServiceStack.OrmLite.SqlServerSpatialsTest/SqlServerGeographyTypeConverter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Data;
+using ServiceStack.OrmLite;
+
+namespace ServiceStack.OrmLite.SqlServer.Converters
+{
+    public class SqlServerGeographyTypeConverter : OrmLiteConverter
+    {
+        public override string ColumnDefinition
+        {
+            get { return "GEOGRAPHY"; }
+        }
+
+        public override DbType DbType
+        {
+            get { return DbType.Object; }
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServerSpatialsTest/SqlServerGeometryTypeConverter.cs
+++ b/src/ServiceStack.OrmLite.SqlServerSpatialsTest/SqlServerGeometryTypeConverter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Data;
+using ServiceStack.OrmLite;
+
+namespace ServiceStack.OrmLite.SqlServer.Converters
+{
+    public class SqlServerGeometryTypeConverter : OrmLiteConverter
+    {
+        public override string ColumnDefinition
+        {
+            get { return "GEOMETRY"; }
+        }
+
+        public override DbType DbType
+        {
+            get { return DbType.Object; }
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServerSpatialsTest/SqlServerSpatialsOrmLiteTestBase.cs
+++ b/src/ServiceStack.OrmLite.SqlServerSpatialsTest/SqlServerSpatialsOrmLiteTestBase.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Configuration;
+using System.Data;
+using System.Data.SqlClient;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+using Microsoft.SqlServer.Types;
+using ServiceStack.Logging;
+using ServiceStack.OrmLite.SqlServer;
+using ServiceStack.OrmLite.SqlServer.Converters;
+
+namespace ServiceStack.OrmLite.SqlServerTests.Spatials
+{
+    public class SqlServerSpatialsOrmLiteTestBase
+    {
+        protected virtual string ConnectionString { get; set; }
+
+        public IDbConnection Db { get; set; }
+
+        [TestFixtureSetUp]
+        public void TestFixtureSetUp()
+        {
+            try
+            {
+                LogManager.LogFactory = new ConsoleLogFactory();
+
+                // Get the appropriate Windows System Path
+                //  32-bit: C:\Windows\System32
+                //  64-bit: C:\Windows\SysWOW64
+                var systemPathEnum = (!Environment.Is64BitProcess)
+                        ? Environment.SpecialFolder.SystemX86
+                        : Environment.SpecialFolder.System;
+                
+                var systemPath = Environment.GetFolderPath(systemPathEnum);
+
+                // Add directory separator character if needed
+                if (!systemPath.EndsWith(System.IO.Path.DirectorySeparatorChar.ToString()))
+                {
+                    systemPath += System.IO.Path.DirectorySeparatorChar;
+                }
+
+                // The versions of the files must match the version associated with Sql Server
+                // These files can been installed from the Microsoft SQL Server Feature Pack 
+                // 
+                // SQL Server 2008: https://www.microsoft.com/en-us/download/details.aspx?id=44277
+                // SQL Server 2008 R2: https://www.microsoft.com/en-us/download/details.aspx?id=44272
+                // SQL Server 2012 SP2: http://www.microsoft.com/en-us/download/details.aspx?id=43339
+                // SQL Server 2014 SP1: https://www.microsoft.com/en-us/download/details.aspx?id=46696
+                LoadUnmanagedAssembly(systemPath, "msvcr100.dll");
+                LoadUnmanagedAssembly(systemPath, "SqlServerSpatial110.dll");
+
+                // Appending the Sql Server Type System Version to use SqlServerSpatial110.dll (2012) assembly
+                // Sql Server defaults to SqlServerSpatial100.dll (2008 R2) even for versions greater
+                // https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlconnection.connectionstring.aspx
+                ConnectionString = ConfigurationManager.ConnectionStrings["testDb"].ConnectionString + ";Type System Version=SQL Server 2012;";
+
+                var dialectProvider = new SqlServer2012SpatialsDialectProvider();
+                dialectProvider.RegisterConverter<SqlGeography>(new SqlServerGeographyTypeConverter());
+                dialectProvider.RegisterConverter<SqlGeometry>(new SqlServerGeometryTypeConverter());
+
+                Db = new OrmLiteConnection(new OrmLiteConnectionFactory(ConnectionString, dialectProvider));                
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+        }
+
+        public void Log(string text)
+        {
+            Console.WriteLine(text);
+        }
+
+        public virtual IDbConnection OpenDbConnection(string connString = null)
+        {
+            connString = connString ?? ConnectionString;
+            return connString.OpenDbConnection();
+        }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern IntPtr LoadLibrary(string libname);
+
+        private static void LoadUnmanagedAssembly(string path, string assemblyName)
+        {
+            path += assemblyName;
+            var ptr = LoadLibrary(path);
+            if (ptr == IntPtr.Zero)
+            {
+                throw new Exception(string.Format(
+                    "Error loading {0} (ErrorCode: {1})",
+                    assemblyName,
+                    Marshal.GetLastWin32Error()));
+            }
+        }
+
+    }
+
+    public class SqlServer2012SpatialsDialectProvider : SqlServer2012OrmLiteDialectProvider
+    {
+        public override void SetParameter(FieldDefinition fieldDef, IDbDataParameter p)
+        {
+            base.SetParameter(fieldDef, p);
+
+            if (fieldDef.ColumnType == typeof(SqlGeography) || fieldDef.ColumnType == typeof(SqlGeometry))
+            {
+                var geogParam = (SqlParameter)p;
+                geogParam.SqlDbType = SqlDbType.Udt;
+                geogParam.UdtTypeName = fieldDef.CustomFieldDefinition ?? Converters[fieldDef.ColumnType].ColumnDefinition;
+            }
+            else
+            {
+                ((SqlParameter)p).SqlDbType = GetSqlDbType(p.DbType);
+            }            
+        }
+
+        public SqlDbType GetSqlDbType(DbType dbType)
+        {
+            return (SqlDbType)Enum.Parse(typeof(DbType), dbType.ToString());
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServerSpatialsTest/SqlServerSpatialsTest.cs
+++ b/src/ServiceStack.OrmLite.SqlServerSpatialsTest/SqlServerSpatialsTest.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using NUnit.Framework;
+using Microsoft.SqlServer.Types;
+using ServiceStack.DataAnnotations;
+using ServiceStack.OrmLite.SqlServer;
+
+namespace ServiceStack.OrmLite.SqlServerTests.Spatials
+{
+    [TestFixture]
+    public class SqlServerSpatialTests : SqlServerSpatialsOrmLiteTestBase
+    {
+        [SetUp]
+        public void Setup()
+        {
+            OpenDbConnection().CreateTable<GeoTestTable>(true);
+        }
+
+        // Avoid painful refactor to change all tests to use a using pattern
+        private IDbConnection db;
+
+        public override IDbConnection OpenDbConnection(string connString = null)
+        {
+            if (db != null && db.State != ConnectionState.Open)
+                db = null;
+
+            return db ?? (db = base.OpenDbConnection(connString));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (db == null)
+                return;
+            db.Dispose();
+            db = null;
+        }
+
+
+        [Test]
+        public void Can_insert_and_retrieve_SqlGeography()
+        {
+            using (var db = OpenDbConnection())
+            {
+                // Statue of Liberty
+                var geo = SqlGeography.Point(40.6898329,-74.0452177, 4326);
+
+                db.Insert(new GeoTestTable() { Location = geo });
+
+                var result = db.Select(db.From<GeoTestTable>()).First().Location;
+
+                Assert.AreEqual(geo.Lat, result.Lat);
+                Assert.AreEqual(geo.Long, result.Long);
+                Assert.AreEqual(geo.STSrid, result.STSrid);
+            }
+        }
+
+        [Test]
+        public void Can_insert_and_retrieve_SqlGeometry()
+        {
+            using (var db = OpenDbConnection())
+            {
+                // A simple line from (0,0) to (4,4)  Length = SQRT(2 * 4^2)
+                var wkt = new System.Data.SqlTypes.SqlChars("LINESTRING(0 0, 4 4)".ToCharArray());
+                var shape = SqlGeometry.STLineFromText(wkt, 0);
+
+                db.Insert(new GeoTestTable() { Shape = shape });
+
+                var result = db.Select(db.From<GeoTestTable>()).First().Shape;
+
+                var lengths = db.Column<double>("select Shape.STLength() AS Length from GeoTestTable");
+
+                Assert.AreEqual((double)result.STLength(), lengths.First());
+
+                Assert.AreEqual(shape.STStartPoint().STX, result.STStartPoint().STX);
+                Assert.AreEqual(shape.STStartPoint().STY, result.STStartPoint().STY);
+
+                Assert.AreEqual(shape.STEndPoint().STX, result.STEndPoint().STX);
+                Assert.AreEqual(shape.STEndPoint().STY, result.STEndPoint().STY);
+
+                Assert.AreEqual(2, (int)result.STNumPoints());
+            }
+        }
+    }
+
+    public class GeoTestTable
+    {
+        [AutoIncrement()]
+        public long ID { get; set; }
+
+        public SqlGeography Location { get; set; }
+
+        public SqlGeometry Shape { get; set; }
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServerSpatialsTest/app.config
+++ b/src/ServiceStack.OrmLite.SqlServerSpatialsTest/app.config
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<configuration>
+  <configSections>
+  </configSections>
+  <connectionStrings>
+    <add name="testDb" connectionString="Data Source=ci;Initial Catalog=test;User Id=test;Password=test;Connect Timeout=120;MultipleActiveResultSets=True" providerName="System.Data.SqlClient"/>
+  </connectionStrings>
+  <appSettings>
+    <add key="servicestack:license" value="1001-e1JlZjoxMDAxLE5hbWU6VGVzdCBCdXNpbmVzcyxUeXBlOkJ1c2luZXNzLEhhc2g6UHVNTVRPclhvT2ZIbjQ5MG5LZE1mUTd5RUMzQnBucTFEbTE3TDczVEF4QUNMT1FhNXJMOWkzVjFGL2ZkVTE3Q2pDNENqTkQyUktRWmhvUVBhYTBiekJGUUZ3ZE5aZHFDYm9hL3lydGlwUHI5K1JsaTBYbzNsUC85cjVJNHE5QVhldDN6QkE4aTlvdldrdTgyTk1relY2eis2dFFqTThYN2lmc0JveHgycFdjPSxFeHBpcnk6MjAxMy0wMS0wMX0="/>
+  </appSettings>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>

--- a/src/ServiceStack.OrmLite.SqlServerSpatialsTest/packages.config
+++ b/src/ServiceStack.OrmLite.SqlServerSpatialsTest/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.SqlServer.Types" version="11.0.2" targetFramework="net45" />
+</packages>

--- a/src/ServiceStack.OrmLite.sln
+++ b/src/ServiceStack.OrmLite.sln
@@ -113,6 +113,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceStack.OrmLite.Sqlite
 EndProject
 Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "ServiceStack.OrmLite.VbNetTests", "..\tests\ServiceStack.OrmLite.VbNetTests\ServiceStack.OrmLite.VbNetTests.vbproj", "{CC385BE2-B49D-46AF-8F1B-BC9943E106E6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceStack.OrmLite.SqlServerTests.Spatials", "ServiceStack.OrmLite.SqlServerSpatialsTest\ServiceStack.OrmLite.SqlServerTests.Spatials.csproj", "{2B366503-ECFC-4783-AFB6-900F1364EA7B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -841,6 +843,26 @@ Global
 		{CC385BE2-B49D-46AF-8F1B-BC9943E106E6}.Signed|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{CC385BE2-B49D-46AF-8F1B-BC9943E106E6}.Signed|Mixed Platforms.Build.0 = Release|Any CPU
 		{CC385BE2-B49D-46AF-8F1B-BC9943E106E6}.Signed|x86.ActiveCfg = Release|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Default|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Default|Any CPU.Build.0 = Debug|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Default|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Default|Mixed Platforms.Build.0 = Debug|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Default|x86.ActiveCfg = Debug|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Release|x86.ActiveCfg = Release|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Signed|Any CPU.ActiveCfg = Signed|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Signed|Any CPU.Build.0 = Signed|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Signed|Mixed Platforms.ActiveCfg = Signed|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Signed|Mixed Platforms.Build.0 = Signed|Any CPU
+		{2B366503-ECFC-4783-AFB6-900F1364EA7B}.Signed|x86.ActiveCfg = Signed|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/packages/repositories.config
+++ b/src/packages/repositories.config
@@ -14,4 +14,5 @@
   <repository path="..\ServiceStack.OrmLite.Sqlite.Windows\packages.config" />
   <repository path="..\ServiceStack.OrmLite.Sqlite32\packages.config" />
   <repository path="..\ServiceStack.OrmLite.Sqlite64\packages.config" />
+  <repository path="..\ServiceStack.OrmLite.SqlServerSpatialsTest\packages.config" />
 </repositories>


### PR DESCRIPTION
Added new test project demonstrating the use of Spatials (both Geometry and Geography) types with OrmLite.  This functionality depends on the Microsoft.SqlServer.Types library from NuGet, plus references to the unmanaged libraries msvcr100.dll & SqlServerSpatials110.dll that are available from Microsoft's site (SQL Server version specific).

I attempted t0 figure out ways to integrate anything into OrmLite, but no approach was pretty. One thought I had about making this functionality more streamlined with OrmLite, was to wrap the Microsoft Libraries (new project) and provide interfaces that user's could inherit so that they don't have to mess with these over complicated libraries, then possibly provide some SqlExpressions for the type specific functions (i.e. STLength()), but this all seemed outside the scope of just illustrating that you can do it.

https://servicestack.uservoice.com/forums/176786-feature-requests/suggestions/9030526-allow-us-to-use-geography-data-type-in-sql-server