### PR TITLE
Added support for the HierarchyId data type to the SqlServer.Converters package

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServer.Converters/ServiceStack.OrmLite.SqlServer.Converters.csproj
+++ b/src/ServiceStack.OrmLite.SqlServer.Converters/ServiceStack.OrmLite.SqlServer.Converters.csproj
@@ -58,6 +58,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SqlServerConverters.cs" />
+    <Compile Include="SqlServerHierarchyIdTypeConverter.cs" />
     <Compile Include="SqlServerGeographyTypeConverter.cs" />
     <Compile Include="SqlServerGeometryTypeConverter.cs" />
     <Compile Include="SqlServerTypeConverter.cs" />

--- a/src/ServiceStack.OrmLite.SqlServer.Converters/ServiceStack.OrmLite.SqlServer.Converters.csproj
+++ b/src/ServiceStack.OrmLite.SqlServer.Converters/ServiceStack.OrmLite.SqlServer.Converters.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -70,6 +72,13 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerConverters.cs
+++ b/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerConverters.cs
@@ -8,6 +8,7 @@ namespace ServiceStack.OrmLite.SqlServer.Converters
         {
             dialectProvider.RegisterConverter<SqlGeography>(new SqlServerGeographyTypeConverter());
             dialectProvider.RegisterConverter<SqlGeometry>(new SqlServerGeometryTypeConverter());
+            dialectProvider.RegisterConverter<SqlHierarchyId>(new SqlServerHierarchyIdTypeConverter());
             return dialectProvider;
         }
     }

--- a/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerGeographyTypeConverter.cs
+++ b/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerGeographyTypeConverter.cs
@@ -1,17 +1,61 @@
 ﻿using System;
+using Microsoft.SqlServer.Types;
 
 namespace ServiceStack.OrmLite.SqlServer.Converters
 {
-    public class SqlServerGeographyTypeConverter : SqlServerTypeConverter
+    /// <summary>
+    /// SqlServer Database Converter for the Geometry data type
+    /// https://msdn.microsoft.com/en-us/library/microsoft.sqlserver.types.sqlgeography.aspx
+    /// </summary>
+    public class SqlServerGeographyTypeConverter : SqlServerSpatialTypeConverter
     {
         public SqlServerGeographyTypeConverter(string libraryPath = null, string msvcrFileName = "msvcr100.dll", string sqlSpatialFileName = "SqlServerSpatial110.dll") 
             : base(libraryPath, msvcrFileName, sqlSpatialFileName) 
-        { 
-        }
+        { }
 
         public override string ColumnDefinition
         {
             get { return "GEOGRAPHY"; }
+        }
+
+        public override object FromDbValue(Type fieldType, object value)
+        {
+            var geo = value as SqlGeography;
+            if (geo == null || geo.IsNull)
+            {
+                return null;
+            }
+
+            return base.FromDbValue(fieldType, value);
+        }
+
+        public override object ToDbValue(Type fieldType, object value)
+        {
+            if (value == null)
+            {
+                return SqlGeography.Null;
+            }
+
+            if (value is SqlGeography)
+            {
+                return value;
+            }
+
+            if (value is string)
+            {
+                var str = value as string;
+                return SqlGeography.Parse(str);
+            }
+
+            if (value is byte[])
+            {
+                var bin = value as byte[];
+                var sqlBin = new System.Data.SqlTypes.SqlBytes(bin);
+
+                return SqlGeography.Deserialize(sqlBin);
+            }
+
+            return base.ToDbValue(fieldType, value);
         }
     }
 }

--- a/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerGeometryTypeConverter.cs
+++ b/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerGeometryTypeConverter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Data.SqlTypes;
 using Microsoft.SqlServer.Types;
 
 namespace ServiceStack.OrmLite.SqlServer.Converters

--- a/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerGeometryTypeConverter.cs
+++ b/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerGeometryTypeConverter.cs
@@ -1,17 +1,62 @@
 ﻿using System;
