### PR TITLE
Add logic to handle EnumAsInt attribute for Oracle databases

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
@@ -7,6 +7,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
+using ServiceStack.DataAnnotations;
 using ServiceStack.OrmLite.Converters;
 using ServiceStack.OrmLite.Oracle.Converters;
 using ServiceStack.Text;
@@ -426,7 +427,7 @@ namespace ServiceStack.OrmLite.Oracle
             if (value == null || value is DBNull)
                 return null;
 
-            if (type.IsEnum)
+            if (type.IsEnum && !type.HasAttribute<EnumAsIntAttribute>())
                 return EnumConverter.ToDbValue(type, value);
 
             if (type.IsRefType())


### PR DESCRIPTION
Hi @mythz.

This PR adds logic to handle the EnumAsInt attribute for Oracle databases.

Several of the tests in ServiceStack.OrmLite.Tests.EnumTests which cover this functionality are currently failing on Oracle. They will continue to fail even with these changes as they use hand-coded SQL containing the '@' symbol to specify parameters. Obviously I cannot change this, as the Oracle tests are just links to the main test project. However, when I modify the tests locally to use ':" instead of '@' they do pass on Oracle.

I have signed the CLA.

Perhaps @BruceCowan-AI  would like to take a look at this?