### PR TITLE
DropColumn fails in SQL Server

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServerTests/SchemaTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/SchemaTests.cs
@@ -1,0 +1,34 @@
+﻿using NUnit.Framework;
+
+namespace ServiceStack.OrmLite.SqlServerTests
+{
+    [TestFixture]
+    public class SchemaTests : OrmLiteTestBase
+    {
+        public class SchemaTest
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        [Test]
+        public void Drop_add_column()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.CreateTable<SchemaTest>();
+
+                Assert.That(db.ColumnExists<SchemaTest>(x => x.Id));
+                Assert.That(db.ColumnExists<SchemaTest>(x => x.Name));
+
+                db.DropColumn<SchemaTest>(nameof(SchemaTest.Name));
+                Assert.That(!db.ColumnExists<SchemaTest>(x => x.Name));
+                db.DropColumn<SchemaTest>(nameof(SchemaTest.Name)); // Doesn't throw, even though column doesn't exist
+
+                db.AddColumn<SchemaTest>(x => x.Name);
+                Assert.That(db.ColumnExists<SchemaTest>(x => x.Name));
+                db.AddColumn<SchemaTest>(x => x.Name); // Doesn't throw, even though column already exists
+            }
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
+++ b/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Converters\ConvertersOrmLiteTestBase.cs" />
     <Compile Include="Converters\HierarchyIdTests.cs" />
     <Compile Include="Converters\SpatialsTests.cs" />
+    <Compile Include="SchemaTests.cs" />
     <Compile Include="SqlServerExpressionVisitorQueryTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SqlServerTypes\Loader.cs" />


### PR DESCRIPTION
OrmLiteSchemaModifyApi.DropColumn() fails when used with SQL Server, because the syntax it uses is `ALTER TABLE table_name DROP column_name` while SQL Server expects `ALTER TABLE table_name DROP COLUMN column_name` This unit test reproduces the problem. It fails with

```
System.Data.SqlClient.SqlException : 'Name' is not a constraint.
Could not drop constraint. See previous errors.
   at System.Data.SqlClient.SqlConnection.OnError(SqlException exception, Boolean breakConnection, Action`1 wrapCloseInAction)
   at System.Data.SqlClient.TdsParser.ThrowExceptionAndWarning(TdsParserStateObject stateObj, Boolean callerHasConnectionLock, Boolean asyncClose)
   at System.Data.SqlClient.TdsParser.TryRun(RunBehavior runBehavior, SqlCommand cmdHandler, SqlDataReader dataStream, BulkCopySimpleResultSet bulkCopyHandler, TdsParserStateObject stateObj, Boolean& dataReady)
   at System.Data.SqlClient.SqlCommand.RunExecuteNonQueryTds(String methodName, Boolean async, Int32 timeout, Boolean asyncWrite)
   at System.Data.SqlClient.SqlCommand.InternalExecuteNonQuery(TaskCompletionSource`1 completion, String methodName, Boolean sendToPipe, Int32 timeout, Boolean asyncWrite)
   at System.Data.SqlClient.SqlCommand.ExecuteNonQuery()
   at ServiceStack.OrmLite.OrmLiteCommand.ExecuteNonQuery() in C:\G it\ServiceStack.OrmLite\src\ServiceStack.OrmLite\OrmLiteCommand.cs:line 43
   at ServiceStack.OrmLite.OrmLiteWriteCommandExtensions.ExecuteSql(IDbCommand dbCmd, String sql, IEnumerable`1 sqlParams) in C:\G it\ServiceStack.OrmLite\src\ServiceStack.OrmLite\OrmLiteWriteCommandExtensions.cs:line 233
   at ServiceStack.OrmLite.OrmLiteWriteApi.<>c__DisplayClass2_0.<ExecuteSql>b__0(IDbCommand dbCmd) in C:\G it\ServiceStack.OrmLite\src\ServiceStack.OrmLite\OrmLiteWriteApi.cs:line 46
   at ServiceStack.OrmLite.OrmLiteExecFilter.Exec[T](IDbConnection dbConn, Func`2 filter) in C:\G it\ServiceStack.OrmLite\src\ServiceStack.OrmLite\OrmLiteExecFilter.cs:line 61
   at ServiceStack.OrmLite.OrmLiteReadExpressionsApi.Exec[T](IDbConnection dbConn, Func`2 filter) in C:\G it\ServiceStack.OrmLite\src\ServiceStack.OrmLite\OrmLiteReadExpressionsApi.cs:line 14
   at ServiceStack.OrmLite.OrmLiteWriteApi.ExecuteSql(IDbConnection dbConn, String sql) in C:\G it\ServiceStack.OrmLite\src\ServiceStack.OrmLite\OrmLiteWriteApi.cs:line 46
   at ServiceStack.OrmLite.OrmLiteSchemaModifyApi.DropColumn(IDbConnection dbConn, Type modelType, String columnName) in C:\G it\ServiceStack.OrmLite\src\ServiceStack.OrmLite\OrmLiteSchemaModifyApi.cs:line 91
   at ServiceStack.OrmLite.OrmLiteSchemaModifyApi.DropColumn[T](IDbConnection dbConn, String columnName) in C:\G it\ServiceStack.OrmLite\src\ServiceStack.OrmLite\OrmLiteSchemaModifyApi.cs:line 80
   at ServiceStack.OrmLite.SqlServerTests.SchemaTests.Drop_add_column() in C:\G it\ServiceStack.OrmLite\src\ServiceStack.OrmLite.SqlServerTests\SchemaTests.cs:line 24
```