### PR TITLE
Fix time stamp types

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle/Converters/OracleDateTimeOffsetConverter.cs
+++ b/src/ServiceStack.OrmLite.Oracle/Converters/OracleDateTimeOffsetConverter.cs
@@ -42,7 +42,7 @@ namespace ServiceStack.OrmLite.Oracle.Converters
 
         public override void InitDbParam(IDbDataParameter p, Type fieldType)
         {
-            p.DbType = DbType.String;
+            _timestampConverter.SetParameterTimeStampTzType(p);
         }
     }
 }

--- a/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
@@ -15,6 +15,7 @@ namespace ServiceStack.OrmLite.Oracle
     public class OracleOrmLiteDialectProvider : OrmLiteDialectProviderBase<OracleOrmLiteDialectProvider>
     {
         public const string OdpProvider = "Oracle.DataAccess.Client";
+        public const string ManagedProvider = "Oracle.ManagedDataAccess.Client";
         public const string MicrosoftProvider = "System.Data.OracleClient";
 
         protected readonly List<string> ReservedNames = new List<string>
@@ -70,6 +71,7 @@ namespace ServiceStack.OrmLite.Oracle
 
         public OracleOrmLiteDialectProvider(bool compactGuid, bool quoteNames, string clientProvider = OdpProvider)
         {
+            OrmLiteConfig.DeoptimizeReader = true;
             ClientProvider = clientProvider;
             //CompactGuid = compactGuid;
             QuoteNames = quoteNames;
@@ -94,7 +96,7 @@ namespace ServiceStack.OrmLite.Oracle
             ExecFilter = new OracleExecFilter();
 
             _factory = DbProviderFactories.GetFactory(ClientProvider);
-            _timestampConverter = new OracleTimestampConverter(_factory.GetType());
+            _timestampConverter = new OracleTimestampConverter(_factory.GetType(), ClientProvider);
 
             InitColumnTypeMap();
 

--- a/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
@@ -1768,8 +1768,8 @@ namespace ServiceStack.OrmLite
 
             if (value != null)
             {
-                p.Value = DialectProvider.GetParamValue(value, value.GetType());
                 DialectProvider.InitDbParam(p, value.GetType());
+                p.Value = DialectProvider.GetParamValue(value, value.GetType());
             }
             else
             {
@@ -1867,8 +1867,8 @@ namespace ServiceStack.OrmLite
 
             if (value != null)
             {
-                to.Value = dialectProvider.GetParamValue(value, valueType);
                 dialectProvider.InitDbParam(to, valueType);
+                to.Value = dialectProvider.GetParamValue(value, valueType);
             }
             else
             {


### PR DESCRIPTION
@mythz Here are a couple more fixes for the Oracle provider. It now only fails on the tests that it has always failed on.
It also supports the Oracle fully-managed provider (but defaults to the old one), except for a problem with initialization which I haven't figured out - when it attempts to load the managed provider a callback into OrmLite occurs for some reason which I don't understand and things go very sideways from there because it starts executing code which should not be run at that point in time, If you comment out the oracle.manageddataaccess section in machine.config then it all works. Cheers, Bruce