### PR TITLE
More unit test fixes

### DIFF
--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/OrmLiteInsertTests.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/OrmLiteInsertTests.cs
@@ -113,10 +113,10 @@ namespace ServiceStack.OrmLite.Tests
                 var row2 = new ModelWithIdAndName1() { Name = "B", Id = 5 };
 
                 var row1LastInsertId = db.Insert(row1, selectIdentity: true);
-                Assert.That(db.GetLastSql(), Is.StringEnding(") RETURNING id"));
+                Assert.That(db.GetLastSql(), Is.StringMatching("\\) RETURNING \"?id"));
 
                 var row2LastInsertId = db.Insert(row2, selectIdentity: true);
-                Assert.That(db.GetLastSql(), Is.StringEnding(") RETURNING id"));
+                Assert.That(db.GetLastSql(), Is.StringMatching("\\) RETURNING \"?id"));
 
                 var insertedRow1 = db.SingleById<ModelWithIdAndName1>(row1LastInsertId);
                 var insertedRow2 = db.SingleById<ModelWithIdAndName1>(row2LastInsertId);

--- a/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerHierarchyIdTypeConverter.cs
+++ b/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerHierarchyIdTypeConverter.cs
@@ -16,7 +16,7 @@ namespace ServiceStack.OrmLite.SqlServer.Converters
 
         public override string ColumnDefinition
         {
-            get { return "HIERARCHYID"; }
+            get { return "hierarchyid"; }
         }
 
         public override DbType DbType


### PR DESCRIPTION
This fixes 2 more unit tests, similar to PR #506.

"hierarchyid" was case-sensitive just like "geometry" and "geography" and my SQL Server quotes the column name in `RETURNING "id"` (probably a server setting somewhere.

Now all tests in the Tests project pass and only 1 test in SqlServerTests fails: `Can_execute_stored_proceduce_returning_scalars` says with "Could not find stored procedure 'GetUserIdsFromEmailAddresses'."`