### PR TITLE
don't need to reset CommandTimeout where it's already set in CreateCommand

### DIFF
--- a/src/ServiceStack.OrmLite/Async/OrmLiteReadCommandExtensionsAsync.cs
+++ b/src/ServiceStack.OrmLite/Async/OrmLiteReadCommandExtensionsAsync.cs
@@ -30,7 +30,6 @@ namespace ServiceStack.OrmLite
 
         internal static Task<IDataReader> ExecReaderAsync(this IDbCommand dbCmd, string sql, IEnumerable<IDataParameter> parameters, CancellationToken token)
         {
-            dbCmd.CommandTimeout = OrmLiteConfig.CommandTimeout;
             dbCmd.CommandText = sql;
             dbCmd.Parameters.Clear();
 

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -620,7 +620,6 @@ namespace ServiceStack.OrmLite
             var modelDef = typeof(T).GetModelDefinition();
 
             cmd.Parameters.Clear();
-            cmd.CommandTimeout = OrmLiteConfig.CommandTimeout;
 
             foreach (var fieldDef in modelDef.FieldDefinitionsArray)
             {
@@ -661,7 +660,6 @@ namespace ServiceStack.OrmLite
             var modelDef = typeof(T).GetModelDefinition();
 
             dbCmd.Parameters.Clear();
-            dbCmd.CommandTimeout = OrmLiteConfig.CommandTimeout;
 
             foreach (var entry in args)
             {
@@ -737,7 +735,6 @@ namespace ServiceStack.OrmLite
             var updateAllFields = updateFields == null || updateFields.Count == 0;
 
             cmd.Parameters.Clear();
-            cmd.CommandTimeout = OrmLiteConfig.CommandTimeout;
 
             foreach (var fieldDef in modelDef.FieldDefinitions)
             {
@@ -803,7 +800,6 @@ namespace ServiceStack.OrmLite
             var hadRowVesion = false;
 
             cmd.Parameters.Clear();
-            cmd.CommandTimeout = OrmLiteConfig.CommandTimeout;
 
             foreach (var fieldDef in modelDef.FieldDefinitions)
             {

--- a/src/ServiceStack.OrmLite/OrmLiteReadCommandExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadCommandExtensions.cs
@@ -35,7 +35,6 @@ namespace ServiceStack.OrmLite
 
         internal static IDataReader ExecReader(this IDbCommand dbCmd, string sql)
         {
-            dbCmd.CommandTimeout = OrmLiteConfig.CommandTimeout;
             dbCmd.CommandText = sql;
 
             if (Log.IsDebugEnabled)
@@ -46,7 +45,6 @@ namespace ServiceStack.OrmLite
 
         internal static IDataReader ExecReader(this IDbCommand dbCmd, string sql, IEnumerable<IDataParameter> parameters)
         {
-            dbCmd.CommandTimeout = OrmLiteConfig.CommandTimeout;
             dbCmd.CommandText = sql;
             dbCmd.Parameters.Clear();
 
@@ -959,7 +957,6 @@ namespace ServiceStack.OrmLite
         {
             dbCmd.CommandType = CommandType.StoredProcedure;
             dbCmd.CommandText = name;
-            dbCmd.CommandTimeout = OrmLiteConfig.CommandTimeout;
 
             dbCmd.SetParameters(inParams.ToObjectDictionary(), excludeDefaults);
 


### PR DESCRIPTION
I've removed the reset of CommandTimeout where it would be set by the CreateCommand in the ExecFilter.

https://forums.servicestack.net/t/setcommandtimeout/3063/4
