### PR TITLE
Add ExecNonQuery overload with dbCmdCallback

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteReadApi.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadApi.cs
@@ -555,6 +555,15 @@ namespace ServiceStack.OrmLite
         }
 
         /// <summary>
+        /// Executes a raw sql non-query using a parameterized query with a dbCmd filter. E.g:
+        /// </summary>
+        /// <returns>number of rows affected</returns>
+        public static int ExecuteNonQuery(this IDbConnection dbConn, string sql, Action<IDbCommand> dbCmdFilter)
+        {
+            return dbConn.Exec(dbCmd => dbCmd.ExecNonQuery(sql, dbCmdFilter));
+        }
+
+        /// <summary>
         /// Returns results from a Stored Procedure, using a parameterized query.
         /// </summary>
         public static List<TOutputModel> SqlProcedure<TOutputModel>(this IDbConnection dbConn, object anonType)

--- a/src/ServiceStack.OrmLite/OrmLiteResultsFilterExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteResultsFilterExtensions.cs
@@ -62,6 +62,21 @@ namespace ServiceStack.OrmLite
             return dbCmd.ExecuteNonQuery();
         }
 
+        public static int ExecNonQuery(this IDbCommand dbCmd, string sql, Action<IDbCommand> dbCmdFilter)
+        {
+            if (dbCmdFilter != null) dbCmdFilter(dbCmd);
+
+            dbCmd.CommandText = sql;
+
+            if (Log.IsDebugEnabled)
+                Log.DebugCommand(dbCmd);
+
+            if (OrmLiteConfig.ResultsFilter != null)
+                return OrmLiteConfig.ResultsFilter.ExecuteSql(dbCmd);
+
+            return dbCmd.ExecuteNonQuery();
+        }
+
         public static List<T> ConvertToList<T>(this IDbCommand dbCmd, string sql = null)
         {
             if (sql != null)

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteExecuteNonQueryTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteExecuteNonQueryTests.cs
@@ -11,6 +11,152 @@
     [TestFixture]
     public class OrmLiteExecuteNonQueryTests
     {
+        public class WithDbCmdFilter : OrmLiteTestBase
+        {
+            [Test]
+            public void Can_insert_one_row_and_get_one_affected_row()
+            {
+                using (var db = OpenDbConnection())
+                {
+                    db.DropAndCreateTable<Person>();
+
+                    var name = "Jane Doe";
+
+                    var affectedRows = db.ExecuteNonQuery(Dialect != Dialect.Firebird
+                        ? "insert into Person (Name) Values (@name);"
+                        : "insert into Person (Id, Name) Values (1, @name);", cmd =>
+                        {
+                            cmd.AddParam("name", name);
+                        });
+
+                    var personId = db.Single<Person>(q => q.Name == name).Id;
+
+                    var insertedRow = db.SingleById<Person>(personId);
+
+                    Assert.That(affectedRows, Is.EqualTo(1));
+                    Assert.That(insertedRow.Name, Is.EqualTo(name));
+                }
+            }
+
+            [Test]
+            public void Can_insert_multiple_rows_and_get_matching_number_of_affected_rows()
+            {
+                using (var db = OpenDbConnection())
+                {
+                    db.DropAndCreateTable<Person>();
+
+                    var name1 = "Jane Doe";
+                    var name2 = "john Smith";
+
+                    int affectedRows = 0;
+                    if (Dialect != Dialect.Firebird)
+                    {
+                        affectedRows = db.ExecuteNonQuery(@"
+                        INSERT INTO Person (Name)
+                        SELECT @name1
+                        UNION
+                        SELECT @name2", cmd =>
+                        {
+                            cmd.AddParam("name1", name1);
+                            cmd.AddParam("name2", name2);
+                        });
+                    }
+                    else
+                    {
+                        affectedRows = db.ExecuteNonQuery(@"
+                        INSERT INTO Person (Id, Name)
+                        SELECT 1, CAST(@name1 as VARCHAR(128)) FROM RDB$DATABASE
+                        UNION
+                        SELECT 2, CAST(@name2 as VARCHAR(128)) FROM RDB$DATABASE", cmd =>
+                        {
+                            cmd.AddParam("name1", name1);
+                            cmd.AddParam("name2", name2);
+                        });
+                    }
+
+                    var rows = db.SqlColumn<Person>("select * from Person order by name");
+
+                    Assert.That(affectedRows, Is.EqualTo(2));
+                    Assert.That(rows[0].Name, Is.EqualTo(name1));
+                    Assert.That(rows[1].Name, Is.EqualTo(name2));
+
+                    var ids = db.SqlColumn<int>("select Id from Person order by Id");
+                    Assert.That(ids, Is.EquivalentTo(new[] { 1, 2 }));
+                }
+            }
+
+            [Test]
+            public void Can_update_and_returns_appropriate_number_of_affected_rows()
+            {
+                using (var db = OpenDbConnection())
+                {
+                    db.DropAndCreateTable<Person>();
+
+                    var person = new Person
+                    {
+                        Name = "Jane Doe"
+                    };
+
+                    var personId = db.Insert(person, selectIdentity: true);
+
+                    var newName = "John Smith";
+
+                    var affectedRows = db.ExecuteNonQuery("Update Person Set Name = @newName where Id = @personId", cmd =>
+                    {
+                        cmd.AddParam("personId", personId);
+                        cmd.AddParam("newName", newName);
+                    });
+
+                    var updatedPerson = db.SingleById<Person>(personId);
+
+                    Assert.That(affectedRows, Is.EqualTo(1));
+                    Assert.That(updatedPerson.Name, Is.EqualTo(newName));
+                }
+            }
+
+            [Test]
+            public void Can_delete_and_returns_appropriate_number_of_affected_rows()
+            {
+                using (var db = OpenDbConnection())
+                {
+                    db.DropAndCreateTable<Person>();
+
+                    var person = new Person
+                    {
+                        Name = "Jane Doe"
+                    };
+
+                    var personId = db.Insert(person, selectIdentity: true);
+
+                    var affectedRows = db.ExecuteNonQuery("Delete From Person where Id = @personId", cmd =>
+                    {
+                        cmd.AddParam("personId", personId);
+                    });
+
+                    var count = db.Count<Person>();
+
+                    Assert.That(affectedRows, Is.EqualTo(1));
+                    Assert.That(count, Is.EqualTo(0));
+                }
+            }
+
+            [Test]
+            public void Can_exec_statement_which_performs_no_changes_and_returns_no_affected_rows()
+            {
+                using (var db = OpenDbConnection())
+                {
+                    db.DropAndCreateTable<Person>();
+
+                    var affectedRows = db.ExecuteNonQuery(@"Delete From Person Where Id = @nonExistingId", cmd =>
+                    {
+                        cmd.AddParam("nonExistingId", -1);
+                    });
+
+                    Assert.That(affectedRows, Is.EqualTo(0));
+                }
+            }
+        }
+
         public class UsingAnonType : OrmLiteTestBase
         {
             [Test]


### PR DESCRIPTION
This provides an alternative to SqlProc for executing non-query stored procedure with output params. This way uses a callback rather than returning a dbCmd (like SqlProc). It can be used the same way SqlList is for queries.
