### PR TITLE
MySQL issue with nullable enum + int casting prob

### DIFF
--- a/src/ServiceStack.OrmLite.MySql.Tests/EnumTests.cs
+++ b/src/ServiceStack.OrmLite.MySql.Tests/EnumTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using NUnit.Framework;
+using ServiceStack.DataAnnotations;
 
 namespace ServiceStack.OrmLite.MySql.Tests
 {
@@ -30,6 +31,36 @@ namespace ServiceStack.OrmLite.MySql.Tests
                 var obj = new TypeWithEnum { Id = 1, EnumValue = SomeEnum.Value1 };
                 con.Save(obj);
                 var target = con.SingleById<TypeWithEnum>(obj.Id);
+                Assert.AreEqual(obj.Id, target.Id);
+                Assert.AreEqual(obj.EnumValue, target.EnumValue);
+            }
+        }
+
+        [Test]
+        public void CanCreateTableNullableEnum()
+        {
+            OpenDbConnection().CreateTable<TypeWithNullableEnum>(true);
+        }
+
+        [Test]
+        public void CanStoreNullableEnumValue()
+        {
+            using (var con = OpenDbConnection())
+            {
+                con.CreateTable<TypeWithNullableEnum>(true);
+                con.Save(new TypeWithNullableEnum { Id = 1, EnumValue = SomeEnum.Value1 });
+            }
+        }
+
+        [Test]
+        public void CanGetNullableEnumValue()
+        {
+            using (var con = OpenDbConnection())
+            {
+                con.CreateTable<TypeWithNullableEnum>(true);
+                var obj = new TypeWithNullableEnum { Id = 1, EnumValue = SomeEnum.Value1 };
+                con.Save(obj);
+                var target = con.SingleById<TypeWithNullableEnum>(obj.Id);
                 Assert.AreEqual(obj.Id, target.Id);
                 Assert.AreEqual(obj.EnumValue, target.EnumValue);
             }
@@ -82,6 +113,72 @@ namespace ServiceStack.OrmLite.MySql.Tests
                 Assert.AreEqual(2, target.Count());
             }
         }
+
+        [Test]
+        public void CanQueryByNullableEnumValue_using_where_with_AnonType()
+        {
+            using (var con = OpenDbConnection())
+            {
+                con.CreateTable<TypeWithEnum>(true);
+                con.Save(new TypeWithNullableEnum { Id = 1, EnumValue = SomeEnum.Value1, IntEnum = SomeIntEnum.One });
+                con.Save(new TypeWithNullableEnum { Id = 2, EnumValue = SomeEnum.Value1, IntEnum = SomeIntEnum.One });
+                con.Save(new TypeWithNullableEnum { Id = 3, EnumValue = SomeEnum.Value2, IntEnum = SomeIntEnum.Two });
+
+                var target = con.Where<TypeWithNullableEnum>(new { EnumValue = SomeEnum.Value1 });
+                var enumInt = con.Where<TypeWithNullableEnum>(new {IntEnum = SomeIntEnum.One});
+
+                Assert.AreEqual(2, target.Count);
+                Assert.AreEqual(2, enumInt.Count);
+            }
+        }
+
+        [Test]
+        public void CanSaveNullableEnum_with_specific_id_select_with_anon_type()
+        {
+            using (var con = OpenDbConnection())
+            {
+                con.CreateTableIfNotExists<MyObj>();
+                var myObj = new MyObj();
+                myObj.Id = 1;
+                myObj.Test = MyEnum.One;
+                con.Insert(myObj);
+
+                myObj = con.Single<MyObj>(new {Id = 1});
+
+                Assert.That(myObj.Id, Is.EqualTo(1));
+                Assert.That(myObj.Test, Is.Not.EqualTo(null));
+                Assert.That(myObj.Test, Is.EqualTo(MyEnum.One));
+            }
+        }
+
+        [Test]
+        public void CanSaveNullableEnum_with_specific_id_select_with_type()
+        {
+            using (var existsCon = OpenDbConnection())
+            {
+                existsCon.CreateTableIfNotExists<MyObj>();
+                var exists = existsCon.SingleById<MyObj>(1);
+                if (exists != null)
+                {
+                    existsCon.DeleteById<MyObj>(1);
+                }
+            }
+
+            using (var con = OpenDbConnection())
+            {
+
+                var myObj = new MyObj();
+                myObj.Id = 1;
+                myObj.Test = MyEnum.One;
+                con.Insert(myObj);
+
+                myObj = con.Single<MyObj>(x => x.Id == 1);
+
+                Assert.That(myObj.Id, Is.EqualTo(1));
+                Assert.That(myObj.Test, Is.Not.EqualTo(null));
+                Assert.That(myObj.Test, Is.EqualTo(MyEnum.One));
+            }
+        }
     }
 
     public enum SomeEnum : long
@@ -91,9 +188,38 @@ namespace ServiceStack.OrmLite.MySql.Tests
         Value3
     }
 
+    [EnumAsInt]
+    public enum SomeIntEnum
+    {
+        Zero = 0,
+        One = 1,
+        Two = 2
+    }
+
+    [EnumAsInt]
+    public enum MyEnum : int
+    {
+        Zero = 0,
+        One = 1
+    }
+
+    public class MyObj
+    {
+        public int Id { get; set; }
+        public MyEnum? Test { get; set; }
+    }
+
     public class TypeWithEnum
     {
         public int Id { get; set; }
-        public SomeEnum EnumValue { get; set; } 
+        public SomeEnum EnumValue { get; set; }
+        public SomeIntEnum IntEnum { get; set; }
+    }
+	
+	public class TypeWithNullableEnum
+    {
+        public int Id { get; set; }
+        public SomeEnum? EnumValue { get; set; }
+        public SomeIntEnum? IntEnum { get; set; }
     }
 }

--- a/src/ServiceStack.OrmLite/OrmLiteWriteCommandExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteWriteCommandExtensions.cs
@@ -341,7 +341,16 @@ namespace ServiceStack.OrmLite
                         else
                         {
                             var fieldValue = converter.FromDbValue(fieldDef.FieldType, value);
-                            fieldDef.SetValueFn(objWithProperties, fieldValue);
+                            if (fieldDef.FieldType.IsEnum && fieldDef.IsNullable)
+                            {
+                                var enumType = Nullable.GetUnderlyingType(fieldDef.PropertyInfo.PropertyType);
+                                var enumValue = Enum.ToObject(enumType, value);
+                                fieldDef.PropertyInfo.SetProperty(objWithProperties, enumValue);
+                            }
+                            else
+                            {
+                                fieldDef.SetValueFn(objWithProperties, fieldValue);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Hey @mythz,

Related to [issue posted in the forums](https://forums.servicestack.net/t/enumasint-field-not-loading-when-nullable-4-0-54/2170), I found a simple solution to show way forward/issue with nullable enum properties casting from integer.

Better solution would probably be done in the Express building in `PropertyInvoker.cs` 

https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/src/ServiceStack.OrmLite/PropertyInvoker.cs#L37

Expression could build a predicate checking for Enum + Nullable type, eg 

```
Nullable.GetUnderlyingType(propertyInfo.PropertyType) != null
&& Nullable.GetUnderlyingType(propertyInfo.PropertyType).IsEnum)
``` 

Not familiar with Expression building, so was unsure how to build an expression to call equivalent of:

```
var enumType = Nullable.GetUnderlyingType(fieldDef.PropertyInfo.PropertyType);
var enumValue = Enum.ToObject(enumType, value);
``` 

Only tested with MySQL, but might be a problem with other DBs as well. Any ideas?