### PR TITLE
Handle fields with CustomSelect attribute in Oracle provider

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
@@ -778,6 +778,9 @@ namespace ServiceStack.OrmLite.Oracle
             var modelDef = GetModel(tableType);
             foreach (var fieldDef in modelDef.FieldDefinitions)
             {
+                if (fieldDef.CustomSelect != null)
+                    continue;
+
                 if (fieldDef.IsPrimaryKey)
                 {
                     sbPk.AppendFormat(sbPk.Length != 0 ? ",{0}" : "{0}", GetQuotedColumnName(fieldDef.FieldName));


### PR DESCRIPTION
OracleOrmLiteDialectProvider.ToCreateTableStatement() now skips fields with CustomSelect attribute.

@mythz - Right now, the test `Can_select_custom_field_expressions()` in CustomSqlTests fails on Oracle. The change in this PR causes it to pass.