### PR TITLE
add functionality to allow enums to be stored as integer values

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
@@ -113,8 +113,10 @@ namespace ServiceStack.OrmLite
                     ? Nullable.GetUnderlyingType(propertyInfo.PropertyType)
                     : propertyInfo.PropertyType;
 
+                var isEnumAsInt = propertyInfo.HasAttribute<EnumAsIntAttribute>();
+
                 Type treatAsType = null;
-                if (propertyType.IsEnumFlags())
+                if (isEnumAsInt || propertyType.IsEnumFlags())
                 {
                     treatAsType = Enum.GetUnderlyingType(propertyType);
                 }

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -300,11 +300,14 @@ namespace ServiceStack.OrmLite
 
         public virtual IOrmLiteConverter GetConverterBestMatch(FieldDefinition fieldDef)
         {
-            var fieldType = Nullable.GetUnderlyingType(fieldDef.FieldType) ?? fieldDef.FieldType;
+            //var fieldType = Nullable.GetUnderlyingType(fieldDef.FieldType) ?? fieldDef.FieldType;
+            var fieldType = Nullable.GetUnderlyingType(fieldDef.ColumnType) ?? fieldDef.ColumnType;
+
             if (fieldDef.IsRowVersion)
                 return RowVersionConverter;
 
             IOrmLiteConverter converter;
+
             if (Converters.TryGetValue(fieldType, out converter))
                 return converter;
 

--- a/src/ServiceStack.OrmLite/OrmLiteEnumAsIntAttribute.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteEnumAsIntAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ServiceStack.OrmLite
+{
+    public class EnumAsIntAttribute: Attribute
+    {
+    }
+}

--- a/src/ServiceStack.OrmLite/ServiceStack.OrmLite.csproj
+++ b/src/ServiceStack.OrmLite/ServiceStack.OrmLite.csproj
@@ -120,6 +120,7 @@
     <Compile Include="NamingStrategy.cs" />
     <Compile Include="OrmLiteCommand.cs" />
     <Compile Include="OrmLiteContext.cs" />
+    <Compile Include="OrmLiteEnumAsIntAttribute.cs" />
     <Compile Include="OrmLiteReadApiAsync.cs" />
     <Compile Include="Async\OrmLiteReadCommandExtensionsAsync.cs" />
     <Compile Include="Async\OrmLiteResultsFilterExtensionsAsync.cs" />

--- a/src/ServiceStack.OrmLiteV45/ServiceStack.OrmLiteV45.csproj
+++ b/src/ServiceStack.OrmLiteV45/ServiceStack.OrmLiteV45.csproj
@@ -193,6 +193,9 @@
     <Compile Include="..\ServiceStack.OrmLite\OrmLiteDialectProviderExtensions.cs">
       <Link>OrmLiteDialectProviderExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\ServiceStack.OrmLite\OrmLiteEnumAsIntAttribute.cs">
+      <Link>OrmLiteEnumAsIntAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\ServiceStack.OrmLite\OrmLiteExecFilter.cs">
       <Link>OrmLiteExecFilter.cs</Link>
     </Compile>


### PR DESCRIPTION
Add functionality to allow enums to be stored as integer values without having to declare them as "flags"

1. Create new attribute type EnumAsAttrubute. This works just as a property label - the class has no functionality.

2. In OrmLiteConfigExtensions.cs - GetModelDefinition(), Check for this new attribute, and if included, set treatAsType to the underlying type.

3. In OrmLiteDialectProviderBase.cs - GetConverterBestMatch(), use fieldDef.ColumnType rather than fieldDef.FieldType. ColumnType will return FieldType anyway if TreatAsType is null.
