### PR TITLE
Fix CreateParameter in Oracle provider and add missing DefaultValueTests

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle.Tests/ServiceStack.OrmLite.Oracle.Tests.csproj
+++ b/src/ServiceStack.OrmLite.Oracle.Tests/ServiceStack.OrmLite.Oracle.Tests.csproj
@@ -94,6 +94,9 @@
     <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\DateTimeOffsetTests.cs">
       <Link>DateTimeOffsetTests.cs</Link>
     </Compile>
+    <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\DefaultValueTests.cs">
+      <Link>DefaultValueTests.cs</Link>
+    </Compile>
     <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\EnumTests.cs">
       <Link>EnumTests.cs</Link>
     </Compile>
@@ -391,9 +394,7 @@
     <Compile Include="..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="WrappedCommandTests.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="WrappedCommandTests.cs" />
     <Compile Include="DateTimeColumnTest.cs" />
     <Compile Include="ForeignKeyAttributeTests.cs" />
     <Compile Include="OracleParamTests.cs">

--- a/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
@@ -1160,7 +1160,7 @@ namespace ServiceStack.OrmLite.Oracle
 
         public override IDbDataParameter CreateParam()
         {
-            return new OrmLiteDataParameter();
+            return _factory.CreateParameter();
         }
 
         public override bool DoesTableExist(IDbCommand dbCmd, string tableName, string schema=null)


### PR DESCRIPTION
@mythz Here is a fix for parameterized stuff for the Oracle provider. It cuts the failing tests from 37 to 21, and it makes your new parameterized updates work. BTW, thanks very much for that - we really wanted that. Cheers, Bruce