### PR TITLE
Rename invalid property names including % sign ot valid output

### DIFF
--- a/src/T4/OrmLite.SP.tt
+++ b/src/T4/OrmLite.SP.tt
@@ -59,7 +59,7 @@ namespace <#=SPNamespace#>
 	if (!sp.SPOutputColumns.Any()) continue; #>
 		public class <#=sp.CleanName#>_Result
 		{ 
-		<# foreach(var prop in sp.SPOutputColumns) { var alias = false; var propName = prop.Name;  if (propName.Contains(' ') || propName.Contains('$') || propName.Contains('+')) { propName = propName.Replace(' ','_').Replace("$","_Dollar").Replace("+","_Plus"); alias = true; }; if (char.IsDigit(propName[0])) { propName = "_" + propName; alias = true; };
+				<# foreach(var prop in sp.SPOutputColumns) { var alias = false; var propName = prop.Name;  if (propName.Contains(' ') || propName.Contains('$') || propName.Contains('+') || propName.Contains('%')) { propName = propName.Replace(' ','_').Replace("$","_Dollar").Replace("+","_Plus").Replace("%","_Percent"); alias = true; }; if (char.IsDigit(propName[0])) { propName = "_" + propName; alias = true; };
 			
 		if (alias) {#>		[Alias("<#=prop.Name#>")]
 		<#}#>


### PR DESCRIPTION
Adding another rename condition to deal with Stored Procedure outputs which are not valid C# property names.