### PR TITLE
Fixed handling of Sql.In(empty array) and Sql.In(null)

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServerTests/Expressions/AuthorUseCase.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/Expressions/AuthorUseCase.cs
@@ -374,6 +374,14 @@ namespace ServiceStack.OrmLite.SqlServerTests.Expressions
                 expected = db.Select<Author>(x => x.Active == false).Count;
                 rows = db.Delete<Author>(x => x.Active == false);
                 Assert.AreEqual(expected, rows);
+
+                // Sql.In(empty array) and Sql.In(null) should evaluate to false rather than failing
+
+                expected = 0;
+                result = db.Select<Author>(rn => Sql.In(rn.City, new string[0]));
+                Assert.AreEqual(expected, result.Count);
+                result = db.Select<Author>(rn => Sql.In(rn.City, (string[])null));
+                Assert.AreEqual(expected, result.Count);
             }
         }
     }

--- a/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
@@ -1663,10 +1663,16 @@ namespace ServiceStack.OrmLite
             var lambda = Expression.Lambda<Func<object>>(member);
             var getter = lambda.Compile();
             var argValue = getter();
+
+            if (argValue == null)
+                return "(1=0)"; // "column IN (NULL)" is always false
+
             var enumerableArg = argValue as IEnumerable;
             if (enumerableArg != null)
             {
                 var inArgs = Sql.Flatten(getter() as IEnumerable);
+                if (inArgs.Count == 0)
+                    return "(1=0)"; // "column IN ([])" is always false
 
                 var sIn = new StringBuilder();
                 foreach (var e in inArgs)


### PR DESCRIPTION
Sql.In(empty array) and Sql.In(null) are now evaluated as false (i.e. match no rows) rather than failing with an unhelpful error like "System.Data.SqlClient.SqlException : Incorrect syntax near ')'." or NullReferenceException, respectively.