### PR TITLE
Implemented an UpdateIncrement API

### DIFF
--- a/src/ServiceStack.OrmLite/Expressions/WriteExpressionCommandExtensions.cs
+++ b/src/ServiceStack.OrmLite/Expressions/WriteExpressionCommandExtensions.cs
@@ -51,6 +51,38 @@ namespace ServiceStack.OrmLite
             return dbCmd.UpdateOnly(obj, q);
         }
 
+        public static int UpdateIncrement<T>(this IDbCommand dbCmd, T model, SqlExpression<T> fields)
+        {
+            UpdateIncrementSql(dbCmd, model, fields);
+            return dbCmd.ExecNonQuery();
+        }
+
+        internal static void UpdateIncrementSql<T>(this IDbCommand dbCmd, T model, SqlExpression<T> fields)
+        {
+            if (OrmLiteConfig.UpdateFilter != null)
+                OrmLiteConfig.UpdateFilter(dbCmd, model);
+
+            fields.CopyParamsTo(dbCmd);
+
+            dbCmd.GetDialectProvider().PrepareUpdateRowIncrementStatement(dbCmd, model, fields.UpdateFields);
+
+            if (!fields.WhereExpression.IsNullOrEmpty())
+                dbCmd.CommandText += " " + fields.WhereExpression;
+        }
+
+        public static int UpdateIncrement<T, TKey>(this IDbCommand dbCmd, T obj,
+            Expression<Func<T, TKey>> fields = null,
+            Expression<Func<T, bool>> where = null)
+        {
+            if (fields == null)
+                throw new ArgumentNullException("fields");
+
+            var q = dbCmd.GetDialectProvider().SqlExpression<T>();
+            q.Update(fields);
+            q.Where(where);
+            return dbCmd.UpdateIncrement(obj, q);
+        }
+
         public static int UpdateNonDefaults<T>(this IDbCommand dbCmd, T item, Expression<Func<T, bool>> obj)
         {
             if (OrmLiteConfig.UpdateFilter != null)

--- a/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
@@ -121,6 +121,8 @@ namespace ServiceStack.OrmLite
 
         void PrepareUpdateRowStatement(IDbCommand dbCmd, object objWithProperties, ICollection<string> UpdateFields = null);
 
+        void PrepareUpdateRowIncrementStatement(IDbCommand dbCmd, object objWithProperties, ICollection<string> UpdateFields);
+
         string ToDeleteStatement(Type tableType, string sqlFilter, params object[] filterParams);
 
         IDbCommand CreateParameterizedDeleteStatement(IDbConnection connection, object objWithProperties);

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -949,6 +949,59 @@ namespace ServiceStack.OrmLite
                 throw new Exception("No valid update properties provided (e.g. p => p.FirstName): " + dbCmd.CommandText);
         }
 
