### PR TITLE
Created new SqlServerTypeConverter abstract class

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServerSpatialsTest/ServiceStack.OrmLite.SqlServerTests.Spatials.csproj
+++ b/src/ServiceStack.OrmLite.SqlServerSpatialsTest/ServiceStack.OrmLite.SqlServerTests.Spatials.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SqlServerGeographyTypeConverter.cs" />
     <Compile Include="SqlServerGeometryTypeConverter.cs" />
+    <Compile Include="SqlServerTypeConverter.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServiceStack.OrmLite.SqlServer\ServiceStack.OrmLite.SqlServer.csproj">

--- a/src/ServiceStack.OrmLite.SqlServerSpatialsTest/SqlServerGeographyTypeConverter.cs
+++ b/src/ServiceStack.OrmLite.SqlServerSpatialsTest/SqlServerGeographyTypeConverter.cs
@@ -1,27 +1,17 @@
 ﻿using System;
-using System.Data;
-using System.Data.SqlClient;
-using ServiceStack.OrmLite;
 
 namespace ServiceStack.OrmLite.SqlServer.Converters
 {
-    public class SqlServerGeographyTypeConverter : OrmLiteConverter
+    public class SqlServerGeographyTypeConverter : SqlServerTypeConverter
     {
+        public SqlServerGeographyTypeConverter(string libraryPath = null, string msvcrFileName = "msvcr100.dll", string sqlSpatialFileName = "SqlServerSpatial110.dll") 
+            : base(libraryPath, msvcrFileName, sqlSpatialFileName) 
+        { 
+        }
+
         public override string ColumnDefinition
         {
             get { return "GEOGRAPHY"; }
-        }
-
-        public override DbType DbType
-        {
-            get { return DbType.Object; }
-        }
-
-        public override void InitDbParam(IDbDataParameter p, Type fieldType)
-        {
-            var geogParam = (SqlParameter)p;
-            geogParam.SqlDbType = SqlDbType.Udt;
-            geogParam.UdtTypeName = ColumnDefinition;
         }
     }
 }

--- a/src/ServiceStack.OrmLite.SqlServerSpatialsTest/SqlServerGeometryTypeConverter.cs
+++ b/src/ServiceStack.OrmLite.SqlServerSpatialsTest/SqlServerGeometryTypeConverter.cs
@@ -1,27 +1,17 @@
 ﻿using System;
-using System.Data;
-using System.Data.SqlClient;
-using ServiceStack.OrmLite;
 
 namespace ServiceStack.OrmLite.SqlServer.Converters
 {
-    public class SqlServerGeometryTypeConverter : OrmLiteConverter
+    public class SqlServerGeometryTypeConverter : SqlServerTypeConverter
     {
+        public SqlServerGeometryTypeConverter(string libraryPath = null, string msvcrFileName = "msvcr100.dll", string sqlSpatialFileName = "SqlServerSpatial110.dll")
+            : base(libraryPath, msvcrFileName, sqlSpatialFileName)
+        { 
+        }
+
         public override string ColumnDefinition
         {
             get { return "GEOMETRY"; }
-        }
-
-        public override DbType DbType
-        {
-            get { return DbType.Object; }
-        }
-
-        public override void InitDbParam(IDbDataParameter p, Type fieldType)
-        {
-            var geogParam = (SqlParameter)p;
-            geogParam.SqlDbType = SqlDbType.Udt;
-            geogParam.UdtTypeName = ColumnDefinition;
         }
     }
 }

--- a/src/ServiceStack.OrmLite.SqlServerSpatialsTest/SqlServerSpatialsOrmLiteTestBase.cs
+++ b/src/ServiceStack.OrmLite.SqlServerSpatialsTest/SqlServerSpatialsOrmLiteTestBase.cs
@@ -24,31 +24,6 @@ namespace ServiceStack.OrmLite.SqlServerTests.Spatials
             {
                 LogManager.LogFactory = new ConsoleLogFactory();
 
-                // Get the appropriate Windows System Path
-                //  32-bit: C:\Windows\System32
-                //  64-bit: C:\Windows\SysWOW64
-                var systemPathEnum = (!Environment.Is64BitProcess)
-                        ? Environment.SpecialFolder.SystemX86
-                        : Environment.SpecialFolder.System;
-                
-                var systemPath = Environment.GetFolderPath(systemPathEnum);
-
-                // Add directory separator character if needed
-                if (!systemPath.EndsWith(System.IO.Path.DirectorySeparatorChar.ToString()))
-                {
-                    systemPath += System.IO.Path.DirectorySeparatorChar;
-                }
-
-                // The versions of the files must match the version associated with Sql Server
-                // These files can been installed from the Microsoft SQL Server Feature Pack 
-                // 
-                // SQL Server 2008: https://www.microsoft.com/en-us/download/details.aspx?id=44277
-                // SQL Server 2008 R2: https://www.microsoft.com/en-us/download/details.aspx?id=44272
-                // SQL Server 2012 SP2: http://www.microsoft.com/en-us/download/details.aspx?id=43339
-                // SQL Server 2014 SP1: https://www.microsoft.com/en-us/download/details.aspx?id=46696
-                LoadUnmanagedAssembly(systemPath, "msvcr100.dll");
-                LoadUnmanagedAssembly(systemPath, "SqlServerSpatial110.dll");
-
                 // Appending the Sql Server Type System Version to use SqlServerSpatial110.dll (2012) assembly
                 // Sql Server defaults to SqlServerSpatial100.dll (2008 R2) even for versions greater
                 // https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlconnection.connectionstring.aspx
@@ -75,22 +50,6 @@ namespace ServiceStack.OrmLite.SqlServerTests.Spatials
         {
             connString = connString ?? ConnectionString;
             return connString.OpenDbConnection();
-        }
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        private static extern IntPtr LoadLibrary(string libname);
-
-        private static void LoadUnmanagedAssembly(string path, string assemblyName)
-        {
-            path += assemblyName;
-            var ptr = LoadLibrary(path);
-            if (ptr == IntPtr.Zero)
-            {
-                throw new Exception(string.Format(
-                    "Error loading {0} (ErrorCode: {1})",
-                    assemblyName,
-                    Marshal.GetLastWin32Error()));
-            }
         }
     }
 }

