### PR TITLE
SqlServer ToDeleteRowStatement uses from entire from expression

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerExpression.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerExpression.cs
@@ -53,6 +53,11 @@ namespace ServiceStack.OrmLite.SqlServer
                 right = "CAST({0} AS TIME)".Fmt(right);
             }
         }
+
+        public override string ToDeleteRowStatement()
+        {
+            return $"DELETE {DialectProvider.GetQuotedTableName(modelDef)} {FromExpression} {WhereExpression}";
+        }
     }
 
     internal class SqlServerExpressionUtils

--- a/src/ServiceStack.OrmLite.SqlServerTests/Issues/DeleteWithJoinTest.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/Issues/DeleteWithJoinTest.cs
@@ -1,0 +1,50 @@
+﻿using NUnit.Framework;
+using ServiceStack.OrmLite.SqlServerTests.Converters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ServiceStack.OrmLite.SqlServerTests.Issues
+{
+    class MainTable
+    {
+        public int Id { get; set; }
+    }
+    class JoinedTable
+    {
+        public int Id { get; set; }
+        public int MainTableId { get; set; }
+    }
+
+    [TestFixture]
+    public class DeleteWithJoinTest : SqlServerConvertersOrmLiteTestBase
+    {
+        [Test]
+        public void Can_delete_entity_with_join_expression()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable(typeof(MainTable));
+                db.DropAndCreateTable(typeof(JoinedTable));
+
+                db.Insert(new MainTable() { Id = 1 });
+                db.Insert(new JoinedTable() { Id = 1, MainTableId = 1 });
+                db.Insert(new JoinedTable() { Id = 2, MainTableId = 1 });
+
+                var ev = db.From<MainTable>();
+                ev.Join<JoinedTable>((x, y) => x.Id == y.MainTableId);
+                ev.Where<JoinedTable>(x => x.Id == 2);
+
+                var record = db.Single(ev);
+
+                Assert.That(record.Id == 1);
+
+                db.Delete(ev);
+
+                Assert.That(db.Select<MainTable>().Count, Is.EqualTo(0));                
+            }
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
+++ b/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Issues\CustomSelectWithPagingIssue.cs" />
     <Compile Include="Converters\InheritanceTest.cs" />
     <Compile Include="Issues\DeleteWithGeoTypesIssue.cs" />
+    <Compile Include="Issues\DeleteWithJoinTest.cs" />
     <Compile Include="Issues\JamesGeoIssue.cs" />
     <Compile Include="Issues\SerializationTests.cs" />
     <Compile Include="NestedTransactions.cs" />


### PR DESCRIPTION
When deleting from an experssion that contains a join, SqlServer would create an incorrect SQL Command expression.

This fixes the issue, but only for SqlServer.