### PR TITLE
add functionality to allow enums to be stored as integer values #2

### DIFF
--- a/src/ServiceStack.OrmLite/EnumAsIntAttribute.cs
+++ b/src/ServiceStack.OrmLite/EnumAsIntAttribute.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace ServiceStack.OrmLite
+namespace ServiceStack.Interfaces
 {
     public class EnumAsIntAttribute: Attribute
     {

--- a/src/ServiceStack.OrmLite/IOrmLiteConverter.cs
+++ b/src/ServiceStack.OrmLite/IOrmLiteConverter.cs
@@ -6,7 +6,7 @@ namespace ServiceStack.OrmLite
     public interface IOrmLiteConverter
     {
         IOrmLiteDialectProvider DialectProvider { get; set; }
-        
+
         DbType DbType { get; }
 
         string ColumnDefinition { get; }
@@ -89,7 +89,7 @@ namespace ServiceStack.OrmLite
         /// </summary>
         public virtual object GetValue(IDataReader reader, int columnIndex, object[] values)
         {
-            var value = values != null 
+            var value = values != null
                 ? values[columnIndex]
                 : reader.GetValue(columnIndex);
 
@@ -119,6 +119,10 @@ namespace ServiceStack.OrmLite
         {
             if (value.GetType() == toIntegerType)
                 return value;
+
+            // this is used for a field / property with EnumAsInt attribute
+            if (toIntegerType.IsEnum)
+                return Enum.Parse(toIntegerType, value.ToString());
 
             var typeCode = toIntegerType.GetUnderlyingTypeCode();
             switch (typeCode)

--- a/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using ServiceStack.DataAnnotations;
+using ServiceStack.Interfaces;
 
 namespace ServiceStack.OrmLite
 {

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -300,6 +300,7 @@ namespace ServiceStack.OrmLite
 
         public virtual IOrmLiteConverter GetConverterBestMatch(FieldDefinition fieldDef)
         {
+            // use ColumnType rather than FieldType for EnumAsInt
             //var fieldType = Nullable.GetUnderlyingType(fieldDef.FieldType) ?? fieldDef.FieldType;
             var fieldType = Nullable.GetUnderlyingType(fieldDef.ColumnType) ?? fieldDef.ColumnType;
 
@@ -821,7 +822,8 @@ namespace ServiceStack.OrmLite
             var converter = GetConverterBestMatch(fieldDef);
             try
             {
-                return converter.ToDbValue(fieldDef.FieldType, value);
+                //return converter.ToDbValue(fieldDef.FieldType, value);
+                return converter.ToDbValue(fieldDef.ColumnType, value);
             }
             catch (Exception ex)
             {

--- a/src/ServiceStack.OrmLite/OrmLiteWriteCommandExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteWriteCommandExtensions.cs
@@ -341,6 +341,7 @@ namespace ServiceStack.OrmLite
                         else
                         {
                             var fieldValue = converter.FromDbValue(fieldDef.FieldType, value);
+                            //var fieldValue = converter.FromDbValue(fieldDef.ColumnType, value);
                             fieldDef.SetValueFn(objWithProperties, fieldValue);
                         }
                     }

--- a/src/ServiceStack.OrmLite/ServiceStack.OrmLite.csproj
+++ b/src/ServiceStack.OrmLite/ServiceStack.OrmLite.csproj
@@ -120,7 +120,7 @@
     <Compile Include="NamingStrategy.cs" />
     <Compile Include="OrmLiteCommand.cs" />
     <Compile Include="OrmLiteContext.cs" />
-    <Compile Include="OrmLiteEnumAsIntAttribute.cs" />
+    <Compile Include="EnumAsIntAttribute.cs" />
     <Compile Include="OrmLiteReadApiAsync.cs" />
     <Compile Include="Async\OrmLiteReadCommandExtensionsAsync.cs" />
     <Compile Include="Async\OrmLiteResultsFilterExtensionsAsync.cs" />

--- a/src/ServiceStack.OrmLiteV45/EnumAsIntAttribute.cs
+++ b/src/ServiceStack.OrmLiteV45/EnumAsIntAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ServiceStack.Interfaces
+{
+    public class EnumAsIntAttribute: Attribute
+    {
+    }
+}

--- a/src/ServiceStack.OrmLiteV45/ServiceStack.OrmLiteV45.csproj
+++ b/src/ServiceStack.OrmLiteV45/ServiceStack.OrmLiteV45.csproj
@@ -193,9 +193,6 @@
     <Compile Include="..\ServiceStack.OrmLite\OrmLiteDialectProviderExtensions.cs">
       <Link>OrmLiteDialectProviderExtensions.cs</Link>
     </Compile>
-    <Compile Include="..\ServiceStack.OrmLite\OrmLiteEnumAsIntAttribute.cs">
-      <Link>OrmLiteEnumAsIntAttribute.cs</Link>
-    </Compile>
     <Compile Include="..\ServiceStack.OrmLite\OrmLiteExecFilter.cs">
       <Link>OrmLiteExecFilter.cs</Link>
     </Compile>
@@ -280,6 +277,7 @@
     <Compile Include="..\ServiceStack.OrmLite\UntypedApi.cs">
       <Link>UntypedApi.cs</Link>
     </Compile>
+    <Compile Include="EnumAsIntAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup />

--- a/tests/ServiceStack.OrmLite.Tests/EnumAsIntTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/EnumAsIntTests.cs
@@ -1,0 +1,184 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using ServiceStack.Interfaces;
+
+namespace ServiceStack.OrmLite.Tests
+{
+    public class EnumAsIntTests : OrmLiteTestBase
+    {
+        [Test]
+        public void CanCreateTable()
+        {
+            OpenDbConnection().CreateTable<TypeWithIntEnum>(true);
+        }
+
+        [Test]
+        public void CanStoreEnumValue()
+        {
+            using (var con = OpenDbConnection())
+            {
+                con.CreateTable<TypeWithIntEnum>(true);
+                con.Save(new TypeWithIntEnum { Id = 1, EnumValue = SomeEnum.Value1 });
+            }
+        }
+
+        [Test]
+        public void CanGetEnumValue()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<TypeWithIntEnum>();
+
+                var obj = new TypeWithIntEnum { Id = 1, EnumValue = SomeEnum.Value1 };
+                db.Save(obj);
+                var target = db.SingleById<TypeWithIntEnum>(obj.Id);
+                Assert.AreEqual(obj.Id, target.Id);
+                Assert.AreEqual(obj.EnumValue, target.EnumValue);
+            }
+        }
+
+        [Test]
+        public void CanQueryByEnumValue_using_select_with_expression()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<TypeWithIntEnum>();
+                db.Save(new TypeWithIntEnum { Id = 1, EnumValue = SomeEnum.Value1 });
+                db.Save(new TypeWithIntEnum { Id = 2, EnumValue = SomeEnum.Value1 });
+                db.Save(new TypeWithIntEnum { Id = 3, EnumValue = SomeEnum.Value2 });
+
+                var results = db.Select<TypeWithIntEnum>(q => q.EnumValue == SomeEnum.Value1);
+                Assert.That(results.Count, Is.EqualTo(2));
+                results = db.Select<TypeWithIntEnum>(q => q.EnumValue == SomeEnum.Value2);
+                Assert.That(results.Count, Is.EqualTo(1));
+            }
+        }
+
+        [Test]
+        public void CanQueryByEnumValue_using_select_with_string()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<TypeWithIntEnum>();
+                db.Save(new TypeWithIntEnum { Id = 1, EnumValue = SomeEnum.Value1 });
+                db.Save(new TypeWithIntEnum { Id = 2, EnumValue = SomeEnum.Value1 });
+                db.Save(new TypeWithIntEnum { Id = 3, EnumValue = SomeEnum.Value2 });
+
+                var target = db.SelectFmt<TypeWithIntEnum>("EnumValue".SqlColumn() + " = {0}", (int)SomeEnum.Value1);
+
+                Assert.AreEqual(2, target.Count());
+            }
+        }
+
+        [Test]
+        public void CanQueryByEnumValue_using_where_with_AnonType()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<TypeWithIntEnum>();
+                db.Save(new TypeWithIntEnum { Id = 1, EnumValue = SomeEnum.Value1 });
+                db.Save(new TypeWithIntEnum { Id = 2, EnumValue = SomeEnum.Value1 });
+                db.Save(new TypeWithIntEnum { Id = 3, EnumValue = SomeEnum.Value2 });
+
+                var target = db.Where<TypeWithIntEnum>(new { EnumValue = SomeEnum.Value1 });
+
+                Assert.AreEqual(2, target.Count());
+            }
+        }
+
+        [Test]
+        public void can_select_enum_equals_other_enum()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<DoubleStateEnumAsInt>();
+                db.Insert(new DoubleStateEnumAsInt { Id = "1", State1 = DoubleStateEnumAsInt.State.OK, State2 = DoubleStateEnumAsInt.State.KO });
+                db.Insert(new DoubleStateEnumAsInt { Id = "2", State1 = DoubleStateEnumAsInt.State.OK, State2 = DoubleStateEnumAsInt.State.OK });
+                IEnumerable<DoubleStateEnumAsInt> doubleStates = db.Select<DoubleStateEnumAsInt>(x => x.State1 != x.State2);
+                Assert.AreEqual(1, doubleStates.Count());
+            }
+        }
+        
+        [Test]
+        public void Can_Select_Type_with_Nullable_Enum()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<TypeWithNullableIntEnum>();
+
+                db.Insert(new TypeWithNullableIntEnum { Id = 1, EnumValue = SomeEnum.Value1, NullableEnumValue = SomeEnum.Value2 });
+                db.Insert(new TypeWithNullableIntEnum { Id = 2, EnumValue = SomeEnum.Value1 });
+
+                var rows = db.Select<TypeWithNullableIntEnum>();
+                Assert.That(rows.Count, Is.EqualTo(2));
+
+                var row = rows.First(x => x.NullableEnumValue == null);
+                Assert.That(row.Id, Is.EqualTo(2));
+
+                rows = db.SqlList<TypeWithNullableIntEnum>("SELECT * FROM {0}"
+                    .Fmt(typeof(TypeWithNullableIntEnum).Name.SqlTable()));
+
+                row = rows.First(x => x.NullableEnumValue == null);
+                Assert.That(row.Id, Is.EqualTo(2));
+
+                rows = db.SqlList<TypeWithNullableIntEnum>("SELECT * FROM {0}"
+                    .Fmt(typeof(TypeWithNullableIntEnum).Name.SqlTable()), new { Id = 2 });
+
+                row = rows.First(x => x.NullableEnumValue == null);
+                Assert.That(row.Id, Is.EqualTo(2));
+            }
+        }
+
+        [Test]
+        public void Can_get_Scalar_Enum()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<TypeWithIntEnum>();
+
+                var row = new TypeWithIntEnum { Id = 1, EnumValue = SomeEnum.Value2 };
+                db.Insert(row);
+
+                var someEnum = db.Scalar<SomeEnum>(db.From<TypeWithIntEnum>()
+                    .Where(o => o.Id == row.Id)
+                    .Select(o => o.EnumValue));
+
+                Assert.That(someEnum, Is.EqualTo(SomeEnum.Value2));
+            }
+        }
+    }
+
+    public class DoubleStateEnumAsInt
+    {
+        public enum State
+        {
+            OK,
+            KO
+        }
+
+        public string Id { get; set; }
+        [EnumAsInt]
+        public State State1 { get; set; }
+        [EnumAsInt]
+        public State State2 { get; set; }
+    }
+
+    public class TypeWithIntEnum
+    {
+        public int Id { get; set; }
+        [EnumAsInt]
+        public SomeEnum EnumValue { get; set; }
+    }
+
+    public class TypeWithNullableIntEnum
+    {
+        public int Id { get; set; }
+        [EnumAsInt]
+        public SomeEnum EnumValue { get; set; }
+        [EnumAsInt]
+        public SomeEnum? NullableEnumValue { get; set; }
+    }
+
+
+}

