### PR TITLE
ConverterTests did update wrong so fix it, also add it to Oracle tests

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle.Tests/ServiceStack.OrmLite.Oracle.Tests.csproj
+++ b/src/ServiceStack.OrmLite.Oracle.Tests/ServiceStack.OrmLite.Oracle.Tests.csproj
@@ -88,6 +88,9 @@
     <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\CompositeKeyTests.cs">
       <Link>CompositeKeyTests.cs</Link>
     </Compile>
+    <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\ConverterTests.cs">
+      <Link>ConverterTests.cs</Link>
+    </Compile>
     <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\CustomSqlTests.cs">
       <Link>CustomSqlTests.cs</Link>
     </Compile>

--- a/tests/ServiceStack.OrmLite.Tests/ConverterTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/ConverterTests.cs
@@ -57,7 +57,7 @@ namespace ServiceStack.OrmLite.Tests
                 var updatedRows = 3.Times(i =>
                 {
                     var updated = AllTypes.Create(i + 3);
-                    updated.Id = i;
+                    updated.Id = i + 1;
                     db.Update(updated);
                     return updated;
                 });


### PR DESCRIPTION
@mythz We had a problem with bools in SQLite in 4.0.48, so I was checking that it was OK in 4.0.52. When doing so, I noticed that the update in the converter test was not doing what it really wanted to do because  the keys were off by 1. Hence this fix.