### PR TITLE
Do not guess column mapping when an exact match is found for a requested column

### DIFF
--- a/src/ServiceStack.OrmLite/FieldDefinition.cs
+++ b/src/ServiceStack.OrmLite/FieldDefinition.cs
@@ -100,6 +100,11 @@ namespace ServiceStack.OrmLite
 
         public bool IsRefType { get; set; }
 
+        public override string ToString()
+        {
+            return Name;
+        }
+
         public bool ShouldSkipInsert()
         {
             return AutoIncrement || IsComputed || IsRowVersion;

--- a/src/ServiceStack.OrmLite/ModelDefinition.cs
+++ b/src/ServiceStack.OrmLite/ModelDefinition.cs
@@ -123,15 +123,26 @@ namespace ServiceStack.OrmLite
 
         public FieldDefinition GetFieldDefinition(string fieldName)
         {
-            if (fieldName != null)
+            if (fieldName == null)
+                return null;
+
+            var comparison = StringComparison.OrdinalIgnoreCase;
+            FieldDefinition bestMatch = null;
+
+            for (var i = 0; i < FieldDefinitionsArray.Length; ++i)
             {
-                foreach (var f in FieldDefinitionsArray)
+                if (string.Equals(FieldDefinitionsArray[i].Name, fieldName, comparison))
                 {
-                    if (string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase))
-                        return f;
+                    bestMatch = FieldDefinitionsArray[i];
+                    if (comparison == StringComparison.Ordinal)
+                        return bestMatch;
+
+                    comparison = StringComparison.Ordinal; // Keep looking for a better match
+                    --i; // Check the current field again, now using case-sensitive comparison
                 }
             }
-            return null;
+
+            return bestMatch;
         }
 
         public void AfterInit()

--- a/tests/ServiceStack.OrmLite.Tests/Issues/ColumnGuessingTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Issues/ColumnGuessingTests.cs
@@ -1,0 +1,46 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using ServiceStack.Text;
+
+namespace ServiceStack.OrmLite.Tests.Issues
+{
+    [TestFixture]
+    public class ColumnGuessingTests : OrmLiteTestBase
+    {
+        private class Person
+        {
+            public string Name { get; set; }
+            public string LastName { get; set; }
+            public string NameAtBirth { get; set; }
+        }
+
+        [Test]
+        public void Dont_guess_extra_columns_when_match_found()
+        {
+            // Only the specified column should be selected. The value of Name should not be written to FirstName nor NameAtBirth,
+            // since there is already a match for the requested column in the data model class.
+
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<Person>();
+                db.Insert(new Person { LastName = "Smith", Name = "John", NameAtBirth = "Black" });
+
+                var row = db.Select(db.From<Person>().Select(r => new { r.LastName })).Single();
+                AssertPerson(new Person { LastName = "Smith" }, row);
+
+                row = db.Select(db.From<Person>().Select(r => new { r.Name })).Single();
+                AssertPerson(new Person { Name = "John" }, row);
+
+                row = db.Select(db.From<Person>().Select(r => new { r.NameAtBirth })).Single();
+                AssertPerson(new Person { NameAtBirth = "Black" }, row);
+            }
+        }
+
+        private static void AssertPerson(Person expected, Person actual)
+        {
+            Assert.AreEqual(expected.Name, actual.Name, "Name differs");
+            Assert.AreEqual(expected.LastName, actual.LastName, "LastName differs");
+            Assert.AreEqual(expected.NameAtBirth, actual.NameAtBirth, "NameAtBirth differs");
+        }
+    }
+}

--- a/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
+++ b/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
@@ -130,6 +130,7 @@
     <Compile Include="DefaultValueTests.cs" />
     <Compile Include="Issues\BelongsToIssue.cs" />
     <Compile Include="Issues\CanBuildExpressionWithAbstractType.cs" />
+    <Compile Include="Issues\ColumnGuessingTests.cs" />
     <Compile Include="Issues\JoinBoolSqlServerIssue.cs" />
     <Compile Include="Issues\MergingNestedSqlExpressionIssue.cs" />
     <Compile Include="Issues\SqlExpressionSubSqlExpressionIssue.cs" />


### PR DESCRIPTION
This resulted in a nasty production bug for us where data was being mapped to the wrong column (as well as the right column). It's highly unexpected behaviour from the user point of view. I really think column guessing should be disabled by default, but this patch at least avoids guessing for a column that was already matched exactly.

To make the `Does_populate_custom_mixed_columns` unit test pass again I had to fix ModelDefinition.GetFieldDefinition() to keep looking for a case-sensitive match even when a case-insensitive match is found, rather than relying on the guessing to fix this later.

Adding `FieldDefinition.ToString()` just makes debugging much easier - I hope this is OK.