### PR TITLE
StackOverflowException when FromDbValue() is called with a value type that has no converter registered

### DIFF
--- a/tests/ServiceStack.OrmLite.Tests/ConverterTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/ConverterTests.cs
@@ -10,6 +10,18 @@ namespace ServiceStack.OrmLite.Tests
     [TestFixture]
     public class ConverterTests : OrmLiteTestBase
     {
+        private struct TestStruct
+        {
+        }
+
+        [Test, Explicit]
+        public void FromDbValue_StackOverflowException()
+        {
+            var dialectProvider = OrmLiteConfig.DialectProvider;
+            var convertedValue = dialectProvider.FromDbValue(12345, typeof(TestStruct)); // StackOverflowException in v4.0.54
+            Assert.That(convertedValue, Is.Null);
+        }
+
         [Test]
         public void Can_insert_update_and_select_AllTypes()
         {


### PR DESCRIPTION
Here is a unit test that reproduces the problem. I'm not sure what it _should_ do, but definitely not _that_. :) In v4.0.44 it returned null, which isn't great either, as it masks the problem (lack of a converter). A helpful exception would probably be good here, but I don't know the best place to throw it.