### PR TITLE
Unit test fixes

### DIFF
--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/CreatePostgreSQLTablesTests.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/CreatePostgreSQLTablesTests.cs
@@ -110,9 +110,9 @@ namespace ServiceStack.OrmLite.PostgreSQL.Tests
 BEGIN
 
     IF NOT EXISTS(
-        SELECT schema_name
-          FROM information_schema.schemata
-          WHERE schema_name = '{0}'
+        SELECT 1
+          FROM INFORMATION_SCHEMA.SCHEMATA
+          WHERE SCHEMA_NAME = '{0}'
       )
     THEN
       EXECUTE 'CREATE SCHEMA ""{0}""';

--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/SchemaTests.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/SchemaTests.cs
@@ -31,9 +31,9 @@ namespace ServiceStack.OrmLite.Tests
 BEGIN
 
     IF NOT EXISTS(
-        SELECT schema_name
-          FROM information_schema.schemata
-          WHERE schema_name = 'TestSchema'
+        SELECT 1
+          FROM INFORMATION_SCHEMA.SCHEMATA
+          WHERE SCHEMA_NAME = 'TestSchema'
       )
     THEN
       EXECUTE 'CREATE SCHEMA ""TestSchema""';

--- a/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerGeographyTypeConverter.cs
+++ b/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerGeographyTypeConverter.cs
@@ -11,7 +11,7 @@ namespace ServiceStack.OrmLite.SqlServer.Converters
     {
         public override string ColumnDefinition
         {
-            get { return "GEOGRAPHY"; }
+            get { return "geography"; }
         }
 
         public override object FromDbValue(Type fieldType, object value)

--- a/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerGeometryTypeConverter.cs
+++ b/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerGeometryTypeConverter.cs
@@ -11,7 +11,7 @@ namespace ServiceStack.OrmLite.SqlServer.Converters
     {
         public override string ColumnDefinition
         {
-            get { return "GEOMETRY"; }
+            get { return "geometry"; }
         }
 
         public override object FromDbValue(Type fieldType, object value)

--- a/src/ServiceStack.OrmLite.SqlServerTests/SchemaTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/SchemaTests.cs
@@ -86,7 +86,7 @@ namespace ServiceStack.OrmLite.SqlServerTests
             then '(' + convert(varchar(10), character_maximum_length) + ')'
         else ''
     end as COLUMN_DEFINITION
-FROM information_schema.columns";
+FROM INFORMATION_SCHEMA.COLUMNS";
 
             using (var db = OpenDbConnection())
             {

--- a/src/T4/OrmLite.Core.ttinclude
+++ b/src/T4/OrmLite.Core.ttinclude
@@ -1339,7 +1339,7 @@ WHERE   o.type = 'P'
                             'sysdiagrams' )";
 
 
-    const string SP_PARAMETERS_SQL=@"SELECT * from information_schema.PARAMETERS
+    const string SP_PARAMETERS_SQL=@"SELECT * from INFORMATION_SCHEMA.PARAMETERS
                                 where SPECIFIC_NAME = @spname
                                 order by ORDINAL_POSITION";
 
@@ -1644,11 +1644,11 @@ class PostGreSqlSchemaReader : SchemaReader
 	string GetPK(string table){
 
 		string sql=@"SELECT kcu.column_name
-			FROM information_schema.key_column_usage kcu
-			JOIN information_schema.table_constraints tc
-			ON kcu.constraint_name=tc.constraint_name
-			WHERE lower(tc.constraint_type)='primary key'
-			AND kcu.table_name=@tablename";
+			FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
+			JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
+			ON kcu.CONSTRAINT_NAME=tc.CONSTRAINT_NAME
+			WHERE lower(tc.CONSTRAINT_TYPE)='primary key'
+			AND kcu.TABLE_NAME=@tablename";
 
 		using (var cmd=_factory.CreateCommand())
 		{
@@ -1730,16 +1730,16 @@ class PostGreSqlSchemaReader : SchemaReader
 
 
 	const string TABLE_SQL=@"
-			SELECT table_name, table_schema, table_type
-			FROM information_schema.tables
-			WHERE (table_type='BASE TABLE' OR table_type='VIEW')
-				AND table_schema NOT IN ('pg_catalog', 'information_schema');
+			SELECT TABLE_NAME, TABLE_SCHEMA, TABLE_TYPE
+			FROM INFORMATION_SCHEMA.TABLES
+			WHERE (TABLE_TYPE='BASE TABLE' OR TABLE_TYPE='VIEW')
+				AND TABLE_SCHEMA NOT IN ('pg_catalog', 'INFORMATION_SCHEMA');
 			";
 
 	const string COLUMN_SQL=@"
-			SELECT column_name, is_nullable, udt_name, column_default
-			FROM information_schema.columns
-			WHERE table_name=@tableName;
+			SELECT COLUMN_NAME, IS_NULLABLE, UDT_NAME, COLUMN_DEFAULT
+			FROM INFORMATION_SCHEMA.COLUMNS
+			WHERE TABLE_NAME=@tableName;
 			";
 
 }
@@ -1869,8 +1869,8 @@ class MySqlSchemaReader : SchemaReader
 
 	const string TABLE_SQL=@"
 			SELECT *
-			FROM information_schema.tables
-			WHERE (table_type='BASE TABLE' OR table_type='VIEW')
+			FROM INFORMATION_SCHEMA.TABLES
+			WHERE (TABLE_TYPE='BASE TABLE' OR TABLE_TYPE='VIEW')
 			";
 
 }

--- a/tests/ServiceStack.OrmLite.Tests/LoadReferencesJoinTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/LoadReferencesJoinTests.cs
@@ -792,7 +792,7 @@ namespace ServiceStack.OrmLite.Tests
                 sb.AppendLine(tuple.Item2.Dump());
             }
 
-            Assert.That(sb.ToString().Replace("\r", "").Trim(), Is.EqualTo(
+            Assert.That(sb.ToString().NormalizeNewLines().Trim(), Is.EqualTo(
 @"Customer:
 {
 	Id: 1,
@@ -804,7 +804,7 @@ Customer Address:
 	CustomerId: 1,
 	AddressLine1: 1 Australia Street,
 	Country: Australia
-}"));
+}".NormalizeNewLines()));
         }
 
         [Test]
@@ -837,7 +837,7 @@ Customer Address:
 
         private static void AssertMultiCustomerOrderResults(StringBuilder sb)
         {
-            Assert.That(sb.ToString().Replace("\r", "").Trim(), Is.EqualTo(
+            Assert.That(sb.ToString().NormalizeNewLines().Trim(), Is.EqualTo(
                 @"Customer:
 {
 	Id: 1,
@@ -877,7 +877,7 @@ Order:
 	LineItem: Line 2,
 	Qty: 2,
 	Cost: 2.99
-}"));
+}".NormalizeNewLines()));
         }
     }
 

--- a/tests/ServiceStack.OrmLiteV45.Tests/LoadReferenceJoinTests.cs
+++ b/tests/ServiceStack.OrmLiteV45.Tests/LoadReferenceJoinTests.cs
@@ -87,7 +87,7 @@ namespace ServiceStack.OrmLite.Tests
                 sb.AppendLine(tuple.Item2.Dump());
             }
 
-            Assert.That(sb.ToString().Replace("\r", "").Trim(), Is.EqualTo(
+            Assert.That(sb.ToString().NormalizeNewLines().Trim(), Is.EqualTo(
 @"Customer:
 {
 	Id: 1,
@@ -99,7 +99,7 @@ Customer Address:
 	CustomerId: 1,
 	AddressLine1: 1 Australia Street,
 	Country: Australia
-}"));
+}".NormalizeNewLines()));
         }
 
         [Test]
@@ -130,7 +130,7 @@ Customer Address:
 
         private static void AssertMultiCustomerOrderResults(StringBuilder sb)
         {
-            Assert.That(sb.ToString().Replace("\r", "").Trim(), Is.EqualTo(
+            Assert.That(sb.ToString().NormalizeNewLines().Trim(), Is.EqualTo(
                 @"Customer:
 {
 	Id: 1,
@@ -170,7 +170,7 @@ Order:
 	LineItem: Line 2,
 	Qty: 2,
 	Cost: 2.99
-}"));
+}".NormalizeNewLines()));
         }
     }
 }

--- a/tests/ServiceStack.OrmLiteV45.Tests/T4/OrmLite.Core.ttinclude
+++ b/tests/ServiceStack.OrmLiteV45.Tests/T4/OrmLite.Core.ttinclude
@@ -1187,7 +1187,7 @@ WHERE   o.type = 'P'
                             'sysdiagrams' )";
 
 
-    const string SP_PARAMETERS_SQL=@"SELECT * from information_schema.PARAMETERS
+    const string SP_PARAMETERS_SQL=@"SELECT * from INFORMATION_SCHEMA.PARAMETERS
                                 where SPECIFIC_NAME = @spname
                                 order by ORDINAL_POSITION";
 
@@ -1491,12 +1491,12 @@ class PostGreSqlSchemaReader : SchemaReader
 
 	string GetPK(string table){
 
-		string sql=@"SELECT kcu.column_name
-			FROM information_schema.key_column_usage kcu
-			JOIN information_schema.table_constraints tc
-			ON kcu.constraint_name=tc.constraint_name
-			WHERE lower(tc.constraint_type)='primary key'
-			AND kcu.table_name=@tablename";
+		string sql=@"SELECT kcu.COLUMN_NAME
+			FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
+			JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
+			ON kcu.CONSTRAINT_NAME=tc.CONSTRAINT_NAME
+			WHERE lower(tc.CONSTRAINT_TYPE)='primary key'
+			AND kcu.TABLE_NAME=@tablename";
 
 		using (var cmd=_factory.CreateCommand())
 		{
@@ -1578,15 +1578,15 @@ class PostGreSqlSchemaReader : SchemaReader
 
 
 	const string TABLE_SQL=@"
-			SELECT table_name, table_schema, table_type
-			FROM information_schema.tables
-			WHERE (table_type='BASE TABLE' OR table_type='VIEW')
-				AND table_schema NOT IN ('pg_catalog', 'information_schema');
+			SELECT TABLE_NAME, TABLE_SCHEMA, TABLE_TYPE
+			FROM INFORMATION_SCHEMA.TABLES
+			WHERE (TABLE_TYPE='BASE TABLE' OR TABLE_TYPE='VIEW')
+				AND TABLE_SCHEMA NOT IN ('pg_catalog', 'INFORMATION_SCHEMA');
 			";
 
 	const string COLUMN_SQL=@"
 			SELECT column_name, is_nullable, udt_name, column_default
-			FROM information_schema.columns
+			FROM INFORMATION_SCHEMA.COLUMNS
 			WHERE table_name=@tableName;
 			";
 
@@ -1717,8 +1717,8 @@ class MySqlSchemaReader : SchemaReader
 
 	const string TABLE_SQL=@"
 			SELECT *
-			FROM information_schema.tables
-			WHERE (table_type='BASE TABLE' OR table_type='VIEW')
+			FROM INFORMATION_SCHEMA.TABLES
+			WHERE (TABLE_TYPE='BASE TABLE' OR TABLE_TYPE='VIEW')
 			";
 
 }


### PR DESCRIPTION
Some fixes to unit tests that failed for me, especially due a case-sensitive server collation for SQL Server.

PostgreSQL tests still fail due to the mismatch in Npgsql version (2.2.7 vs 3.0.5), which can be fixed by downgrading the test projects to Npgsql 2.2.7, but I'm not including that in this PR.