### PR TITLE
Made [EnumAsInt] attribute work when applied to the property as well as when applied to the enum type

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
@@ -109,7 +109,7 @@ namespace ServiceStack.OrmLite
                     : propertyInfo.PropertyType;
 
                 Type treatAsType = null;
-                if (propertyType.IsEnumFlags() || propertyType.HasAttribute<EnumAsIntAttribute>())
+                if (propertyType.IsEnumFlags() || propertyType.HasAttribute<EnumAsIntAttribute>() || propertyInfo.HasAttribute<EnumAsIntAttribute>())
                     treatAsType = Enum.GetUnderlyingType(propertyType);
 
                 var aliasAttr = propertyInfo.FirstAttribute<AliasAttribute>();

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -847,7 +847,7 @@ namespace ServiceStack.OrmLite
             var converter = GetConverterBestMatch(fieldDef);
             try
             {
-                return converter.ToDbValue(fieldDef.FieldType, value);
+                return converter.ToDbValue(fieldDef.ColumnType, value);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This is particularly useful when you have no control over the enum type (e.g. System.DayOfWeek)