### PR TITLE
fix order of setting DbType and Value when creating DbDataParameter

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteReadCommandExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadCommandExtensions.cs
@@ -294,9 +294,9 @@ namespace ServiceStack.OrmLite
                 p.ParameterName = kvp.Key;
 
                 p.Direction = ParameterDirection.Input;
-                p.Value = value ?? DBNull.Value;
                 if (value != null)
                     dialectProvider.InitDbParam(p, value.GetType());
+                p.Value = value ?? DBNull.Value;
 
                 dbCmd.Parameters.Add(p);
             }


### PR DESCRIPTION
previous order of setting value before type causes "Value does not fall within the expected range"
in oracle, on types like .NET boolean which has no direct corresponding type in the database