### PR TITLE
Fix the Oracle string length default in the string converter

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle/Converters/OracleStringConverters.cs
+++ b/src/ServiceStack.OrmLite.Oracle/Converters/OracleStringConverters.cs
@@ -5,7 +5,7 @@ namespace ServiceStack.OrmLite.Oracle.Converters
 {
     public class OracleStringConverter : StringConverter
     {
-        public OracleStringConverter() : base(128) {}
+        public OracleStringConverter() : base(4000) {}
         public OracleStringConverter(int stringLength) : base(stringLength) {}
 
         public override string MaxColumnDefinition


### PR DESCRIPTION
@mythz This fixes the mysterious failures I was getting. Something changed so that the length is copied into the parameter as the max size, so it needs to be correct now.
Shortly I'll be able to get back to the memory leak issue.