### PR TITLE
MySql DateTime Column Read 2 donet Datetime type  throw error,

### DIFF
--- a/src/ServiceStack.OrmLite.MySql/Converters/MySqlDateTimeConverter.cs
+++ b/src/ServiceStack.OrmLite.MySql/Converters/MySqlDateTimeConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using ServiceStack.OrmLite.Converters;
+using MySql.Data.Types;
 
 namespace ServiceStack.OrmLite.MySql.Converters
 {
@@ -13,6 +14,15 @@ namespace ServiceStack.OrmLite.MySql.Converters
              */
             var dateTime = (DateTime)value;
             return DateTimeFmt(dateTime, "yyyy-MM-dd HH:mm:ss");
+        }
+        public override object FromDbValue(object value)
+        {
+            if (value is MySqlDateTime)
+            {
+                var time = (MySqlDateTime)value;
+                return time.GetDateTime();
+            }
+            return base.FromDbValue(value);
         }
     }
 }


### PR DESCRIPTION
BUG:mysql数据库中的字段为datetime类型时,读取出来的数据库值类型为mysqldatetime,强转为datetime时会抛出异常