### PR TITLE
Removed ToString so it uses StringSerializer

### DIFF
--- a/src/ServiceStack.OrmLite/Converters/SpecialConverters.cs
+++ b/src/ServiceStack.OrmLite/Converters/SpecialConverters.cs
@@ -14,7 +14,7 @@ namespace ServiceStack.OrmLite.Converters
             long enumValue;
             if (!isEnumFlags && long.TryParse(value.ToString(), out enumValue))
             {
-                value = Enum.ToObject(fieldType, enumValue).ToString();
+                value = Enum.ToObject(fieldType, enumValue);
             }
 
             var enumString = DialectProvider.StringSerializer.SerializeToString(value);


### PR DESCRIPTION
I removed the ToString() on an enum so the serialization of it can be
done by the configured StringSerializer.
Because some Expression related stuff changed when building with VS2015
Update 1 this resulted in an issue when I wanted my StringSerializer to
behave differently when serializing enums.

See:
http://stackoverflow.com/questions/34099809/expressions-breaking-code-when-compiled-using-vs2015-update-1