### PR TITLE
Added table hints to Sql Server join expressions

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServer/ServiceStack.OrmLite.SqlServer.csproj
+++ b/src/ServiceStack.OrmLite.SqlServer/ServiceStack.OrmLite.SqlServer.csproj
@@ -103,7 +103,9 @@
     <Compile Include="SqlServerDialect.cs" />
     <Compile Include="SqlServerExpression.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SqlServerExpressionExtensions.cs" />
     <Compile Include="SqlServerOrmLiteDialectProvider.cs" />
+    <Compile Include="SqlServerTableHint.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServiceStack.OrmLite\ServiceStack.OrmLite.csproj">

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerExpression.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerExpression.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Linq.Expressions;
 using System.Text;
 using ServiceStack.OrmLite.SqlServer.Converters;
 using ServiceStack.Text;
@@ -26,6 +27,33 @@ namespace ServiceStack.OrmLite.SqlServer
         public override SqlExpression<T> OrderByRandom()
         {
             return base.OrderBy("NEWID()");
+        }
+
+        public SqlExpression<T> JoinWithHint<Target>(Expression<Func<T, Target, bool>> joinExpr, string joinTableHint)
+        {
+            if (joinTableHint == null)
+            {
+                throw new ArgumentNullException("joinTableHint");
+            }
+            return InternalJoin("INNER JOIN", joinExpr, joinTableHint);
+        }
+
+        public SqlExpression<T> LeftJoinWithHint<Target>(Expression<Func<T, Target, bool>> joinExpr, string joinTableHint)
+        {
+            if (joinTableHint == null)
+            {
+                throw new ArgumentNullException("joinTableHint");
+            }
+            return InternalJoin("LEFT JOIN", joinExpr, joinTableHint);
+        }
+
+        public SqlExpression<T> RightJoinWithHint<Target>(Expression<Func<T, Target, bool>> joinExpr, string joinTableHint)
+        {
+            if (joinTableHint == null)
+            {
+                throw new ArgumentNullException("joinTableHint");
+            }
+            return InternalJoin("RIGHT JOIN", joinExpr, joinTableHint);
         }
 
         protected override void ConvertToPlaceholderAndParameter(ref object right)

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerExpressionExtensions.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerExpressionExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using ServiceStack.DataAnnotations;
+
+namespace ServiceStack.OrmLite.SqlServer
+{
+    public static class SqlServerExpressionExtensions
+    {
+        public static SqlExpression<T> JoinWithHint<T, Target>(this SqlExpression<T> expression, Expression<Func<T, Target, bool>> joinExpr, string sqlServerTableHint)
+        {
+            var sqlExpression = new SqlServerExpression<T>(expression.DialectProvider);
+
+            return sqlExpression.JoinWithHint(joinExpr, sqlServerTableHint);
+        }
+
+        public static SqlExpression<T> LeftJoinWithHint<T, Target>(this SqlExpression<T> expression, Expression<Func<T, Target, bool>> joinExpr, string sqlServerTableHint)
+        {
+            var sqlExpression = new SqlServerExpression<T>(expression.DialectProvider);
+
+            return sqlExpression.LeftJoinWithHint(joinExpr, sqlServerTableHint);
+
+        }
+
+        public static SqlExpression<T> RightJoinWithHint<T, Target>(this SqlExpression<T> expression, Expression<Func<T, Target, bool>> joinExpr, string sqlServerTableHint)
+        {
+            var sqlExpression = new SqlServerExpression<T>(expression.DialectProvider);
+
+            return sqlExpression.RightJoinWithHint(joinExpr, sqlServerTableHint);
+
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerTableHint.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerTableHint.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using ServiceStack.DataAnnotations;
+
+namespace ServiceStack.OrmLite.SqlServer
+{
+    public class SqlServerTableHint
+    {
+        public const string ReadUncommitted = "WITH (READUNCOMMITTED)";
+        public const string ReadCommitted = "WITH (READCOMMITTED)";
+        public const string ReadPast = "WITH (READPAST)";
+        public const string Serializable = "WITH (SERIALIZABLE)";
+        public const string RepeatableRead = "WITH (REPEATABLEREAD)";
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
+++ b/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
@@ -119,6 +119,7 @@
     <Compile Include="UpdateTests.cs" />
     <Compile Include="UseCase\ComplexJoinWithLimitAndNoOrderByTests.cs" />
     <Compile Include="UseCase\ComplexJoinWithLimitAndSpacesInAliasesTests.cs" />
+    <Compile Include="UseCase\JoinWithHintUseCase.cs" />
     <Compile Include="UseCase\TestEntityWithAliases.cs" />
     <Compile Include="UseCase\SimpleUseCase.cs" />
     <Compile Include="UseCase\TestEntity.cs" />

--- a/src/ServiceStack.OrmLite.SqlServerTests/UseCase/JoinWithHintUseCase.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/UseCase/JoinWithHintUseCase.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using ServiceStack.DataAnnotations;
+using ServiceStack.OrmLite.SqlServer;
+
+namespace ServiceStack.OrmLite.SqlServerTests.UseCase
+{
+    [TestFixture]
+    public class JoinWithHintUseCase : OrmLiteTestBase
+    {
+        [Alias("car")]
+        class Car
+        {
+
+            [PrimaryKey]
+            [Alias("car_id")]
+            [AutoIncrement]
+            public int CarId { get; set; }
+
+            [Alias("car_name")]
+            public string Name { get; set; }
+        }
+
+        [Alias("car_type")]
+        class CarType
+        {
+            [Alias("car_id")]
+            public int CarId { get; set; }
+
+            [Alias("car_type_name")]
+            public string CarTypeName { get; set; }
+        }
+
+        class CarTypeJoin
+        {
+            public int CarId { get; set; }
+            public string CarTypeName { get; set; }
+        }
+
+        private static void InitTables(IDbConnection db)
+        {
+            db.DropTable<Car>();
+            db.DropTable<CarType>();
+
+            db.CreateTable<Car>();
+            db.CreateTable<CarType>();
+
+
+            var id1 = db.Insert(new Car { Name = "Subaru" }, true);
+            var id2 = db.Insert(new Car { Name = "BMW" }, true);
+            var id3 = db.Insert(new Car { Name = "Nissan" }, true);
+
+            db.Insert(new CarType { CarId = (int)id1, CarTypeName = "Sedan" });
+            db.Insert(new CarType { CarId = (int)id2, CarTypeName = "Coupe" });
+            db.Insert(new CarType { CarId = (int)id3, CarTypeName = "SUV" });
+        }
+
+        [Test]
+        public void can_join_with_readuncommitted()
+        {
+            using (var db = OpenDbConnection())
+            {
+                InitTables(db);
+
+                var join = db.From<Car>()
+                    .JoinWithHint<Car, CarType>((l, r) => l.CarId == r.CarId, SqlServerTableHint.ReadUncommitted);
+
+                var selectStatement = join.ToSelectStatement();
+
+                var data = db.Select<CarTypeJoin>(join);
+
+                Assert.That(selectStatement.Contains("READUNCOMMITTED"));
+            }
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite/Expressions/SqlExpression.Join.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpression.Join.cs
@@ -76,13 +76,12 @@ namespace ServiceStack.OrmLite
             return InternalJoin("CROSS JOIN", joinExpr);
         }
 
-        private SqlExpression<T> InternalJoin<Source, Target>(string joinType, 
-            Expression<Func<Source, Target, bool>> joinExpr)
+        protected SqlExpression<T> InternalJoin<Source, Target>(string joinType, Expression<Func<Source, Target, bool>> joinExpr, string customJoinModifier = null)
         {
             var sourceDef = typeof(Source).GetModelDefinition();
             var targetDef = typeof(Target).GetModelDefinition();
 
-            return InternalJoin(joinType, joinExpr, sourceDef, targetDef);
+            return InternalJoin(joinType, joinExpr, sourceDef, targetDef, customJoinModifier);
         }
 
         private string InternalCreateSqlFromExpression(Expression joinExpr, bool isCrossJoin) 
@@ -126,8 +125,7 @@ namespace ServiceStack.OrmLite
             return this;
         }
 
-        private SqlExpression<T> InternalJoin(string joinType, 
-            Expression joinExpr, ModelDefinition sourceDef, ModelDefinition targetDef)
+        private SqlExpression<T> InternalJoin(string joinType, Expression joinExpr, ModelDefinition sourceDef, ModelDefinition targetDef, string customJoinModifier = null)
         {
             PrefixFieldWithTableName = true;
 
@@ -150,7 +148,14 @@ namespace ServiceStack.OrmLite
                               ? sourceDef
                               : targetDef;
 
-            FromExpression += " {0} {1} {2}".Fmt(joinType, SqlTable(joinDef), sqlExpr);
+            if (customJoinModifier != null)
+            {
+                FromExpression += " {0} {1} {2} {3}".Fmt(joinType, SqlTable(joinDef), customJoinModifier, sqlExpr);
+            }
+            else
+            {
+                FromExpression += " {0} {1} {2}".Fmt(joinType, SqlTable(joinDef), sqlExpr);
+            }
 
             return this;
         }


### PR DESCRIPTION
It looked like extension methods were the easiest way to implement this. Table hints vary by provider (if any), and putting them on to the base SqlExpression<T> seemed wrong. Open to any suggestions!