### PR TITLE
Enhance T4 templates for SqlServer to include more foreign key support

### DIFF
--- a/src/T4/OrmLite.Core.ttinclude
+++ b/src/T4/OrmLite.Core.ttinclude
@@ -829,12 +829,12 @@ class SqlServerSchemaReader : SchemaReader
 
 	public override Tables ReadSchema(DbConnection connection, DbProviderFactory factory)
 	{
-		var result=new Tables();
+		var result = new Tables();
 
 		_connection=connection;
 		_factory=factory;
 
-		var cmd=_factory.CreateCommand();
+		var cmd = _factory.CreateCommand();
 		cmd.Connection=connection;
 		cmd.CommandText=TABLE_SQL;
 
@@ -853,8 +853,34 @@ class SqlServerSchemaReader : SchemaReader
 					tbl.IsFunction=string.Compare(rdr["TABLE_TYPE"].ToString(), "TVF", true)==0;
 					tbl.CleanName=CleanUp(tbl.Name);
 					tbl.ClassName=Inflector.MakeSingular(tbl.CleanName);
-
+					
 					result.Add(tbl);
+				}
+			}
+		}
+		
+		var cmdFks = _factory.CreateCommand();
+		cmdFks.Connection=connection;
+		cmdFks.CommandText=FOREIGN_KEYS_SQL;
+		//get all the foreign keys and add them to the tables.
+		using(cmdFks)
+		{
+			using (var rdr=cmdFks.ExecuteReader())
+			{
+				while(rdr.Read())
+				{
+					var tableName = rdr["TableWithForeignKey"].ToString();
+					var table = result.FirstOrDefault(x => x.Name == tableName);
+					if (table != null) {
+						if (table.FKeys == null) {
+							table.FKeys = new List<FKey>(); 
+						}
+						var newForeignKey = new FKey();
+						newForeignKey.ToTable = rdr["TargetTable"].ToString();
+						newForeignKey.FromColumn = rdr["ForeignKeyColumn"].ToString();
+						newForeignKey.ToColumn = rdr["TargetTableKey"].ToString();
+						table.FKeys.Add(newForeignKey);
+                    }
 				}
 			}
 		}
@@ -1285,6 +1311,20 @@ class SqlServerSchemaReader : SchemaReader
 								WHERE TABLE_NAME=@tableName AND TABLE_SCHEMA=@schemaName
 								) T
 								ORDER BY T.OrdinalPosition ASC";
+
+	const string FOREIGN_KEYS_SQL=
+@"SELECT DISTINCT
+	tableWithForeignKey.name AS TableWithForeignKey,
+	columnWithForeignKey.name AS ForeignKeyColumn,
+	referencedTable.name AS TargetTable,
+	referencedColumn.name AS TargetTableKey
+FROM sys.foreign_key_columns foreignKeyColumn
+INNER JOIN sys.tables tableWithForeignKey ON tableWithForeignKey.object_id = foreignKeyColumn.parent_object_id
+INNER JOIN sys.columns columnWithForeignKey ON columnWithForeignKey.object_id = foreignKeyColumn.parent_object_id 
+	AND columnWithForeignKey.column_id = foreignKeyColumn.parent_column_id
+INNER JOIN sys.tables referencedTable ON referencedTable.object_id = foreignKeyColumn.referenced_object_id
+INNER JOIN sys.columns referencedColumn ON referencedColumn.object_id = foreignKeyColumn.referenced_object_id 
+	AND referencedColumn.column_id = foreignKeyColumn.referenced_column_id";
 
     const string SP_NAMES_SQL=@"SELECT  o.name AS sp_name, s.name AS schema_name
 FROM    sys.objects o

--- a/src/T4/OrmLite.Poco.tt
+++ b/src/T4/OrmLite.Poco.tt
@@ -89,6 +89,9 @@ priorProperyNames.Add(col.PropertyName);
         [AutoIncrement]
 <# }  if (col.IsComputed) { #>
         [Compute]        
+<# }  if (tbl.FKeys != null && tbl.FKeys.Any(x => x.FromColumn ==  col.PropertyName)) { 
+	   var toTable = tbl.FKeys.First(x => x.FromColumn == col.PropertyName).ToTable;#>
+        [References(typeof(<#=toTable#>))]  
 <# }  if (col.IsNullable != true && col.IsAutoIncrement != true) { #>
         [Required]
 <# } if (!col.IsPK){#>


### PR DESCRIPTION
Hit a problem during development where we'd have an item described below:

```
Item {
   OwnerId: 1,
   Owner2Id: 2
}
```
Added the following properties to the partial class to load references:

```
[Reference]
public Owner Owner { get; set; }
[Reference]
public Owner Owner2 { get; set; }
```
However, on doing a Db.LoadSingleById(), we'd end up with this:

```
Item {
   OwnerId: 1,
   Owner: { Id: 1, Name: "Owner" },
   Owner2Id: 2,
   Owner2: { Id: 1, Name: "Owner" }
}
```
The first Owner entity was being loaded into the second.

Adding the [References(typeof(Owner))] attribute to the foreign key field in the POCO generated by the T4 templates resolved the odd behaviour, and brought the POCO's more in line with the code demonstrated on the Ormlite documentation page.

The result is that in the POCO, this:

```
public int? OwnerId { get; set; }
public int? Owner2Id { get; set; }
```
Becomes this:

```
[References(typeof(Owner))]
public int? OwnerId { get; set; }
[References(typeof(Owner))]
public int? Owner2Id { get; set; }
```

I'm not sure if the underlying issue needs to be addressed. It does not affect me any more. It could still be a nuisance for people using the T4 templates for database engines other than SqlServer or SQLite.