+        public virtual void PrepareUpdateRowIncrementStatement(IDbCommand dbCmd, object objWithProperties, ICollection<string> updateFields)
+        {
+            if (updateFields.Count == 0)
+                throw new Exception("No valid update properties provided (e.g. p => p.FirstName): " + dbCmd.CommandText);
+
+            var sqlFilter = new StringBuilder();
+            var sql = new StringBuilder();
+            var modelDef = objWithProperties.GetType().GetModelDefinition();
+            var quotedFieldName = string.Empty;
+
+            foreach (var fieldDef in modelDef.FieldDefinitions)
+            {
+                if (!updateFields.Contains(fieldDef.FieldName))
+                    continue;
+
+                if (fieldDef.AutoIncrement || fieldDef.IsComputed || fieldDef.IsPrimaryKey ||
+                    fieldDef.IsRowVersion || fieldDef.Name == OrmLiteConfig.IdField)
+                    continue;
+
+                try
+                {
+                    if (sql.Length > 0)
+                        sql.Append(", ");
+
+                    quotedFieldName = GetQuotedColumnName(fieldDef.FieldName);
+
+                    if (fieldDef.FieldType.IsNumericType())
+                    {
+                        sql
+                            .Append(quotedFieldName)
+                            .Append("=")
+                            .Append(quotedFieldName)
+                            .Append("+")
+                            .Append(this.AddParam(dbCmd, fieldDef.GetValue(objWithProperties), fieldDef.ColumnType).ParameterName);
+                    }
+                    else
+                    {
+                        sql
+                            .Append(quotedFieldName)
+                            .Append("=")
+                            .Append(this.AddParam(dbCmd, fieldDef.GetValue(objWithProperties), fieldDef.ColumnType).ParameterName);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Error("ERROR in ToUpdateIncrementRowStatement(): " + ex.Message, ex);
+                }
+            }
+
+            dbCmd.CommandText = string.Format("UPDATE {0} SET {1}{2}",
+                GetQuotedTableName(modelDef), sql, (sqlFilter.Length > 0 ? " WHERE " + sqlFilter : ""));
+        }
+
         public virtual string ToDeleteStatement(Type tableType, string sqlFilter, params object[] filterParams)
         {
             var sql = new StringBuilder();

--- a/tests/ServiceStack.OrmLite.Tests/ApiSqlServerTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/ApiSqlServerTests.cs
@@ -324,6 +324,18 @@ namespace ServiceStack.OrmLite.Tests
             db.UpdateOnly(new Person { FirstName = "JJ" }, q => q.Update(x => x.FirstName).Where(x => x.FirstName == "Jimi"));
             Assert.That(db.GetLastSql(), Is.EqualTo("UPDATE \"Person\" SET \"FirstName\"=@1 WHERE (\"FirstName\" = @0)"));
 
+            db.UpdateIncrement(new Person { Age = 3 }, x => x.Age);
+            Assert.That(db.GetLastSql(), Is.EqualTo("UPDATE \"Person\" SET \"Age\"=\"Age\"+@0"));
+
+            db.UpdateIncrement(new Person { Age = 5 }, x => x.Age, x => x.LastName == "Presley");
+            Assert.That(db.GetLastSql(), Is.EqualTo("UPDATE \"Person\" SET \"Age\"=\"Age\"+@1 WHERE (\"LastName\" = @0)"));
+
+            db.UpdateIncrement(new Person { Age = -2, LastName = "Hendo" }, db.From<Person>().Update(x => new { x.Age, x.LastName }));
+            Assert.That(db.GetLastSql(), Is.EqualTo("UPDATE \"Person\" SET \"LastName\"=@0, \"Age\"=\"Age\"+@1"));
+
+            db.UpdateIncrement(new Person { Age = 10}, db.From<Person>().Update(x => x.Age).Where(x => x.FirstName == "JJ"));
+            Assert.That(db.GetLastSql(), Is.EqualTo("UPDATE \"Person\" SET \"Age\"=\"Age\"+@1 WHERE (\"FirstName\" = @0)"));
+
             db.UpdateFmt<Person>(set: "FirstName = {0}".SqlFmt("JJ"), where: "LastName = {0}".SqlFmt("Hendrix"));
             Assert.That(db.GetLastSql(), Is.EqualTo("UPDATE \"Person\" SET FirstName = 'JJ' WHERE LastName = 'Hendrix'"));
 

--- a/tests/ServiceStack.OrmLite.Tests/ApiSqliteTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/ApiSqliteTests.cs
@@ -328,6 +328,18 @@ namespace ServiceStack.OrmLite.Tests
             db.UpdateOnly(new Person { FirstName = "JJ" }, q => q.Update(p => p.FirstName).Where(x => x.FirstName == "Jimi"));
             Assert.That(db.GetLastSql(), Is.EqualTo("UPDATE \"Person\" SET \"FirstName\"=@1 WHERE (\"FirstName\" = @0)"));
 
+            db.UpdateIncrement(new Person { Age = 3 }, x => x.Age);
+            Assert.That(db.GetLastSql(), Is.EqualTo("UPDATE \"Person\" SET \"Age\"=\"Age\"+@0"));
+
+            db.UpdateIncrement(new Person { Age = 5 }, x => x.Age, x => x.LastName == "Presley");
+            Assert.That(db.GetLastSql(), Is.EqualTo("UPDATE \"Person\" SET \"Age\"=\"Age\"+@1 WHERE (\"LastName\" = @0)"));
+
+            db.UpdateIncrement(new Person { Age = -2, LastName = "Hendo" }, db.From<Person>().Update(x => new { x.Age, x.LastName }));
+            Assert.That(db.GetLastSql(), Is.EqualTo("UPDATE \"Person\" SET \"LastName\"=@0, \"Age\"=\"Age\"+@1"));
+
+            db.UpdateIncrement(new Person { Age = 10 }, db.From<Person>().Update(x => x.Age).Where(x => x.FirstName == "JJ"));
+            Assert.That(db.GetLastSql(), Is.EqualTo("UPDATE \"Person\" SET \"Age\"=\"Age\"+@1 WHERE (\"FirstName\" = @0)"));
+
             db.UpdateFmt<Person>(set: "FirstName = {0}".SqlFmt("JJ"), where: "LastName = {0}".SqlFmt("Hendrix"));
             Assert.That(db.GetLastSql(), Is.EqualTo("UPDATE \"Person\" SET FirstName = 'JJ' WHERE LastName = 'Hendrix'"));
 


### PR DESCRIPTION
Implement an UpdateIncrement API similar to UpdateOnly, but that generates SQL to add the value to the existing database field instead of doing attribution, when the field is a numeric field. Other field types still do attribution and we can mix field types.

db.UpdateIncrement(new Person { Age = 5 }, db.From<Person>().Update(p =>p.Age).Where(x => x.FirstName == "Jimi"));
will generate this SQL:
UPDATE "Person" SET "Age" = "Age" + 5 WHERE ("FirstName" = 'Jimi')

This is usefull to increment counter, totals, etc. without having to load the object from the BD first and avoinding concurrency conflicts.