### PR TITLE
Make all ExecNonQuery overloads public

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteResultsFilterExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteResultsFilterExtensions.cs
@@ -14,7 +14,7 @@ namespace ServiceStack.OrmLite
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(OrmLiteResultsFilterExtensions));
 
-        internal static int ExecNonQuery(this IDbCommand dbCmd, string sql, object anonType = null)
+        public static int ExecNonQuery(this IDbCommand dbCmd, string sql, object anonType = null)
         {
             if (anonType != null)
                 dbCmd.SetParameters(anonType.ToObjectDictionary(), (bool)false);
@@ -32,7 +32,7 @@ namespace ServiceStack.OrmLite
             return dbCmd.ExecuteNonQuery();
         }
 
-        internal static int ExecNonQuery(this IDbCommand dbCmd, string sql, Dictionary<string, object> dict)
+        public static int ExecNonQuery(this IDbCommand dbCmd, string sql, Dictionary<string, object> dict)
         {
 
             if (dict != null)
@@ -51,7 +51,7 @@ namespace ServiceStack.OrmLite
             return dbCmd.ExecuteNonQuery();
         }
 
-        internal static int ExecNonQuery(this IDbCommand dbCmd)
+        public static int ExecNonQuery(this IDbCommand dbCmd)
         {
             if (Log.IsDebugEnabled)
                 Log.DebugCommand(dbCmd);


### PR DESCRIPTION
The async equivalents are already public: https://github.com/ServiceStack/ServiceStack.OrmLite/blob/b8b26326ce46ac04191eedba4589d59fd4afaafd/src/ServiceStack.OrmLite/Async/OrmLiteResultsFilterExtensionsAsync.cs#L16 