### PR TITLE
Set UseThreadStatic=true in Oracle provider. OK because the Oracle cl…

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
@@ -71,6 +71,9 @@ namespace ServiceStack.OrmLite.Oracle
 
         public OracleOrmLiteDialectProvider(bool compactGuid, bool quoteNames, string clientProvider = OdpProvider)
         {
+            // Make managed provider work with CaptureSqlFilter, safe since Oracle providers don't support async
+            OrmLiteContext.UseThreadStatic = true;
+            // Not nice to slow down, but need to read some types via Oracle-specific read methods so can't read all fields in single call
             OrmLiteConfig.DeoptimizeReader = true;
             ClientProvider = clientProvider;
             //CompactGuid = compactGuid;


### PR DESCRIPTION
…ients

do not support async. This gets rid of configuration error.

@mythz Here is the simple fix to make the CaptureSqlFilter tests work on Oracle managed client.