+using System.Data.SqlTypes;
+using Microsoft.SqlServer.Types;
 
 namespace ServiceStack.OrmLite.SqlServer.Converters
 {
-    public class SqlServerGeometryTypeConverter : SqlServerTypeConverter
+    /// <summary>
+    /// SqlServer Database Converter for the Geometry data type
+    /// https://msdn.microsoft.com/en-us/library/microsoft.sqlserver.types.sqlgeometry.aspx
+    /// </summary>
+    public class SqlServerGeometryTypeConverter : SqlServerSpatialTypeConverter
     {
         public SqlServerGeometryTypeConverter(string libraryPath = null, string msvcrFileName = "msvcr100.dll", string sqlSpatialFileName = "SqlServerSpatial110.dll")
             : base(libraryPath, msvcrFileName, sqlSpatialFileName)
-        { 
-        }
+        { }
 
         public override string ColumnDefinition
         {
             get { return "GEOMETRY"; }
+        }
+
+        public override object FromDbValue(Type fieldType, object value)
+        {
+            var geo = value as SqlGeometry;
+            if (geo == null || geo.IsNull)
+            {
+                return null;
+            }
+
+            return base.FromDbValue(fieldType, value);
+        }
+
+        public override object ToDbValue(Type fieldType, object value)
+        {
+            if (value == null)
+            {
+                return SqlGeometry.Null;
+            }
+
+            if (value is SqlGeometry)
+            {
+                return value;
+            }
+
+            if (value is string)
+            {
+                var str = value as string;
+                return SqlGeometry.Parse(str);
+            }
+
+            if (value is byte[])
+            {
+                var bin = value as byte[];
+                var sqlBin = new System.Data.SqlTypes.SqlBytes(bin);
+
+                return SqlGeometry.Deserialize(sqlBin);
+            }
+
+            return base.ToDbValue(fieldType, value);
         }
     }
 }

