### PR TITLE
Skip InsertOnly tests for Oracle

### DIFF
--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteInsertTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteInsertTests.cs
@@ -227,6 +227,8 @@ namespace ServiceStack.OrmLite.Tests
         [Test]
         public void Can_InsertOnly_selected_fields()
         {
+            SuppressIfOracle("Need trigger for autoincrement keys to work in Oracle");
+
             using (var db = OpenDbConnection())
             {
                 db.DropAndCreateTable<PersonWithAutoId>();
@@ -258,6 +260,8 @@ namespace ServiceStack.OrmLite.Tests
         [Test]
         public void Can_InsertOnly_selected_fields_using_AssignmentExpression()
         {
+            SuppressIfOracle("Need trigger for autoincrement keys to work in Oracle");
+
             using (var db = OpenDbConnection())
             {
                 db.DropAndCreateTable<PersonWithAutoId>();


### PR DESCRIPTION
Hi @mythz,

We run the Oracle tests periodically. There are a few that currently fail. We are in the process of addressing some of the causes of these failures, e.g. #527. However there are some failing tests which will never work on Oracle. We would prefer to just ignore these. Please let me know if that's any kind of problem.

FYI @BruceCowan-AI