--- a/src/ServiceStack.OrmLite.SqlServerSpatialsTest/SqlServerTypeConverter.cs
+++ b/src/ServiceStack.OrmLite.SqlServerSpatialsTest/SqlServerTypeConverter.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Data;
+using System.Data.SqlClient;
+using System.IO;
+using System.Runtime.InteropServices;
+using ServiceStack.OrmLite;
+
+namespace ServiceStack.OrmLite.SqlServer.Converters
+{
+    public abstract class SqlServerTypeConverter : OrmLiteConverter
+    {
+        public SqlServerTypeConverter(string libraryPath = null, string msvcrFileName = "msvcr100.dll", string sqlSpatialFileName = "SqlServerSpatial110.dll")
+        {
+            // default libraryPath to Windows System
+            if (String.IsNullOrEmpty(libraryPath))
+            {
+                // Get the appropriate Windows System Path
+                //  32-bit: C:\Windows\System32
+                //  64-bit: C:\Windows\SysWOW64
+                var systemPathEnum = (!Environment.Is64BitProcess)
+                        ? Environment.SpecialFolder.SystemX86
+                        : Environment.SpecialFolder.System;
+
+                libraryPath = Environment.GetFolderPath(systemPathEnum);
+            }
+
+            // The versions of the files must match the version associated with Sql Server
+            // These files can been installed from the Microsoft SQL Server Feature Pack 
+            // 
+            // SQL Server 2008: https://www.microsoft.com/en-us/download/details.aspx?id=44277
+            // SQL Server 2008 R2: https://www.microsoft.com/en-us/download/details.aspx?id=44272
+            // SQL Server 2012 SP2: http://www.microsoft.com/en-us/download/details.aspx?id=43339
+            // SQL Server 2014 SP1: https://www.microsoft.com/en-us/download/details.aspx?id=46696
+            LoadUnmanagedAssembly(libraryPath, msvcrFileName);
+            LoadUnmanagedAssembly(libraryPath, sqlSpatialFileName);
+        }
+
+        public override DbType DbType
+        {
+            get { return DbType.Object; }
+        }
+
+        public override void InitDbParam(IDbDataParameter p, Type fieldType)
+        {
+            var sqlParam = (SqlParameter)p;
+            sqlParam.SqlDbType = SqlDbType.Udt;
+            sqlParam.UdtTypeName = ColumnDefinition;
+        }
+
+
+
+        protected static void LoadUnmanagedAssembly(string libraryPath, string fileName)
+        {
+            var path = Path.Combine(libraryPath, fileName);
+            var ptr = LoadLibrary(path);
+            if (ptr == IntPtr.Zero)
+            {
+                throw new Exception(string.Format(
+                    "Error loading {0} (ErrorCode: {1})",
+                    fileName,
+                    Marshal.GetLastWin32Error()));
+            }
+        }
+
+        protected static void UnloadUnmanagedAssembly(string assemblyName)
+        {
+            var hMod = IntPtr.Zero;
+            if (GetModuleHandleExA(0, assemblyName, hMod))
+            {
+                while (FreeLibrary(hMod))
+                {
+                }
+            }
+        }
+
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern IntPtr LoadLibrary(string libname);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        private static extern bool FreeLibrary(IntPtr hModule);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        private static extern bool GetModuleHandleExA(int dwFlags, string moduleName, IntPtr phModule);
+
+
+    }
+}


### PR DESCRIPTION
Created new SqlServerTypeConverter abstract class for SQL Server Spatial Type Converters. Moved unmanaged library handling into new class' constructor. Provided optional parameters on converters for more developer flexibility with unmanaged filenames and path.