--- a/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerHierarchyIdTypeConverter.cs
+++ b/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerHierarchyIdTypeConverter.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Data;
+using System.Data.SqlClient;
+using Microsoft.SqlServer.Types;
+
+namespace ServiceStack.OrmLite.SqlServer.Converters
+{
+    /// <summary>
+    /// SqlServer Database Converter for the HierarchyId data type
+    /// https://msdn.microsoft.com/en-us/library/microsoft.sqlserver.types.sqlhierarchyid.aspx
+    /// </summary>
+    public class SqlServerHierarchyIdTypeConverter : OrmLiteConverter
+    {
+        public SqlServerHierarchyIdTypeConverter() : base()
+        { }
+
+        public override string ColumnDefinition
+        {
+            get { return "HIERARCHYID"; }
+        }
+
+        public override DbType DbType
+        {
+            get { return DbType.Object; }
+        }
+
+        public override void InitDbParam(IDbDataParameter p, Type fieldType)
+        {
+            var sqlParam = (SqlParameter)p;
+            sqlParam.IsNullable = (fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(Nullable<>));
+            sqlParam.SqlDbType = SqlDbType.Udt;
+            sqlParam.UdtTypeName = ColumnDefinition;
+        }
+
+        public override object FromDbValue(Type fieldType, object value)
+        {
+            if (((SqlHierarchyId)value).IsNull && fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                return null;
+            }
+
+            return base.FromDbValue(fieldType, value);
+        }
+
+        public override object ToDbValue(Type fieldType, object value)
+        {
+            if (value is SqlHierarchyId)
+            {
+                return value;
+            }
+
+            if (value == null)
+            {
+                return SqlHierarchyId.Null;
+            }
+
+            if (value is string)
+            {
+                var str = value as string;
+                return SqlHierarchyId.Parse(str);
+            }
+
+            return base.ToDbValue(fieldType, value);
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerTypeConverter.cs
+++ b/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerTypeConverter.cs
@@ -7,9 +7,9 @@ using ServiceStack.OrmLite;
 
 namespace ServiceStack.OrmLite.SqlServer.Converters
 {
-    public abstract class SqlServerTypeConverter : OrmLiteConverter
+    public abstract class SqlServerSpatialTypeConverter : OrmLiteConverter
     {
-        public SqlServerTypeConverter(string libraryPath = null, string msvcrFileName = "msvcr100.dll", string sqlSpatialFileName = "SqlServerSpatial110.dll")
+        public SqlServerSpatialTypeConverter(string libraryPath = null, string msvcrFileName = "msvcr100.dll", string sqlSpatialFileName = "SqlServerSpatial110.dll")
         {
             // default libraryPath to Windows System
             if (String.IsNullOrEmpty(libraryPath))
@@ -44,6 +44,7 @@ namespace ServiceStack.OrmLite.SqlServer.Converters
         {
             var sqlParam = (SqlParameter)p;
             sqlParam.SqlDbType = SqlDbType.Udt;
+            sqlParam.IsNullable = (fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(Nullable<>));
             sqlParam.UdtTypeName = ColumnDefinition;
         }
 

--- a/src/ServiceStack.OrmLite.SqlServerTests/Converters/ConvertersOrmLiteTestBase.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/Converters/ConvertersOrmLiteTestBase.cs
@@ -11,7 +11,7 @@ using ServiceStack.OrmLite.SqlServer.Converters;
 
 namespace ServiceStack.OrmLite.SqlServerTests.Spatials
 {
-    public class SqlServerSpatialsOrmLiteTestBase
+    public class SqlServerConvertersOrmLiteTestBase
     {
         protected virtual string ConnectionString { get; set; }
 

--- a/src/ServiceStack.OrmLite.SqlServerTests/Converters/HierarchyIdTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/Converters/HierarchyIdTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using NUnit.Framework;
+using Microsoft.SqlServer.Types;
+using ServiceStack.DataAnnotations;
+using ServiceStack.OrmLite.SqlServer;
+
+namespace ServiceStack.OrmLite.SqlServerTests.Spatials
+{
+    [TestFixture]
+    public class HierarchyIdTests : SqlServerConvertersOrmLiteTestBase
+    {
+        [SetUp]
+        public void Setup()
+        {
+            OpenDbConnection().CreateTable<HierarchyTestTable>(true);
+        }
+
+        // Avoid painful refactor to change all tests to use a using pattern
+        private IDbConnection db;
+
+        public override IDbConnection OpenDbConnection(string connString = null)
+        {
+            if (db != null && db.State != ConnectionState.Open)
+                db = null;
+
+            return db ?? (db = base.OpenDbConnection(connString));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (db == null)
+                return;
+            db.Dispose();
+            db = null;
+        }
+        [Test]
+        public void Can_insert_and_retrieve_HierarchyId()
+        {
+            using (var db = OpenDbConnection())
+            {
+                var stringValue = "/1/1/3/";  // 0x5ADE is hex
+
+                var treeId = SqlHierarchyId.Parse(stringValue);
+
+                db.Insert(new HierarchyTestTable() { TreeId = treeId, NullTreeId = SqlHierarchyId.Null });
+
+                var result = db.Select<HierarchyTestTable>();
+                Assert.AreEqual(null, result[0].NullTreeId);
+                Assert.AreEqual(treeId, result[0].TreeId);
+
+                var parent = db.Column<SqlHierarchyId>("SELECT TreeId.GetAncestor(1) from HierarchyTestTable").First();
+                var str = parent.ToString();
+                Assert.AreEqual("/1/1/", str);
+            }
+        }
+    }
+
+    public class HierarchyTestTable
+    {
+        [AutoIncrement]
+        public long Id { get; set; }
+
+        public SqlHierarchyId TreeId { get; set; }
+
+        public Nullable<SqlHierarchyId> NullTreeId { get; set; }
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServerTests/Converters/SpatialsTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/Converters/SpatialsTests.cs
@@ -10,7 +10,7 @@ using ServiceStack.OrmLite.SqlServer;
 namespace ServiceStack.OrmLite.SqlServerTests.Spatials
 {
     [TestFixture]
-    public class SqlServerSpatialTests : SqlServerSpatialsOrmLiteTestBase
+    public class SpatialTests : SqlServerConvertersOrmLiteTestBase
     {
         [SetUp]
         public void Setup()
@@ -37,6 +37,7 @@ namespace ServiceStack.OrmLite.SqlServerTests.Spatials
             db.Dispose();
             db = null;
         }
+
         [Test]
         public void Can_insert_and_retrieve_SqlGeography()
         {
@@ -45,13 +46,16 @@ namespace ServiceStack.OrmLite.SqlServerTests.Spatials
                 // Statue of Liberty
                 var geo = SqlGeography.Point(40.6898329,-74.0452177, 4326);
 
-                db.Insert(new GeoTestTable() { Location = geo });
+                db.Insert(new GeoTestTable() { Location = geo, NullLocation = SqlGeography.Null });
 
-                var result = db.Select(db.From<GeoTestTable>()).First().Location;
+                var result = db.Select(db.From<GeoTestTable>()).First();
 
-                Assert.AreEqual(geo.Lat, result.Lat);
-                Assert.AreEqual(geo.Long, result.Long);
-                Assert.AreEqual(geo.STSrid, result.STSrid);
+                Assert.AreEqual(geo.Lat, result.Location.Lat);
+                Assert.AreEqual(geo.Long, result.Location.Long);
+                Assert.AreEqual(geo.STSrid, result.Location.STSrid);
+
+                // Converter always resolves to null even when Null property inserted into database
+                Assert.AreEqual(null, result.NullLocation);  
             }
         }
 
@@ -89,6 +93,8 @@ namespace ServiceStack.OrmLite.SqlServerTests.Spatials
         public long Id { get; set; }
 
         public SqlGeography Location { get; set; }
+
+        public SqlGeography NullLocation { get; set; }
 
         public SqlGeometry Shape { get; set; }
     }

--- a/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
+++ b/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
@@ -104,8 +104,9 @@
     <Compile Include="Expressions\UnaryExpressionsTest.cs" />
     <Compile Include="ForeignKeyAttributeTests.cs" />
     <Compile Include="OrmLiteTestBase.cs" />
-    <Compile Include="Spatials\SqlServerSpatialsOrmLiteTestBase.cs" />
-    <Compile Include="Spatials\SqlServerSpatialsTest.cs" />
+    <Compile Include="Converters\ConvertersOrmLiteTestBase.cs" />
+    <Compile Include="Converters\HierarchyIdTests.cs" />
+    <Compile Include="Converters\SpatialsTests.cs" />
     <Compile Include="SqlServerExpressionVisitorQueryTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SqlServerTypes\Loader.cs" />
@@ -157,7 +158,9 @@
     </Content>
     <Content Include="SqlServerTypes\readme.htm" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
+++ b/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -157,6 +159,13 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/packages/repositories.config
+++ b/src/packages/repositories.config
@@ -14,5 +14,7 @@
   <repository path="..\ServiceStack.OrmLite.Sqlite.Windows\packages.config" />
   <repository path="..\ServiceStack.OrmLite.Sqlite32\packages.config" />
   <repository path="..\ServiceStack.OrmLite.Sqlite64\packages.config" />
+  <repository path="..\ServiceStack.OrmLite.SqlServer.Converters\packages.config" />
   <repository path="..\ServiceStack.OrmLite.SqlServerSpatialsTest\packages.config" />
+  <repository path="..\ServiceStack.OrmLite.SqlServerTests\packages.config" />
 </repositories>


### PR DESCRIPTION
Added support for the HierarchyId data type to the *SqlServer.Converters* project, included some support for converting to and from NULL values for all 3 *SqlServer.Converters*, and organized/updated the related testing.

Lastly, I have enabled the NuGet package restore option on the project.