### PR TITLE
Implement new public IHasDbTransaction interface from ServiceStack.Common

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteConnection.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConnection.cs
@@ -8,7 +8,7 @@ namespace ServiceStack.OrmLite
     /// Wrapper IDbConnection class to allow for connection sharing, mocking, etc.
     /// </summary>
     public class OrmLiteConnection
-        : IDbConnection, IHasDbConnection, IHasDbTransaction
+        : IDbConnection, IHasDbConnection, IHasDbTransaction, ICanSetDbTransaction
     {
         public readonly OrmLiteConnectionFactory Factory;
         public IDbTransaction Transaction { get; set; }
@@ -34,6 +34,11 @@ namespace ServiceStack.OrmLite
                 }
                 return dbConnection;
             }
+        }
+
+        IDbTransaction IHasDbTransaction.DbTransaction
+        {
+            get { return Transaction; }
         }
 
         public void Dispose()
@@ -125,7 +130,7 @@ namespace ServiceStack.OrmLite
         }
     }
 
-    internal interface IHasDbTransaction
+    internal interface ICanSetDbTransaction
     {
         IDbTransaction Transaction { get; set; }
     }

--- a/src/ServiceStack.OrmLite/OrmLiteConnectionFactory.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConnectionFactory.cs
@@ -218,7 +218,7 @@ namespace ServiceStack.OrmLite
 
         public static IDbTransaction ToDbTransaction(this IDbTransaction dbTrans)
         {
-            var hasDbTrans = dbTrans as IHasDbTransaction;
+            var hasDbTrans = dbTrans as ICanSetDbTransaction;
             return hasDbTrans != null
                 ? hasDbTrans.Transaction
                 : dbTrans;

--- a/src/ServiceStack.OrmLite/OrmLiteTransaction.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteTransaction.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Data;
+using ServiceStack.Data;
 
 namespace ServiceStack.OrmLite
 {
-    public class OrmLiteTransaction : IDbTransaction, IHasDbTransaction
+    public class OrmLiteTransaction : IDbTransaction, IHasDbTransaction, ICanSetDbTransaction
     {
         public IDbTransaction Transaction { get; set; }
         private readonly IDbConnection db;
@@ -14,7 +15,7 @@ namespace ServiceStack.OrmLite
             this.Transaction = transaction;
 
             //If OrmLite managed connection assign to connection, otherwise use OrmLiteContext
-            var ormLiteConn = this.db as IHasDbTransaction;
+            var ormLiteConn = this.db as ICanSetDbTransaction;
             if (ormLiteConn != null)
             {
                 ormLiteConn.Transaction = this.Transaction = transaction;
@@ -25,6 +26,11 @@ namespace ServiceStack.OrmLite
             }
         }
 
+        IDbTransaction IHasDbTransaction.DbTransaction
+        {
+            get { return Transaction; }
+        }
+
         public void Dispose()
         {
             try
@@ -33,7 +39,7 @@ namespace ServiceStack.OrmLite
             }
             finally
             {
-                var ormLiteConn = this.db as IHasDbTransaction;
+                var ormLiteConn = this.db as ICanSetDbTransaction;
                 if (ormLiteConn != null)
                 {
                     ormLiteConn.Transaction = null;


### PR DESCRIPTION
This allows the real transaction to easily be extracted from an OrmLiteTransaction. The existing internal interface was renamed to ICanSetDbTransaction.

These changes will need the new version of ServiceStack.Common.dll to build (not included).