### PR TITLE
Select entire table in SqlExpression.Select() using anonymous types

### DIFF
--- a/src/ServiceStack.OrmLite.Firebird/FirebirdOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Firebird/FirebirdOrmLiteDialectProvider.cs
@@ -657,10 +657,10 @@ namespace ServiceStack.OrmLite.Firebird
                 .Replace("%", @"^%");
         }
 
-        public override string GetColumnNames(ModelDefinition modelDef)
+        public override string GetColumnNames(ModelDefinition modelDef, bool tableQualified = false)
         {
             if (QuoteNames)
-                return modelDef.GetColumnNames(this);
+                return modelDef.GetColumnNames(this); // Calls this.GetColumnNames(modelDef) - infinite loop?
 
             var sqlColumns = StringBuilderCache.Allocate();
             foreach (var field in modelDef.FieldDefinitions)

--- a/src/ServiceStack.OrmLite.Firebird/FirebirdOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Firebird/FirebirdOrmLiteDialectProvider.cs
@@ -657,10 +657,10 @@ namespace ServiceStack.OrmLite.Firebird
                 .Replace("%", @"^%");
         }
 
-        public override string GetColumnNames(ModelDefinition modelDef, bool tableQualified = false)
+        public override string GetColumnNames(ModelDefinition modelDef)
         {
             if (QuoteNames)
-                return modelDef.GetColumnNames(this); // Calls this.GetColumnNames(modelDef) - infinite loop?
+                return modelDef.GetColumnNames(this);
 
             var sqlColumns = StringBuilderCache.Allocate();
             foreach (var field in modelDef.FieldDefinitions)

--- a/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
@@ -128,9 +128,9 @@ namespace ServiceStack.OrmLite.PostgreSQL
         //Convert xmin into an integer so it can be used in comparisons
         public const string RowVersionFieldComparer = "int8in(xidout(xmin))";
 
-        public override string GetRowVersionColumnName(FieldDefinition field)
+        public override SelectListItem GetRowVersionColumnName(FieldDefinition field)
         {
-            return "xmin as " + GetQuotedColumnName(field.FieldName);
+            return new SelectListExpression(this, "xmin", field.FieldName);
         }
 
         public override void AppendFieldCondition(StringBuilder sqlFilter, FieldDefinition fieldDef, IDbCommand cmd)

--- a/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
@@ -1465,6 +1465,10 @@ namespace ServiceStack.OrmLite
 
         protected virtual object VisitParameter(ParameterExpression p)
         {
+            var paramModelDef = p.Type.GetModelDefinition();
+            if (paramModelDef != null)
+                return DialectProvider.GetColumnNames(paramModelDef, true);
+
             return p.Name;
         }
 

--- a/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
@@ -1449,13 +1449,22 @@ namespace ServiceStack.OrmLite
             if (isAnonType)
             {
                 var exprs = VisitExpressionList(nex.Arguments);
+
                 var r = StringBuilderCache.Allocate();
-                foreach (object e in exprs)
+                for (var i = 0; i < exprs.Count; ++i)
                 {
-                    if (r.Length > 0)
+                    if (i > 0)
                         r.Append(",");
 
-                    r.Append(e);
+                    r.Append(exprs[i]);
+
+                    // Use the anon type property name, rather than the table property name, as the returned column name
+
+                    var propertyExpr = nex.Arguments[i] as MemberExpression;
+                    if (propertyExpr != null && propertyExpr.Member.Name != nex.Members[i].Name)
+                    {
+                        r.Append(" AS " + DialectProvider.GetQuotedName(nex.Members[i].Name));
+                    }
                 }
                 return StringBuilderCache.ReturnAndFree(r);
             }

--- a/src/ServiceStack.OrmLite/FieldDefinition.cs
+++ b/src/ServiceStack.OrmLite/FieldDefinition.cs
@@ -74,7 +74,7 @@ namespace ServiceStack.OrmLite
         public string GetQuotedName(IOrmLiteDialectProvider dialectProvider)
         {
             return IsRowVersion
-                ? dialectProvider.GetRowVersionColumnName(this)
+                ? dialectProvider.GetRowVersionColumnName(this).ToString()
                 : dialectProvider.GetQuotedColumnName(FieldName);
         }
 

--- a/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
@@ -157,9 +157,10 @@ namespace ServiceStack.OrmLite
         bool DoesSequenceExist(IDbCommand dbCmd, string sequencName);
 
         ulong FromDbRowVersion(object value);
-        string GetRowVersionColumnName(FieldDefinition field);
+        SelectListItem GetRowVersionColumnName(FieldDefinition field);
 
-        string GetColumnNames(ModelDefinition modelDef, bool tableQualified = false);
+        string GetColumnNames(ModelDefinition modelDef);
+        SelectList GetColumnNames(ModelDefinition modelDef, bool tableQualified);
 
         SqlExpression<T> SqlExpression<T>();
 

--- a/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
@@ -159,7 +159,7 @@ namespace ServiceStack.OrmLite
         ulong FromDbRowVersion(object value);
         string GetRowVersionColumnName(FieldDefinition field);
 
-        string GetColumnNames(ModelDefinition modelDef);
+        string GetColumnNames(ModelDefinition modelDef, bool tableQualified = false);
 
         SqlExpression<T> SqlExpression<T>();
 

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -551,21 +551,32 @@ namespace ServiceStack.OrmLite
             return GetQuotedColumnName(field.FieldName);
         }
 
-        public virtual string GetColumnNames(ModelDefinition modelDef)
+        public virtual string GetColumnNames(ModelDefinition modelDef, bool tableQualified = false)
         {
+            var tablePrefix = "";
+            if (tableQualified)
+            {
+                tablePrefix = GetQuotedTableName(modelDef) + ".";
+            }
+
             var sqlColumns = StringBuilderCache.Allocate();
             foreach (var field in modelDef.FieldDefinitions)
             {
                 if (sqlColumns.Length > 0)
                     sqlColumns.Append(", ");
 
-                if (field.CustomSelect == null)
+                if (field.CustomSelect != null)
                 {
-                    sqlColumns.Append(field.GetQuotedName(this));
+                    sqlColumns.Append(field.CustomSelect + " AS " + field.FieldName);
+                }
+                else if (field.IsRowVersion)
+                {
+                    sqlColumns.Append(GetRowVersionColumnName(field));
                 }
                 else
                 {
-                    sqlColumns.Append(field.CustomSelect + " AS " + field.FieldName);
+                    sqlColumns.Append(tablePrefix);
+                    sqlColumns.Append(GetQuotedColumnName(field.FieldName));
                 }
             }
 


### PR DESCRIPTION
Added support for selecting all of a table's columns in SqlExpression via `.Select<TableA, TableB>((a, b) => new { a })`. If a property name is specified in the anonymous type it's used as a prefix for every column, e.g. `.Select<TableA, TableB>((a, b) => new { ThisIsA = a })` would prefix every column of TableA with "ThisIsA". Property names can also now be used as aliases for individual columns, e.g. `.Select<TableA, TableB>((a, b) => new { a, BName = b.Name })` would result in "SELECT ..., TableB.Name as BName".

I had to add a few extra classes (SelectList, etc.) and make a breaking change the return type of IOrmLiteDialectProvider.GetRowVersionColumnName() to be able to manipulate the column aliases without major hacks. Perhaps they can be useful elsewhere as well. This is technically a breaking change, but hopefully a very minor one - I don't think too many people would be using GetRowVersionColumnName() directly.