--- a/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
+++ b/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
@@ -129,6 +129,8 @@
     <Compile Include="DateTimeOffsetTests.cs" />
     <Compile Include="DateTimeTests.cs" />
     <Compile Include="DefaultValueTests.cs" />
+    <Compile Include="EnumAsIntTests.cs" />
+    <Compile Include="EnumTests.cs" />
     <Compile Include="UseCase\ExpressionsAuthorTests.cs" />
     <Compile Include="Expression\ComplexJoinTests.cs" />
     <Compile Include="Expression\ExpressionUsingCustomSerializedEnumTests.cs" />
@@ -181,7 +183,6 @@
     <Compile Include="TestHelpers.cs" />
     <Compile Include="TypeDescriptorMetadataTests.cs" />
     <Compile Include="Shared\ApiUtilExtensions.cs" />
-    <Compile Include="EnumTests.cs" />
     <Compile Include="ExpressionTests.cs" />
     <Compile Include="ExpressionVisitorTests.cs" />
     <Compile Include="Expression\AdditiveExpressionsTest.cs" />


### PR DESCRIPTION
Resubmission of pull request #490

Add functionality to allow enums to be stored as integer values without having to declare them as "flags"

Create new attribute type EnumAsAttrubute. This works just as a property label - the class has no functionality.

In OrmLiteConfigExtensions.cs - GetModelDefinition(), Check for this new attribute, and if included, set treatAsType to the underlying type.

In OrmLiteDialectProviderBase.cs - GetConverterBestMatch(), use fieldDef.ColumnType rather than fieldDef.FieldType. ColumnType will return FieldType anyway if TreatAsType is null.

SqlExpression.cs
In GetExpression(), check for EnumAsInt attribute and set new EnumAsInt property of EnumMemberAccess as appropriate. Use this new property in VisitBinary().

Ensure that all test in EnumTests pass.

Copy appropriate tests into EnumAsIntTests, using data classes with EnumAsInt attribute and ensure that all pass.