### PR TITLE
Add COALESCE binary expression tests

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServerTests/Expressions/EqualityExpressionsTest.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/Expressions/EqualityExpressionsTest.cs
@@ -257,6 +257,55 @@ namespace ServiceStack.OrmLite.SqlServerTests.Expressions
         }
 
         // Assume not equal works ;-)
+
+        [Test]
+        public void Can_select_equals_coalesce_on_the_left_expression()
+        {
+            // ReSharper disable ConvertToConstant.Local
+            object stringVal = "sometext";
+            // ReSharper restore ConvertToConstant.Local
+
+            var expected = new TestType()
+            {
+                IntColumn = 12,
+                BoolColumn = false,
+                StringColumn = "test",
+                NullableCol = "sometext"
+            };
+
+            EstablishContext(10, expected);
+
+            var actual = OpenDbConnection().Select<TestType>(q => (q.NullableCol ?? "othertext") == stringVal);
+
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(actual.Count, 1);                   // this passes, because PARAMS: @0=othertext, @1=sometext
+            CollectionAssert.Contains(actual, expected);
+        }
+
+        [Test]
+        public void Can_select_equals_coalesce_on_the_right_expression()
+        {
+            // ReSharper disable ConvertToConstant.Local
+            object stringVal = "sometext";
+            // ReSharper restore ConvertToConstant.Local
+
+            var expected = new TestType()
+            {
+                IntColumn = 12,
+                BoolColumn = false,
+                StringColumn = "test",
+                NullableCol = "sometext"
+            };
+
+            EstablishContext(10, expected);
+
+            var actual = OpenDbConnection().Select<TestType>(q => stringVal == (q.NullableCol ?? "othertext"));
+
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(actual.Count, 1);                  // this will fail for now, because PARAMS: @0=othertext, @1={Text:"COALESCE(""NullableCol"",@0)"}
+            CollectionAssert.Contains(actual, expected);       // this will fail as well
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Shows a current issue: when COALESCE is on the right side of a comparison, it's serialized **into** the query param as a string. So the test Can_select_equals_coalesce_on_the_right_expression() will always fail.

From what I see SqlExpression.VisitFilter runs ConvertToPlaceholderAndParameter(ref right). Which adds a param "@1" with the value "{COALESCE("NullableCol",@0)}", then sets right to "@1".

Not sure how to fix it reliably & elegantly... especially to treat nested expressions.