### PR TITLE
Added MemoryOptimized attribute to SqlServer provider

### DIFF
--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/Expressions/AuthorUseCase.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/Expressions/AuthorUseCase.cs
@@ -304,7 +304,7 @@ namespace ServiceStack.OrmLite.PostgreSQL.Tests.Expressions
                     bool r6 = db.Scalar<Author, bool>(e => Sql.Max(e.Active));
                     Assert.AreEqual(expectedBool, r6);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     //????
                     //if (dialect.Name == "PostgreSQL")

--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/ForeignKeyAttributeTests.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/ForeignKeyAttributeTests.cs
@@ -9,7 +9,7 @@ namespace ServiceStack.OrmLite.PostgreSQL.Tests
     {
         public ForeignKeyAttributeTests() : base(Dialect.PostgreSql) { }
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
             DropTables();
@@ -20,7 +20,7 @@ namespace ServiceStack.OrmLite.PostgreSQL.Tests
             }
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             DropTables();

--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/OrmLiteCreateTableWithNamigStrategyTests.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/OrmLiteCreateTableWithNamigStrategyTests.cs
@@ -128,7 +128,7 @@ namespace ServiceStack.OrmLite.Tests
 
     }
 
-    public class PrefixNamingStrategy : OrmLiteNamingStrategyBase
+    internal class PrefixNamingStrategy : OrmLiteNamingStrategyBase
     {
 
         public string TablePrefix { get; set; }
@@ -147,7 +147,7 @@ namespace ServiceStack.OrmLite.Tests
 
     }
 
-    public class LowercaseNamingStrategy : OrmLiteNamingStrategyBase
+    internal class LowercaseNamingStrategy : OrmLiteNamingStrategyBase
     {
 
         public override string GetTableName(string name)
@@ -162,7 +162,7 @@ namespace ServiceStack.OrmLite.Tests
 
     }
 
-    public class UnderscoreSeparatedCompoundNamingStrategy : OrmLiteNamingStrategyBase
+    internal class UnderscoreSeparatedCompoundNamingStrategy : OrmLiteNamingStrategyBase
     {
 
         public override string GetTableName(string name)

--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/OrmLiteGetScalarTests.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/OrmLiteGetScalarTests.cs
@@ -199,7 +199,7 @@ namespace ServiceStack.OrmLite.Tests
     }
     
     
-    public class Author
+    internal class Author
     {
         public Author(){}
         

--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/OrmLiteInsertTests.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/OrmLiteInsertTests.cs
@@ -113,10 +113,10 @@ namespace ServiceStack.OrmLite.Tests
                 var row2 = new ModelWithIdAndName1() { Name = "B", Id = 5 };
 
                 var row1LastInsertId = db.Insert(row1, selectIdentity: true);
-                Assert.That(db.GetLastSql(), Is.StringMatching("\\) RETURNING \"?[Ii]d"));
+                Assert.That(db.GetLastSql(), Does.Match("\\) RETURNING \"?[Ii]d"));
 
                 var row2LastInsertId = db.Insert(row2, selectIdentity: true);
-                Assert.That(db.GetLastSql(), Is.StringMatching("\\) RETURNING \"?[Ii]d"));
+                Assert.That(db.GetLastSql(), Does.Match("\\) RETURNING \"?[Ii]d"));
 
                 var insertedRow1 = db.SingleById<ModelWithIdAndName1>(row1LastInsertId);
                 var insertedRow2 = db.SingleById<ModelWithIdAndName1>(row2LastInsertId);
@@ -138,10 +138,10 @@ namespace ServiceStack.OrmLite.Tests
                 var row2 = ModelWithIdAndName.Create(6);
 
                 var row1LastInsertId = db.Insert(row1, selectIdentity: true);
-                Assert.That(db.GetLastSql(), Is.StringEnding("; SELECT LASTVAL()"));
+                Assert.That(db.GetLastSql(), Does.EndWith("; SELECT LASTVAL()"));
 
                 var row2LastInsertId = db.Insert(row2, selectIdentity: true);
-                Assert.That(db.GetLastSql(), Is.StringEnding("; SELECT LASTVAL()"));
+                Assert.That(db.GetLastSql(), Does.EndWith("; SELECT LASTVAL()"));
 
                 var insertedRow1 = db.SingleById<ModelWithIdAndName>(row1LastInsertId);
                 var insertedRow2 = db.SingleById<ModelWithIdAndName>(row2LastInsertId);

--- a/src/ServiceStack.OrmLite.PostgreSQL.Tests/project.json
+++ b/src/ServiceStack.OrmLite.PostgreSQL.Tests/project.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "NUnitLite" : "3.5.0",
     "ServiceStack.OrmLite" : "1.0.*",
@@ -29,15 +29,15 @@
     "ServiceStack.OrmLite.Tests" : "1.0.*"
   },
   "frameworks": {
-    "netcoreapp1.0": { 
+    "netcoreapp1.1": { 
       "imports": "dnxcore50",
       "dependencies" : {
-          "System.Runtime" : "4.1.0",
-          "System.Runtime.Serialization.Xml" : "4.1.1",
-          "System.Reflection" : "4.1.0",
-          "System.Reflection.Primitives" : "4.0.1",
-          "System.Runtime.Serialization.Primitives": "4.1.1",
-          "System.Threading.Thread" : "4.0.0"
+          "System.Runtime" : "4.*",
+          "System.Runtime.Serialization.Xml" : "4.*",
+          "System.Reflection" : "4.*",
+          "System.Reflection.Primitives" : "4.*",
+          "System.Runtime.Serialization.Primitives": "4.*",
+          "System.Threading.Thread" : "4.*"
         }	
      }
   }

--- a/src/ServiceStack.OrmLite.PostgreSQL/Converters/PostrgreSqlFloatConverters.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL/Converters/PostrgreSqlFloatConverters.cs
@@ -22,12 +22,5 @@ namespace ServiceStack.OrmLite.PostgreSQL.Converters
     {
         public PostrgreSqlDecimalConverter() 
             : base(38, 6) {}
-
-        public virtual string GetColumnDefinition(int? precision, int? scale)
-        {
-            return "NUMERIC({0},{1})".Fmt(
-                precision.GetValueOrDefault(Precision),
-                scale.GetValueOrDefault(Scale));
-        }
     }
 }

--- a/src/ServiceStack.OrmLite.SqlServer/ServiceStack.OrmLite.SqlServer.csproj
+++ b/src/ServiceStack.OrmLite.SqlServer/ServiceStack.OrmLite.SqlServer.csproj
@@ -102,6 +102,8 @@
     <Compile Include="Converters\SqlServerSpecialConverters.cs" />
     <Compile Include="Converters\SqlServerStringConverters.cs" />
     <Compile Include="Converters\SqlServerTimeConverter.cs" />
+    <Compile Include="SqlServer2016OrmLiteDialectProvider.cs" />
+    <Compile Include="SqlServer2014OrmLiteDialectProvider.cs" />
     <Compile Include="SqlServer2012OrmLiteDialectProvider.cs" />
     <Compile Include="SqlServerDialect.cs" />
     <Compile Include="SqlServerExpression.cs" />

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServer2012OrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServer2012OrmLiteDialectProvider.cs
@@ -6,7 +6,7 @@ namespace ServiceStack.OrmLite.SqlServer
 {
     public class SqlServer2012OrmLiteDialectProvider : SqlServerOrmLiteDialectProvider
     {
-        public static SqlServer2012OrmLiteDialectProvider Instance = new SqlServer2012OrmLiteDialectProvider();
+        public static new SqlServer2012OrmLiteDialectProvider Instance = new SqlServer2012OrmLiteDialectProvider();
 
         public override string ToSelectStatement(ModelDefinition modelDef,
             string selectExpression,

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServer2014OrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServer2014OrmLiteDialectProvider.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Data;
+using System.Text;
+using ServiceStack.Text;
+using ServiceStack.DataAnnotations;
+
+namespace ServiceStack.OrmLite.SqlServer
+{
+    public class SqlServer2014OrmLiteDialectProvider : SqlServer2012OrmLiteDialectProvider
+    {
+
+        public override string ToCreateTableStatement(Type tableType)
+        {
+            var sbColumns = StringBuilderCache.Allocate();
+            var sbConstraints = StringBuilderCacheAlt.Allocate();
+            var sbMemOptimized = StringBuilderCacheAlt.Allocate();
+
+            var modelDef = OrmLiteUtils.GetModelDefinition(tableType);
+            foreach (var fieldDef in modelDef.FieldDefinitions)
+            {
+                if (fieldDef.CustomSelect != null)
+                    continue;
+
+                var columnDefinition = GetColumnDefinition(
+                    fieldDef.FieldName,
+                    fieldDef.ColumnType,
+                    fieldDef.IsPrimaryKey,
+                    fieldDef.AutoIncrement,
+                    fieldDef.IsNullable,
+                    fieldDef.IsRowVersion,
+                    fieldDef.FieldLength,
+                    fieldDef.Scale,
+                    GetDefaultValue(fieldDef),
+                    fieldDef.CustomFieldDefinition);
+
+                if (columnDefinition == null)
+                    continue;
+
+                if (sbColumns.Length != 0)
+                    sbColumns.Append(", \n  ");
+
+                sbColumns.Append(columnDefinition);
+
+                if (fieldDef.ForeignKey == null) continue;
+
+                var refModelDef = OrmLiteUtils.GetModelDefinition(fieldDef.ForeignKey.ReferenceType);
+                sbConstraints.Append(
+                    $", \n\n  CONSTRAINT {GetQuotedName(fieldDef.ForeignKey.GetForeignKeyName(modelDef, refModelDef, NamingStrategy, fieldDef))} " +
+                    $"FOREIGN KEY ({GetQuotedColumnName(fieldDef.FieldName)}) " +
+                    $"REFERENCES {GetQuotedTableName(refModelDef)} ({GetQuotedColumnName(refModelDef.PrimaryKey.FieldName)})");
+
+                sbConstraints.Append(GetForeignKeyOnDeleteClause(fieldDef.ForeignKey));
+                sbConstraints.Append(GetForeignKeyOnUpdateClause(fieldDef.ForeignKey));
+            }
+
+            {
+                sbMemOptimized.Append(" WITH (MEMORY_OPTIMIZED=ON");
+                if (attrib.Durability == TableDurability.SCHEMA_ONLY)
+                    sbMemOptimized.Append(", DURABILITY=SCHEMA_ONLY");
+                else if (attrib.Durability == TableDurability.SCHEMA_AND_DATA)
+                    sbMemOptimized.Append(", DURABILITY=SCHEMA_AND_DATA");
+                sbMemOptimized.Append(")");
+            }
+
+            var sql = $"CREATE TABLE {GetQuotedTableName(modelDef)} " +
+                      $"\n(\n  {StringBuilderCache.ReturnAndFree(sbColumns)}{StringBuilderCacheAlt.ReturnAndFree(sbConstraints)} \n){StringBuilderCache.ReturnAndFree(sbMemOptimized)}; \n";
+
+            return sql;
+        }
+    }
+}
+
+namespace ServiceStack.DataAnnotations
+{
+    // SQL 2014: https://msdn.microsoft.com/en-us/library/dn553122(v=sql.120).aspx
+    // SQL 2016: https://msdn.microsoft.com/en-us/library/dn553122(v=sql.130).aspx
+    {
+
+
+        public TableDurability? Durability { get; set; }
+    }
+
+    public enum TableDurability
+    {
+        SCHEMA_ONLY, // (non-durable table) recreated upon server restart, data is lost, no transaction logging and checkpoints
+        SCHEMA_AND_DATA  // (durable table) data persists upon server restart
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServer2014OrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServer2014OrmLiteDialectProvider.cs
@@ -8,6 +8,7 @@ namespace ServiceStack.OrmLite.SqlServer
 {
     public class SqlServer2014OrmLiteDialectProvider : SqlServer2012OrmLiteDialectProvider
     {
+        public static new SqlServer2014OrmLiteDialectProvider Instance = new SqlServer2014OrmLiteDialectProvider();
 
         public override string ToCreateTableStatement(Type tableType)
         {
@@ -53,8 +54,10 @@ namespace ServiceStack.OrmLite.SqlServer
                 sbConstraints.Append(GetForeignKeyOnUpdateClause(fieldDef.ForeignKey));
             }
 
+            if (tableType.HasAttribute<MemoryOptimizedAttribute>())
             {
                 sbMemOptimized.Append(" WITH (MEMORY_OPTIMIZED=ON");
+                var attrib = tableType.FirstAttribute<MemoryOptimizedAttribute>();
                 if (attrib.Durability == TableDurability.SCHEMA_ONLY)
                     sbMemOptimized.Append(", DURABILITY=SCHEMA_ONLY");
                 else if (attrib.Durability == TableDurability.SCHEMA_AND_DATA)
@@ -74,8 +77,11 @@ namespace ServiceStack.DataAnnotations
 {
     // SQL 2014: https://msdn.microsoft.com/en-us/library/dn553122(v=sql.120).aspx
     // SQL 2016: https://msdn.microsoft.com/en-us/library/dn553122(v=sql.130).aspx
+    public class MemoryOptimizedAttribute : Attribute
     {
+        public MemoryOptimizedAttribute() { }
 
+        public MemoryOptimizedAttribute(TableDurability durability) { Durability = durability; }
 
         public TableDurability? Durability { get; set; }
     }

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServer2016OrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServer2016OrmLiteDialectProvider.cs
@@ -7,5 +7,6 @@ namespace ServiceStack.OrmLite.SqlServer
 {
     public class SqlServer2016OrmLiteDialectProvider : SqlServer2014OrmLiteDialectProvider
     {
+        public static new SqlServer2016OrmLiteDialectProvider Instance = new SqlServer2016OrmLiteDialectProvider();
     }
 }

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServer2016OrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServer2016OrmLiteDialectProvider.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Data;
+using System.Text;
+using ServiceStack.Text;
+
+namespace ServiceStack.OrmLite.SqlServer
+{
+    public class SqlServer2016OrmLiteDialectProvider : SqlServer2014OrmLiteDialectProvider
+    {
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerDialect.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerDialect.cs
@@ -11,4 +11,14 @@ namespace ServiceStack.OrmLite
     {
         public static IOrmLiteDialectProvider Provider => SqlServer2012OrmLiteDialectProvider.Instance;
     }
+
+    public static class SqlServer2014Dialect
+    {
+        public static IOrmLiteDialectProvider Provider => SqlServer2014OrmLiteDialectProvider.Instance;
+    }
+
+    public static class SqlServer2016Dialect
+    {
+        public static IOrmLiteDialectProvider Provider => SqlServer2016OrmLiteDialectProvider.Instance;
+    }
 }

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
@@ -199,7 +199,7 @@ namespace ServiceStack.OrmLite.SqlServer
 
             var modelName = GetQuotedTableName(GetModel(modelType).ModelName);
 
-            return string.Format($"ALTER TABLE {modelName} ADD {column};");
+            return $"ALTER TABLE {modelName} ADD {column};";
         }
 
         public override string ToAlterColumnStatement(Type modelType, FieldDefinition fieldDef)

--- a/src/ServiceStack.OrmLite.SqlServerTests/MemoryOptimizedAttributeTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/MemoryOptimizedAttributeTests.cs
@@ -4,6 +4,7 @@ using ServiceStack.DataAnnotations;
 namespace ServiceStack.OrmLite.SqlServerTests
 {
     [TestFixture]
+    public class MemoryOptimizedAttributeTests : OrmLiteTestBase
     {
         [TestFixtureSetUp]
         public void Setup()
@@ -46,6 +47,7 @@ namespace ServiceStack.OrmLite.SqlServerTests
         }
     }
     
+    [MemoryOptimized]
     public class TypeWithMemTableNoDurability
         {
         [AutoIncrement]
@@ -54,6 +56,7 @@ namespace ServiceStack.OrmLite.SqlServerTests
         public string Name { get; set; }
     }
 
+    [MemoryOptimized(TableDurability.SCHEMA_ONLY)]
     public class TypeWithMemTableSchemaOnlyDurability
     {
         [AutoIncrement]
@@ -62,6 +65,7 @@ namespace ServiceStack.OrmLite.SqlServerTests
         public string Name { get; set; }
     }
 
+    [MemoryOptimized(TableDurability.SCHEMA_AND_DATA)]
     public class TypeWithMemTableSchemaAndDataDurability
     {
         [AutoIncrement]

--- a/src/ServiceStack.OrmLite.SqlServerTests/MemoryOptimizedAttributeTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/MemoryOptimizedAttributeTests.cs
@@ -1,0 +1,72 @@
+﻿using NUnit.Framework;
+using ServiceStack.DataAnnotations;
+
+namespace ServiceStack.OrmLite.SqlServerTests
+{
+    [TestFixture]
+    {
+        [TestFixtureSetUp]
+        public void Setup()
+        {
+            OrmLiteConfig.DialectProvider = SqlServer2014Dialect.Provider;
+
+            using (var dbConn = OpenDbConnection())
+            {
+                dbConn.DropTable<TypeWithMemTableNoDurability>();
+                dbConn.DropTable<TypeWithMemTableSchemaOnlyDurability>();
+                dbConn.DropTable<TypeWithMemTableSchemaAndDataDurability>();
+            }
+        }
+
+        [Test]
+        public void CanCreateMemoryOptimizedTable()
+        {
+            using (var dbConn = OpenDbConnection())
+            {
+                dbConn.CreateTable<TypeWithMemTableNoDurability>(true);
+            }
+        }
+
+        [Test]
+        public void CanCreateMemoryOptimizedTableWithSchemaOnlyDurability()
+        {
+            using (var dbConn = OpenDbConnection())
+            {
+                dbConn.CreateTable<TypeWithMemTableSchemaOnlyDurability>(true);
+            }
+        }
+
+        [Test]
+        public void CanCreateMemoryOptimizedTableWithSchemaAndDurability()
+        {
+            using (var dbConn = OpenDbConnection())
+            {
+                dbConn.CreateTable<TypeWithMemTableSchemaAndDataDurability>(true);
+            }
+        }
+    }
+    
+    public class TypeWithMemTableNoDurability
+        {
+        [AutoIncrement]
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    public class TypeWithMemTableSchemaOnlyDurability
+    {
+        [AutoIncrement]
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    public class TypeWithMemTableSchemaAndDataDurability
+    {
+        [AutoIncrement]
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
+++ b/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Issues\DeleteWithGeoTypesIssue.cs" />
     <Compile Include="Issues\JamesGeoIssue.cs" />
     <Compile Include="Issues\SerializationTests.cs" />
+    <Compile Include="MemoryOptimizedAttributeTests.cs" />
     <Compile Include="NestedTransactions.cs" />
     <Compile Include="EnumTests.cs" />
     <Compile Include="Expressions\AdditiveExpressionsTest.cs" />

--- a/tests/ServiceStack.OrmLite.SqliteTests/project.json
+++ b/tests/ServiceStack.OrmLite.SqliteTests/project.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "NUnitLite" : "3.5.0",
     "ServiceStack.OrmLite" : "1.0.*",
@@ -28,14 +28,14 @@
     "ServiceStack.OrmLite.Sqlite" : "1.0.*"
   },
   "frameworks": {
-   "netcoreapp1.0": { 
+   "netcoreapp1.1": { 
       "imports": "dnxcore50",
 	    "dependencies" : {
-          "System.Runtime" : "4.1.0",
-          "System.Runtime.Serialization.Xml" : "4.1.1",
-          "System.Reflection" : "4.1.0",
-          "System.Reflection.Primitives" : "4.0.1",
-          "System.Runtime.Serialization.Primitives": "4.1.1"
+          "System.Runtime" : "4.*",
+          "System.Runtime.Serialization.Xml" : "4.*",
+          "System.Reflection" : "4.*",
+          "System.Reflection.Primitives" : "4.*",
+          "System.Runtime.Serialization.Primitives": "4.*"
         }	
      }
   }

--- a/tests/ServiceStack.OrmLite.Tests/Async/AsyncTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Async/AsyncTests.cs
@@ -51,9 +51,9 @@ namespace ServiceStack.OrmLite.Tests.Async
                 }
                 catch (Exception ex)
                 {
-                    Assert.That(ex.Message.ToLower(), Is.StringContaining("id")
-                                                        .Or.StringContaining("notexists")
-                                                        .Or.StringContaining("not_exists"));
+                    Assert.That(ex.Message.ToLower(), Does.Contain("id")
+                                                        .Or.Contain("notexists")
+                                                        .Or.Contain("not_exists"));
                 }
 
                 try
@@ -63,9 +63,9 @@ namespace ServiceStack.OrmLite.Tests.Async
                 }
                 catch (Exception ex)
                 {
-                    Assert.That(ex.Message.ToLower(), Is.StringContaining("id")
-                                                        .Or.StringContaining("notexists")
-                                                        .Or.StringContaining("not_exists"));
+                    Assert.That(ex.Message.ToLower(), Does.Contain("id")
+                                                        .Or.Contain("notexists")
+                                                        .Or.Contain("not_exists"));
                 }
 
                 try
@@ -79,9 +79,9 @@ namespace ServiceStack.OrmLite.Tests.Async
                 catch (Exception ex)
                 {
                     var innerEx = ex.UnwrapIfSingleException();
-                    Assert.That(innerEx.Message.ToLower(), Is.StringContaining("id")
-                                                        .Or.StringContaining("notexists")
-                                                        .Or.StringContaining("not_exists"));
+                    Assert.That(innerEx.Message.ToLower(), Does.Contain("id")
+                                                        .Or.Contain("notexists")
+                                                        .Or.Contain("not_exists"));
                 }
 
                 try
@@ -95,9 +95,9 @@ namespace ServiceStack.OrmLite.Tests.Async
                 catch (Exception ex)
                 {
                     var innerEx = ex.UnwrapIfSingleException();
-                    Assert.That(innerEx.Message.ToLower(), Is.StringContaining("id")
-                                                        .Or.StringContaining("notexists")
-                                                        .Or.StringContaining("not_exists"));
+                    Assert.That(innerEx.Message.ToLower(), Does.Contain("id")
+                                                        .Or.Contain("notexists")
+                                                        .Or.Contain("not_exists"));
                 }
             }
         }

--- a/tests/ServiceStack.OrmLite.Tests/Async/Issues/SqlServerComputedColumnIssue.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Async/Issues/SqlServerComputedColumnIssue.cs
@@ -41,14 +41,14 @@ namespace ServiceStack.OrmLite.Tests.Async.Issues
     {
         private IDbConnection db;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void TestFixtureSetUp()
         {
             OrmLiteConfig.DialectProvider = SqlServerDialect.Provider;
             db = Config.SqlServerBuildDb.OpenDbConnection();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             db.Dispose();

--- a/tests/ServiceStack.OrmLite.Tests/Async/Legacy/ApiPostgreSqlLegacyTestsAsync.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Async/Legacy/ApiPostgreSqlLegacyTestsAsync.cs
@@ -9,6 +9,7 @@ namespace ServiceStack.OrmLite.Tests.Async.Legacy
     public class ApiPostgreSqlLegacyTestsAsync
         : OrmLiteTestBase
     {
+#pragma warning disable 618
         [Test]
         public async Task API_PostgreSql_Legacy_Examples_Async()
         {
@@ -100,5 +101,6 @@ namespace ServiceStack.OrmLite.Tests.Async.Legacy
 
             db.Dispose();
         }
+#pragma warning restore 618
     }
 }

--- a/tests/ServiceStack.OrmLite.Tests/Async/Legacy/ApiSqlServerLegacyTestsAsync.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Async/Legacy/ApiSqlServerLegacyTestsAsync.cs
@@ -9,6 +9,7 @@ namespace ServiceStack.OrmLite.Tests.Async.Legacy
     public class ApiSqlServerLegacyTestsAsync
         : OrmLiteTestBase
     {
+#pragma warning disable 618
         [Test]
         public async Task API_SqlServer_Legacy_Examples_Async()
         {
@@ -100,5 +101,6 @@ namespace ServiceStack.OrmLite.Tests.Async.Legacy
 
             db.Dispose();
         }
+#pragma warning restore 618
     }
 }

--- a/tests/ServiceStack.OrmLite.Tests/Async/Legacy/ApiSqliteLegacyTestsAsync.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Async/Legacy/ApiSqliteLegacyTestsAsync.cs
@@ -9,6 +9,7 @@ namespace ServiceStack.OrmLite.Tests.Async.Legacy
     public class ApiSqliteLegacyTestsAsync
         : OrmLiteTestBase
     {
+#pragma warning disable 618
         [Test]
         public async Task API_Sqlite_Legacy_Examples_Async()
         {
@@ -99,5 +100,6 @@ namespace ServiceStack.OrmLite.Tests.Async.Legacy
 
             db.Dispose();
         }
+#pragma warning restore 618
     }
 }

--- a/tests/ServiceStack.OrmLite.Tests/Async/LoadReferencesJoinTestsAsync.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Async/LoadReferencesJoinTestsAsync.cs
@@ -14,7 +14,7 @@ namespace ServiceStack.OrmLite.Tests.Async
     {
         private IDbConnection db;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public new void TestFixtureSetUp()
         {
             db = base.OpenDbConnection();
@@ -40,8 +40,8 @@ namespace ServiceStack.OrmLite.Tests.Async
             db.DeleteAll<Country>();
         }
 
-        [TestFixtureTearDown]
-        public void TestFixtureTearDown()
+        [OneTimeTearDown]
+        public new void TestFixtureTearDown()
         {
             db.Dispose();
         }

--- a/tests/ServiceStack.OrmLite.Tests/Async/LoadReferencesTestsAsync.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Async/LoadReferencesTestsAsync.cs
@@ -15,7 +15,7 @@ namespace ServiceStack.OrmLite.Tests.Async
     {
         private IDbConnection db;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public new void TestFixtureSetUp()
         {
             db = base.OpenDbConnection();
@@ -35,8 +35,8 @@ namespace ServiceStack.OrmLite.Tests.Async
             db.DeleteAll<Customer>();
         }
 
-        [TestFixtureTearDown]
-        public void TestFixtureTearDown()
+        [OneTimeTearDown]
+        public new void TestFixtureTearDown()
         {
             db.Dispose();
         }
@@ -168,10 +168,10 @@ namespace ServiceStack.OrmLite.Tests.Async
                 dbCustomers = await db.LoadSelectAsync<Customer>(q => q.Id == customer.Id, include: new[] { "InvalidOption1", "InvalidOption2" });
                 Assert.Fail();
             }
-            catch (System.ArgumentException ex)
+            catch (System.ArgumentException)
             {
             }
-            catch (System.Exception ex)
+            catch (System.Exception)
             {
                 Assert.Fail();
             }
@@ -182,10 +182,10 @@ namespace ServiceStack.OrmLite.Tests.Async
                 dbCustomer = await db.LoadSingleByIdAsync<Customer>(customer.Id, include: new[] { "InvalidOption1", "InvalidOption2" });
                 Assert.Fail();
             }
-            catch (System.ArgumentException ex)
+            catch (System.ArgumentException)
             {
             }
-            catch (System.Exception ex)
+            catch (System.Exception)
             {
                 Assert.Fail();
             }

--- a/tests/ServiceStack.OrmLite.Tests/Async/SqlServerProviderTestsAsync.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Async/SqlServerProviderTestsAsync.cs
@@ -12,13 +12,13 @@ namespace ServiceStack.OrmLite.Tests.Async
     {
         private IDbConnection db;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void TestFixtureSetUp()
         {
             db = Config.OpenDbConnection();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             db.Dispose();

--- a/tests/ServiceStack.OrmLite.Tests/CaptureSqlCommandFilterTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/CaptureSqlCommandFilterTests.cs
@@ -49,7 +49,7 @@ namespace ServiceStack.OrmLite.Tests
                 i++; db.CreateTable<Person>();
 
                 Assert.That(captured.SqlCommandHistory.Last().Sql.NormalizeSql(),
-                            Is.StringStarting("create table person"));
+                            Does.Contain("create table person"));
 
                 Assert.That(captured.SqlCommandHistory.Count, Is.EqualTo(i)
                     .Or.EqualTo(i + 1)); //Check table if exists
@@ -175,7 +175,7 @@ namespace ServiceStack.OrmLite.Tests
                 i++; db.Update(new Person { Id = 1, FirstName = "Jimi", LastName = "Hendrix", Age = 27 });
 
                 Assert.That(captured.SqlCommandHistory.Last().Sql.NormalizeSql(),
-                    Is.StringStarting("update person set firstname=@firstname, lastname=@lastname"));
+                    Does.StartWith("update person set firstname=@firstname, lastname=@lastname"));
 
                 i++; db.Update(new[] { new Person { Id = 1, FirstName = "Jimi", LastName = "Hendrix", Age = 27 } });
                 i++; db.UpdateAll(new[] { new Person { Id = 1, FirstName = "Jimi", LastName = "Hendrix", Age = 27 } });
@@ -264,7 +264,7 @@ namespace ServiceStack.OrmLite.Tests
                 i++; db.Insert(new Person { Id = 7, FirstName = "Amy", LastName = "Winehouse", Age = 27 });
 
                 Assert.That(captured.SqlCommandHistory.Last().Sql.NormalizeSql(),
-                    Is.StringStarting("insert into person (id,firstname,lastname,age) values"));
+                    Does.StartWith("insert into person (id,firstname,lastname,age) values"));
 
                 i++; db.Insert(new Person { Id = 7, FirstName = "Amy", LastName = "Winehouse", Age = 27 });
                 i++; db.InsertAll(new[] { new Person { Id = 10, FirstName = "Biggie", LastName = "Smalls", Age = 24 } });

--- a/tests/ServiceStack.OrmLite.Tests/CaptureSqlFilterTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/CaptureSqlFilterTests.cs
@@ -50,7 +50,7 @@ namespace ServiceStack.OrmLite.Tests
                 i++; db.CreateTable<Person>();
 
                 Assert.That(captured.SqlStatements.Last().NormalizeSql(),
-                            Is.StringStarting("create table person"));
+                            Does.Contain("create table person"));
 
                 Assert.That(captured.SqlCommandHistory.Count, Is.EqualTo(i)
                     .Or.EqualTo(i + 1)); //Check table if exists
@@ -177,7 +177,7 @@ namespace ServiceStack.OrmLite.Tests
                 i++; db.Update(new Person { Id = 1, FirstName = "Jimi", LastName = "Hendrix", Age = 27 });
 
                 Assert.That(captured.SqlStatements.Last().NormalizeSql(),
-                    Is.StringStarting("update person set firstname=@firstname, lastname=@lastname"));
+                    Does.StartWith("update person set firstname=@firstname, lastname=@lastname"));
 
                 i++; db.Update(new[] { new Person { Id = 1, FirstName = "Jimi", LastName = "Hendrix", Age = 27 } });
                 i++; db.UpdateAll(new[] { new Person { Id = 1, FirstName = "Jimi", LastName = "Hendrix", Age = 27 } });
@@ -265,7 +265,7 @@ namespace ServiceStack.OrmLite.Tests
                 i++; db.Insert(new Person { Id = 7, FirstName = "Amy", LastName = "Winehouse", Age = 27 });
 
                 Assert.That(captured.SqlStatements.Last().NormalizeSql(),
-                    Is.StringStarting("insert into person (id,firstname,lastname,age) values"));
+                    Does.Contain("insert into person (id,firstname,lastname,age) values"));
 
                 i++; db.Insert(new Person { Id = 7, FirstName = "Amy", LastName = "Winehouse", Age = 27 });
                 i++; db.InsertAll(new[] { new Person { Id = 10, FirstName = "Biggie", LastName = "Smalls", Age = 24 } });

--- a/tests/ServiceStack.OrmLite.Tests/CustomConverterTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/CustomConverterTests.cs
@@ -33,7 +33,7 @@ namespace ServiceStack.OrmLite.Tests
                 db.DropAndCreateTable<PocoWithTime>();
 
                 var sql = db.GetLastSql();
-                Assert.That(sql, Is.StringContaining("\"TimeSpan\" TIME NOT NULL"));
+                Assert.That(sql, Does.Contain("\"TimeSpan\" TIME NOT NULL"));
                 sql.Print();
 
                 //SQL Server can't do < 1 day and only 3ms precision
@@ -47,8 +47,8 @@ namespace ServiceStack.OrmLite.Tests
                 sql = db.GetLastSql();
                 sql.Print();
 
-                Assert.That(sql, Is.StringContaining("\"TimeSpan\" = '01:01:01.0030000'").
-                                 Or.StringContaining("\"TimeSpan\" = CAST(@0 AS TIME))"));
+                Assert.That(sql, Does.Contain("\"TimeSpan\" = '01:01:01.0030000'").
+                                 Or.Contain("\"TimeSpan\" = CAST(@0 AS TIME))"));
 
                 db.GetDialectProvider().RegisterConverter<TimeSpan>(hold);
             }

--- a/tests/ServiceStack.OrmLite.Tests/CustomSqlTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/CustomSqlTests.cs
@@ -81,13 +81,13 @@ namespace ServiceStack.OrmLite.Tests
 
                 if (Dialect != Dialect.Firebird)
                 {
-                    Assert.That(createTableSql, Is.StringContaining("charcolumn char(20) null"));
-                    Assert.That(createTableSql, Is.StringContaining("decimalcolumn decimal(18,4) null"));
+                    Assert.That(createTableSql, Does.Contain("charcolumn char(20) null"));
+                    Assert.That(createTableSql, Does.Contain("decimalcolumn decimal(18,4) null"));
                 }
                 else
                 {
-                    Assert.That(createTableSql, Is.StringContaining("charcolumn char(20)"));
-                    Assert.That(createTableSql, Is.StringContaining("decimalcolumn decimal(18,4)"));
+                    Assert.That(createTableSql, Does.Contain("charcolumn char(20)"));
+                    Assert.That(createTableSql, Does.Contain("decimalcolumn decimal(18,4)"));
                 }
             }
         }

--- a/tests/ServiceStack.OrmLite.Tests/DateTimeOffsetTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/DateTimeOffsetTests.cs
@@ -11,14 +11,14 @@ namespace ServiceStack.OrmLite.Tests
     {
         private IDbConnection db;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public new void TestFixtureSetUp()
         {
             db = base.OpenDbConnection();
         }
 
-        [TestFixtureTearDown]
-        public void TestFixtureTearDown()
+        [OneTimeTearDown]
+        public new void TestFixtureTearDown()
         {
             db.Dispose();
         }

--- a/tests/ServiceStack.OrmLite.Tests/EnumTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/EnumTests.cs
@@ -138,7 +138,7 @@ namespace ServiceStack.OrmLite.Tests
                 var createTableSql = db.GetLastSql().NormalizeSql();
                 createTableSql.Print();
 
-                Assert.That(createTableSql, Is.StringContaining("flags int"));
+                Assert.That(createTableSql, Does.Contain("flags int"));
             }
         }
 
@@ -152,7 +152,7 @@ namespace ServiceStack.OrmLite.Tests
                 var createTableSql = db.GetLastSql().NormalizeSql();
                 createTableSql.Print();
 
-                Assert.That(createTableSql, Is.StringContaining("enumvalue int"));
+                Assert.That(createTableSql, Does.Contain("enumvalue int"));
             }
         }
 
@@ -168,11 +168,11 @@ namespace ServiceStack.OrmLite.Tests
                 db.Insert(new TypeWithFlagsEnum { Id = 3, Flags = FlagsEnum.FlagOne | FlagsEnum.FlagTwo });
 
                 db.Update(new TypeWithFlagsEnum { Id = 1, Flags = FlagsEnum.FlagThree });
-                Assert.That(db.GetLastSql(), Is.StringContaining("=@Flags").Or.StringContaining("=:Flags"));
+                Assert.That(db.GetLastSql(), Does.Contain("=@Flags").Or.Contain("=:Flags"));
                 db.GetLastSql().Print();
 
                 db.UpdateOnly(new TypeWithFlagsEnum { Id = 1, Flags = FlagsEnum.FlagThree }, onlyFields: q => q.Flags);
-                Assert.That(db.GetLastSql().NormalizeSql(), Is.StringContaining("=@flags"));
+                Assert.That(db.GetLastSql().NormalizeSql(), Does.Contain("=@flags"));
 
                 var row = db.SingleById<TypeWithFlagsEnum>(1);
                 Assert.That(row.Flags, Is.EqualTo(FlagsEnum.FlagThree));
@@ -191,12 +191,12 @@ namespace ServiceStack.OrmLite.Tests
                 db.Insert(new TypeWithEnumAsInt { Id = 3, EnumValue = SomeEnumAsInt.Value3 });
 
                 db.Update(new TypeWithEnumAsInt { Id = 1, EnumValue = SomeEnumAsInt.Value1 });
-                Assert.That(db.GetLastSql(), Is.StringContaining("=@EnumValue").Or.StringContaining("=:EnumValue"));
+                Assert.That(db.GetLastSql(), Does.Contain("=@EnumValue").Or.Contain("=:EnumValue"));
                 db.GetLastSql().Print();
 
                 db.UpdateOnly(new TypeWithEnumAsInt { Id = 1, EnumValue = SomeEnumAsInt.Value3 }, 
                     onlyFields: q => q.EnumValue);
-                Assert.That(db.GetLastSql().NormalizeSql(), Is.StringContaining("=@enumvalue"));
+                Assert.That(db.GetLastSql().NormalizeSql(), Does.Contain("=@enumvalue"));
 
                 var row = db.SingleById<TypeWithEnumAsInt>(1);
                 Assert.That(row.EnumValue, Is.EqualTo(SomeEnumAsInt.Value3));

--- a/tests/ServiceStack.OrmLite.Tests/Expression/ComplexJoinTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Expression/ComplexJoinTests.cs
@@ -189,6 +189,7 @@ namespace ServiceStack.OrmLite.Tests.Expression
             }
         }
 
+#pragma warning disable 618
         [Test]
         public void ComplexJoin_with_JoinSqlBuilder()
         {
@@ -225,6 +226,7 @@ namespace ServiceStack.OrmLite.Tests.Expression
                 Assert.That(fooBarBaz.BazId, Is.EqualTo(_baz1Id));
             }
         }
+#pragma warning restore 618
 
         [Test]
         public void ComplexJoin_with_SqlExpression()

--- a/tests/ServiceStack.OrmLite.Tests/Expression/ExpressionChainingUseCase.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Expression/ExpressionChainingUseCase.cs
@@ -218,7 +218,7 @@ namespace ServiceStack.OrmLite.Tests.Expression
             var ages = db.Select(query).ConvertAll(x => x.Age.Value);
 
             db.GetLastSql().Print();
-            Assert.That(db.GetLastSql(), Is.StringContaining("ORDER BY Age DESC"));
+            Assert.That(db.GetLastSql(), Does.Contain("ORDER BY Age DESC"));
 
             ages.PrintDump();
 

--- a/tests/ServiceStack.OrmLite.Tests/Expression/MethodExpressionTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Expression/MethodExpressionTests.cs
@@ -29,8 +29,8 @@ namespace ServiceStack.OrmLite.Tests.Expression
                 CollectionAssert.AreEquivalent(new[] { int20, int30 }, results);
                 CollectionAssert.AreEquivalent(new[] { int20, int30 }, resultsNullable);
 
-                Assert.That(db.GetLastSql(), Is.StringContaining("(@0,@1,@2)").
-                                             Or.StringContaining("(:0,:1,:2)"));
+                Assert.That(db.GetLastSql(), Does.Contain("(@0,@1,@2)").
+                                             Or.Contain("(:0,:1,:2)"));
             }
         }
 
@@ -54,8 +54,8 @@ namespace ServiceStack.OrmLite.Tests.Expression
                 CollectionAssert.AreEquivalent(new[] { int20, int30 }, results);
                 CollectionAssert.AreEquivalent(new[] { int20, int30 }, resultsNullable);
 
-                Assert.That(db.GetLastSql(), Is.StringContaining("(@0,@1,@2)").
-                                             Or.StringContaining("(:0,:1,:2)"));
+                Assert.That(db.GetLastSql(), Does.Contain("(@0,@1,@2)").
+                                             Or.Contain("(:0,:1,:2)"));
             }
         }
 
@@ -71,7 +71,7 @@ namespace ServiceStack.OrmLite.Tests.Expression
                 var results = db.Select<TestType>(x => ints.Contains(x.Id));
 
                 CollectionAssert.IsEmpty(results);
-                Assert.That(db.GetLastSql(), Is.StringContaining("(NULL)"));
+                Assert.That(db.GetLastSql(), Does.Contain("(NULL)"));
             }
         }
 

--- a/tests/ServiceStack.OrmLite.Tests/Expression/SqlExpressionTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Expression/SqlExpressionTests.cs
@@ -263,10 +263,12 @@ namespace ServiceStack.OrmLite.Tests.Expression
                     db.Insert(new LetterWeighting { LetterFrequencyId = id, Weighting = ++i * 10 });
                 });
 
+#pragma warning disable 618
                 var joinFn = new Func<JoinSqlBuilder<LetterFrequency, LetterWeighting>>(() =>
                     new JoinSqlBuilder<LetterFrequency, LetterWeighting>()
                         .Join<LetterFrequency, LetterWeighting>(x => x.Id, x => x.LetterFrequencyId)
                     );
+#pragma warning restore 618
 
                 var results = db.Select<LetterFrequency>(joinFn());
                 Assert.That(results.Count, Is.EqualTo(5));

--- a/tests/ServiceStack.OrmLite.Tests/ExpressionTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/ExpressionTests.cs
@@ -9,7 +9,7 @@ namespace ServiceStack.OrmLite.Tests
     [TestFixture]
     public class ExpressionTests
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void TestFixtureSetUp()
         {
             OrmLiteConfig.DialectProvider = new SqliteOrmLiteDialectProvider();

--- a/tests/ServiceStack.OrmLite.Tests/ForeignKeyAttributeTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/ForeignKeyAttributeTests.cs
@@ -6,7 +6,7 @@ namespace ServiceStack.OrmLite.Tests
     [TestFixture]
     public class ForeignKeyAttributeTests : OrmLiteTestBase
     {
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
             using (var dbConn = OpenDbConnection())

--- a/tests/ServiceStack.OrmLite.Tests/Issues/CustomFieldTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Issues/CustomFieldTests.cs
@@ -26,7 +26,7 @@ namespace ServiceStack.OrmLite.Tests.Issues
 
                 sql.Print();
 
-                Assert.That(sql, Is.StringContaining("DECIMAL(12,3)"));
+                Assert.That(sql, Does.Contain("DECIMAL(12,3)"));
             }
         }
     }

--- a/tests/ServiceStack.OrmLite.Tests/Issues/MismatchSchemaTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Issues/MismatchSchemaTests.cs
@@ -81,13 +81,13 @@ namespace ServiceStack.OrmLite.Tests.Issues
                 
                 db.SingleById<Poco>(1);
 
-                Assert.That(captured.SqlStatements.Last().ToLower(), Is.StringContaining("schema1"));
+                Assert.That(captured.SqlStatements.Last().ToLower(), Does.Contain("schema1"));
 
                 modelDef.Schema = "schema2";
 
                 db.SingleById<Poco>(1);
 
-                Assert.That(captured.SqlStatements.Last().ToLower(), Is.StringContaining("schema2"));
+                Assert.That(captured.SqlStatements.Last().ToLower(), Does.Contain("schema2"));
             }
         }
     }

--- a/tests/ServiceStack.OrmLite.Tests/Issues/MultiColumnOrderByDescending.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Issues/MultiColumnOrderByDescending.cs
@@ -12,7 +12,7 @@ namespace ServiceStack.OrmLite.Tests.Issues
     {
         private List<Person> _people;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public new void TestFixtureSetUp()
         {
             _people = new List<Person>

--- a/tests/ServiceStack.OrmLite.Tests/Issues/SqlExpressionSubSqlExpressionIssue.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Issues/SqlExpressionSubSqlExpressionIssue.cs
@@ -107,13 +107,13 @@ namespace ServiceStack.OrmLite.Tests.Issues
                     .Select(y => y.Person2Id);
 
                 subExpr.ToSelectStatement().Print();
-                Assert.That(subExpr.ToSelectStatement().NormalizeSql(), Is.StringContaining("@0"));
+                Assert.That(subExpr.ToSelectStatement().NormalizeSql(), Does.Contain("@0"));
 
                 var expr = db.From<Person2>()
                     .Where(x => Sql.In(x.Id, subExpr));
 
                 expr.ToSelectStatement().Print();
-                Assert.That(expr.ToSelectStatement().NormalizeSql(), Is.StringContaining("@0"));
+                Assert.That(expr.ToSelectStatement().NormalizeSql(), Does.Contain("@0"));
             }
         }
 
@@ -166,14 +166,14 @@ namespace ServiceStack.OrmLite.Tests.Issues
 
                 result.PrintDump();
                 db.GetLastSql().PrintDump();
-                Assert.That(db.GetLastSql().NormalizeSql(), Is.StringContaining("is null"));
+                Assert.That(db.GetLastSql().NormalizeSql(), Does.Contain("is null"));
                 
                 model = new AnyObjectClass { db = db, Identity = Guid.Parse("104ECE6A-7117-4205-961C-126AD276565C") };
                 result = model.CustomProperty;
 
                 result.PrintDump();
                 db.GetLastSql().PrintDump();
-                Assert.That(db.GetLastSql().NormalizeSql(), Is.StringContaining("@"));
+                Assert.That(db.GetLastSql().NormalizeSql(), Does.Contain("@"));
             }
         }
 
@@ -187,12 +187,12 @@ namespace ServiceStack.OrmLite.Tests.Issues
                     .Where(y => y.Order2TypeId == orderTypeId)
                     .Select(y => y.Person2Id);
 
-                Assert.That(subExpr.ToSelectStatement().NormalizeSql(), Is.StringContaining("@"));
+                Assert.That(subExpr.ToSelectStatement().NormalizeSql(), Does.Contain("@"));
 
                 var expr = db.From<Person2>()
                     .Where(x => Sql.In(x.Id, subExpr));
 
-                Assert.That(subExpr.ToSelectStatement().NormalizeSql(), Is.StringContaining("@"));
+                Assert.That(subExpr.ToSelectStatement().NormalizeSql(), Does.Contain("@"));
             }
         }
 
@@ -256,7 +256,7 @@ namespace ServiceStack.OrmLite.Tests.Issues
                     )
                     .Select(b => b.MarginItemId)));
 
-            Assert.That(q.ToSelectStatement().NormalizeSql(), Is.StringContaining("@"));
+            Assert.That(q.ToSelectStatement().NormalizeSql(), Does.Contain("@"));
         }
     }
 
@@ -347,7 +347,7 @@ namespace ServiceStack.OrmLite.Tests.Issues
                         .Select(b => b.MarginItemId)));
 
             q.ToSelectStatement().PrintDump();
-            Assert.That(q.ToSelectStatement().NormalizeSql(), Is.StringContaining("@"));
+            Assert.That(q.ToSelectStatement().NormalizeSql(), Does.Contain("@"));
         }
 
         public void TestMethod2()
@@ -359,7 +359,7 @@ namespace ServiceStack.OrmLite.Tests.Issues
                         .Select(b => b.MarginItemId)));
 
             q.ToSelectStatement().PrintDump();
-            Assert.That(q.ToSelectStatement().NormalizeSql(), Is.StringContaining("@"));
+            Assert.That(q.ToSelectStatement().NormalizeSql(), Does.Contain("@"));
         }
 
         public void TestMethod3()
@@ -373,7 +373,7 @@ namespace ServiceStack.OrmLite.Tests.Issues
                         .Select(b => b.MarginItemId)));
 
             q.ToSelectStatement().PrintDump();
-            Assert.That(q.ToSelectStatement().NormalizeSql(), Is.StringContaining("@"));
+            Assert.That(q.ToSelectStatement().NormalizeSql(), Does.Contain("@"));
         }
     }
 }

--- a/tests/ServiceStack.OrmLite.Tests/Legacy/ApiSqlServerLegacyTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Legacy/ApiSqlServerLegacyTests.cs
@@ -26,6 +26,7 @@ namespace ServiceStack.OrmLite.Tests.Legacy
             db.Dispose();
         }
 
+#pragma warning disable 618
         [Test]
         public void API_SqlServer_Legacy_Examples()
         {
@@ -115,5 +116,6 @@ namespace ServiceStack.OrmLite.Tests.Legacy
             db.DeleteFmt(table: "Person", where: "Age = {0}".SqlFmt(27));
             Assert.That(db.GetLastSql(), Is.EqualTo("DELETE FROM \"Person\" WHERE Age = 27"));
         }
+#pragma warning restore 618
     }
 }

--- a/tests/ServiceStack.OrmLite.Tests/Legacy/ApiSqliteLegacyTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Legacy/ApiSqliteLegacyTests.cs
@@ -25,6 +25,7 @@ namespace ServiceStack.OrmLite.Tests.Legacy
             db.Dispose();
         }
 
+#pragma warning disable 618
         [Test]
         public void API_Sqlite_Legacy_Examples()
         {
@@ -113,5 +114,6 @@ namespace ServiceStack.OrmLite.Tests.Legacy
             db.DeleteFmt(table: "Person", where: "Age = {0}".SqlFmt(27));
             Assert.That(db.GetLastSql(), Is.EqualTo("DELETE FROM \"Person\" WHERE Age = 27"));
         }
+#pragma warning restore 618
     }
 }

--- a/tests/ServiceStack.OrmLite.Tests/LicenseUsageTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/LicenseUsageTests.cs
@@ -83,14 +83,14 @@ namespace ServiceStack.OrmLite.Tests
     {
         protected IDbConnection db;
 
-        [TestFixtureSetUp]
-        public void TestFixtureSetUp()
+        [OneTimeSetUp]
+        public new void TestFixtureSetUp()
         {
             db = base.OpenDbConnection();
         }
 
-        [TestFixtureTearDown]
-        public void TestFixtureTearDown()
+        [OneTimeTearDown]
+        public new void TestFixtureTearDown()
         {
             db.Dispose();
         }

--- a/tests/ServiceStack.OrmLite.Tests/LoadReferencesJoinTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/LoadReferencesJoinTests.cs
@@ -18,7 +18,7 @@ namespace ServiceStack.OrmLite.Tests
     {
         private IDbConnection db;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public new void TestFixtureSetUp()
         {
             db = base.OpenDbConnection();
@@ -44,8 +44,8 @@ namespace ServiceStack.OrmLite.Tests
             db.DeleteAll<Country>();
         }
 
-        [TestFixtureTearDown]
-        public void TestFixtureTearDown()
+        [OneTimeTearDown]
+        public new void TestFixtureTearDown()
         {
             db.Dispose();
         }
@@ -524,9 +524,11 @@ namespace ServiceStack.OrmLite.Tests
 
             db.Save(customer, references: true);
 
+#pragma warning disable 472
             var q = db.From<Customer>();
             q.LeftJoin<Order>()
              .Where<Order>(o => o.Id == null);
+#pragma warning restore 472
 
             var customers = db.Select(q);
 

--- a/tests/ServiceStack.OrmLite.Tests/LoadReferencesTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/LoadReferencesTests.cs
@@ -187,7 +187,7 @@ namespace ServiceStack.OrmLite.Tests
     {
         private IDbConnection db;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public new void TestFixtureSetUp()
         {
             db = base.OpenDbConnection();
@@ -221,8 +221,8 @@ namespace ServiceStack.OrmLite.Tests
             db.DeleteAll<Customer>();
         }
 
-        [TestFixtureTearDown]
-        public void TestFixtureTearDown()
+        [OneTimeTearDown]
+        public new void TestFixtureTearDown()
         {
             db.Dispose();
         }
@@ -617,10 +617,10 @@ namespace ServiceStack.OrmLite.Tests
             results.PrintDump();
 
             Assert.That(results.Count, Is.EqualTo(2));
-            Assert.That(results[0].HomeAddress.AddressLine1, Is.StringContaining("Home"));
-            Assert.That(results[0].WorkAddress.AddressLine1, Is.StringContaining("Work"));
-            Assert.That(results[1].HomeAddress.AddressLine1, Is.StringContaining("Home"));
-            Assert.That(results[1].WorkAddress.AddressLine1, Is.StringContaining("Work"));
+            Assert.That(results[0].HomeAddress.AddressLine1, Does.Contain("Home"));
+            Assert.That(results[0].WorkAddress.AddressLine1, Does.Contain("Work"));
+            Assert.That(results[1].HomeAddress.AddressLine1, Does.Contain("Home"));
+            Assert.That(results[1].WorkAddress.AddressLine1, Does.Contain("Work"));
 
             var ukAddress = db.Single<SelfCustomerAddress>(q => q.Country == "UK");
             ukAddress.PrintDump();
@@ -734,9 +734,9 @@ namespace ServiceStack.OrmLite.Tests
 
             Assert.That(orderQuery.Params.Count, Is.EqualTo(2));
             Assert.That(orderQuery.Params[0].Value, Is.EqualTo(1));
-            Assert.That(orderQuery.Params[0].ParameterName, Is.StringEnding("0"));
+            Assert.That(orderQuery.Params[0].ParameterName, Does.EndWith("0"));
             Assert.That(orderQuery.Params[1].Value, Is.EqualTo(-1));
-            Assert.That(orderQuery.Params[1].ParameterName, Is.StringEnding("1"));
+            Assert.That(orderQuery.Params[1].ParameterName, Does.EndWith("1"));
 
             dbOrders = db.Select(orderQuery);
             Assert.That(dbOrders.Count, Is.EqualTo(0));

--- a/tests/ServiceStack.OrmLite.Tests/LoggingTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/LoggingTests.cs
@@ -52,11 +52,11 @@ namespace ServiceStack.OrmLite.Tests
                 var logs = sbLogFactory.GetLogs();
                 logs.Print();
 
-                Assert.That(logs, Is.StringContaining("CREATE TABLE"));
-                Assert.That(logs, Is.StringContaining("INSERT INTO"));
-                Assert.That(logs, Is.StringContaining("SELECT"));
-                Assert.That(logs, Is.StringContaining("UPDATE"));
-                Assert.That(logs, Is.StringContaining("DELETE FROM"));
+                Assert.That(logs, Does.Contain("CREATE TABLE"));
+                Assert.That(logs, Does.Contain("INSERT INTO"));
+                Assert.That(logs, Does.Contain("SELECT"));
+                Assert.That(logs, Does.Contain("UPDATE"));
+                Assert.That(logs, Does.Contain("DELETE FROM"));
             }
         }
 
@@ -80,9 +80,9 @@ namespace ServiceStack.OrmLite.Tests
                     var results = db.Select<LogTest>("Unknown = @arg", new { arg = "foo" });
                     Assert.Fail("Should throw");
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
-                    Assert.That(lastSql, Is.StringContaining("Unknown"));
+                    Assert.That(lastSql, Does.Contain("Unknown"));
                     Assert.That(lastParam.Value, Is.EqualTo("foo"));
                 }
             }

--- a/tests/ServiceStack.OrmLite.Tests/MockAllApiTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/MockAllApiTests.cs
@@ -17,8 +17,8 @@ namespace ServiceStack.OrmLite.Tests
     {
         private IDbConnection db;
 
-        [TestFixtureSetUp]
-        public void TestFixtureSetUp()
+        [OneTimeSetUp]
+        public new void TestFixtureSetUp()
         {
             db = base.OpenDbConnection();
 
@@ -26,8 +26,8 @@ namespace ServiceStack.OrmLite.Tests
             db.InsertAll(Person.Rockstars);
         }
 
-        [TestFixtureTearDown]
-        public void TestFixtureTearDown()
+        [OneTimeTearDown]
+        public new void TestFixtureTearDown()
         {
             db.Dispose();
         }

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableTests.cs
@@ -189,12 +189,12 @@ namespace ServiceStack.OrmLite.Tests
             Console.WriteLine("createTableSql: " + createTableSql);
             if (Dialect != Dialect.PostgreSql)
             {
-                Assert.That(createTableSql, Is.StringContaining("VARCHAR(255)").
-                                            Or.StringContaining("VARCHAR2(255)"));
+                Assert.That(createTableSql, Does.Contain("VARCHAR(255)").
+                                            Or.Contain("VARCHAR2(255)"));
             }
             else
             {
-                Assert.That(createTableSql, Is.StringContaining("TEXT"));
+                Assert.That(createTableSql, Does.Contain("TEXT"));
             }
             converter.StringLength = hold;
         }
@@ -473,8 +473,8 @@ namespace ServiceStack.OrmLite.Tests
             {
                 db.DropAndCreateTable<TableWithIgnoredFields>();
 
-                Assert.That(db.GetLastSql(), Is.StringContaining("DisplayName".SqlColumnRaw()));
-                Assert.That(db.GetLastSql(), Is.Not.StringContaining("IsIgnored".SqlColumnRaw()));
+                Assert.That(db.GetLastSql(), Does.Contain("DisplayName".SqlColumnRaw()));
+                Assert.That(db.GetLastSql(), Does.Not.Contain("IsIgnored".SqlColumnRaw()));
 
                 db.Insert(new TableWithIgnoredFields
                 {

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableWithIndexesTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableWithIndexesTests.cs
@@ -27,8 +27,8 @@ namespace ServiceStack.OrmLite.Tests
                     uniqueName = OrmLiteConfig.DialectProvider.NamingStrategy.ApplyNameRestrictions(uniqueName);
                 }
 
-                Assert.That(sql, Is.StringContaining(indexName));
-                Assert.That(sql, Is.StringContaining(uniqueName));
+                Assert.That(sql, Does.Contain(indexName));
+                Assert.That(sql, Does.Contain(uniqueName));
             }
         }
 
@@ -50,8 +50,8 @@ namespace ServiceStack.OrmLite.Tests
                     compositeName = OrmLiteConfig.DialectProvider.NamingStrategy.ApplyNameRestrictions(compositeName);
                 }
 
-                Assert.That(sql, Is.StringContaining(indexName));
-                Assert.That(sql, Is.StringContaining(compositeName));
+                Assert.That(sql, Does.Contain(indexName));
+                Assert.That(sql, Does.Contain(compositeName));
             }
         }
 
@@ -74,8 +74,8 @@ namespace ServiceStack.OrmLite.Tests
                     compositeName = OrmLiteConfig.DialectProvider.NamingStrategy.ApplyNameRestrictions(compositeName).ToLower();
                 }
 
-                Assert.That(sql, Is.StringContaining(indexName));
-                Assert.That(sql, Is.StringContaining(compositeName));
+                Assert.That(sql, Does.Contain(indexName));
+                Assert.That(sql, Does.Contain(compositeName));
             }
         }
 
@@ -96,7 +96,7 @@ namespace ServiceStack.OrmLite.Tests
                 if (Dialect == Dialect.Oracle || Dialect == Dialect.Firebird)
                     compositeName = OrmLiteConfig.DialectProvider.NamingStrategy.ApplyNameRestrictions(compositeName).ToLower();
 
-                Assert.That(sql, Is.StringContaining(compositeName));
+                Assert.That(sql, Does.Contain(compositeName));
             }
         }
 
@@ -118,9 +118,9 @@ namespace ServiceStack.OrmLite.Tests
                     compositeName = OrmLiteConfig.DialectProvider.NamingStrategy.ApplyNameRestrictions(compositeName);
                 }
 
-                Assert.That(sql, Is.StringContaining(indexName));
-                Assert.That(sql, Is.StringContaining("custom_index_name"));
-                Assert.That(sql, Is.Not.StringContaining(compositeName));
+                Assert.That(sql, Does.Contain(indexName));
+                Assert.That(sql, Does.Contain("custom_index_name"));
+                Assert.That(sql, Does.Not.Contain(compositeName));
             }
         }
 

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableWithNamingStrategyTest.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteCreateTableWithNamingStrategyTest.cs
@@ -56,8 +56,8 @@ namespace ServiceStack.OrmLite.Tests
                 db.CreateTable<ModelWithOnlyStringFields>(true);
 
                 var sql = db.GetLastSql().NormalizeSql();
-                Assert.That(sql, Is.StringContaining("CREATE TABLE TableAlias".NormalizeSql()));
-                Assert.That(sql, Is.StringContaining("ColumnAlias".NormalizeSql()));
+                Assert.That(sql, Does.Contain("CREATE TABLE TableAlias".NormalizeSql()));
+                Assert.That(sql, Does.Contain("ColumnAlias".NormalizeSql()));
 
                 var result = db.SqlList<ModelWithIdAndName>(
                     "SELECT * FROM {0} WHERE {1} = {2}"
@@ -74,8 +74,8 @@ namespace ServiceStack.OrmLite.Tests
 
                 db.CreateTable<ModelWithOnlyStringFields>(true);
                 sql = db.GetLastSql().NormalizeSql();
-                Assert.That(sql, Is.StringContaining("CREATE TABLE table_alias".NormalizeSql()));
-                Assert.That(sql, Is.StringContaining("column_alias".NormalizeSql()));
+                Assert.That(sql, Does.Contain("CREATE TABLE table_alias".NormalizeSql()));
+                Assert.That(sql, Does.Contain("column_alias".NormalizeSql()));
             }
         }
 
@@ -183,7 +183,7 @@ namespace ServiceStack.OrmLite.Tests
 
     }
 
-    public class PrefixNamingStrategy : OrmLiteNamingStrategyBase
+    internal class PrefixNamingStrategy : OrmLiteNamingStrategyBase
     {
 
         public string TablePrefix { get; set; }
@@ -202,7 +202,7 @@ namespace ServiceStack.OrmLite.Tests
 
     }
 
-    public class LowercaseNamingStrategy : OrmLiteNamingStrategyBase
+    internal class LowercaseNamingStrategy : OrmLiteNamingStrategyBase
     {
 
         public override string GetTableName(string name)
@@ -217,7 +217,7 @@ namespace ServiceStack.OrmLite.Tests
 
     }
 
-    public class UnderscoreSeparatedCompoundNamingStrategy : OrmLiteNamingStrategyBase
+    internal class UnderscoreSeparatedCompoundNamingStrategy : OrmLiteNamingStrategyBase
     {
 
         public override string GetTableName(string name)
@@ -255,7 +255,7 @@ namespace ServiceStack.OrmLite.Tests
 
     }
 
-    public class LowerCaseUnderscoreNamingStrategy : OrmLiteNamingStrategyBase
+    internal class LowerCaseUnderscoreNamingStrategy : OrmLiteNamingStrategyBase
     {
         public override string GetTableName(string name)
         {

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteExecFilterTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteExecFilterTests.cs
@@ -40,7 +40,7 @@ namespace ServiceStack.OrmLite.Tests
             {
                 return base.Exec(dbConn, filter);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 var sql = dbConn.GetLastSql();
                 if (sql == "exec sp_name @firstName, @age")

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteGetScalarTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteGetScalarTests.cs
@@ -207,7 +207,7 @@ namespace ServiceStack.OrmLite.Tests
     }
 
 
-    public class Author
+    internal class Author
     {
         public Author() { }
 

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteTestBase.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteTestBase.cs
@@ -109,13 +109,13 @@ namespace ServiceStack.OrmLite.Tests
             return DbFactory;
         }
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void TestFixtureSetUp()
         {
             Init();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TestFixtureTearDown()
         {
             OrmLiteContext.Instance.ClearItems();

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteUpdateTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteUpdateTests.cs
@@ -373,9 +373,9 @@ namespace ServiceStack.OrmLite.Tests
                 db.Update(new Person { Id = 1, FirstName = "JJ", Age = 27 }, p => p.LastName == "Hendrix");
 
                 var sql = db.GetLastSql().NormalizeSql();
-                Assert.That(sql, Is.StringContaining("where (lastname = @0)"));
-                Assert.That(sql, Is.StringContaining("id=@id"));
-                Assert.That(sql, Is.StringContaining("firstname=@firstname"));
+                Assert.That(sql, Does.Contain("where (lastname = @0)"));
+                Assert.That(sql, Does.Contain("id=@id"));
+                Assert.That(sql, Does.Contain("firstname=@firstname"));
 
                 var row = db.SingleById<Person>(1);
                 Assert.That(row.FirstName, Is.EqualTo("JJ"));
@@ -393,8 +393,8 @@ namespace ServiceStack.OrmLite.Tests
                 db.Update<Person>(new { FirstName = "JJ" }, p => p.LastName == "Hendrix");
 
                 var sql = db.GetLastSql().NormalizeSql();
-                Assert.That(sql, Is.StringContaining("where (lastname = @0)"));
-                Assert.That(sql, Is.StringContaining("firstname=@firstname"));
+                Assert.That(sql, Does.Contain("where (lastname = @0)"));
+                Assert.That(sql, Does.Contain("firstname=@firstname"));
 
                 var row = db.SingleById<Person>(1);
                 Assert.That(row.FirstName, Is.EqualTo("JJ"));
@@ -412,8 +412,8 @@ namespace ServiceStack.OrmLite.Tests
                 db.UpdateNonDefaults(new Person { FirstName = "JJ" }, p => p.LastName == "Hendrix");
 
                 var sql = db.GetLastSql().NormalizeSql();
-                Assert.That(sql, Is.StringContaining("where (lastname = @0)"));
-                Assert.That(sql, Is.StringContaining("firstname=@firstname"));
+                Assert.That(sql, Does.Contain("where (lastname = @0)"));
+                Assert.That(sql, Does.Contain("firstname=@firstname"));
 
                 var row = db.SingleById<Person>(1);
                 Assert.That(row.FirstName, Is.EqualTo("JJ"));
@@ -431,8 +431,8 @@ namespace ServiceStack.OrmLite.Tests
                 db.UpdateOnly(new Person { FirstName = "JJ" }, p => p.FirstName, p => p.LastName == "Hendrix");
 
                 var sql = db.GetLastSql().NormalizeSql();
-                Assert.That(sql, Is.StringContaining("where (lastname = @0)"));
-                Assert.That(sql, Is.StringContaining("firstname=@firstname"));
+                Assert.That(sql, Does.Contain("where (lastname = @0)"));
+                Assert.That(sql, Does.Contain("firstname=@firstname"));
 
                 var row = db.SingleById<Person>(1);
                 Assert.That(row.FirstName, Is.EqualTo("JJ"));
@@ -450,8 +450,8 @@ namespace ServiceStack.OrmLite.Tests
                 db.UpdateOnly(() => new Person { FirstName = "JJ" }, p => p.LastName == "Hendrix");
 
                 var sql = db.GetLastSql().NormalizeSql();
-                Assert.That(sql, Is.StringContaining("where (lastname = @0)"));
-                Assert.That(sql, Is.StringContaining("firstname=@firstname"));
+                Assert.That(sql, Does.Contain("where (lastname = @0)"));
+                Assert.That(sql, Does.Contain("firstname=@firstname"));
 
                 var row = db.SingleById<Person>(1);
                 Assert.That(row.FirstName, Is.EqualTo("JJ"));

--- a/tests/ServiceStack.OrmLite.Tests/RowVersionTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/RowVersionTests.cs
@@ -78,7 +78,7 @@ namespace ServiceStack.OrmLite.Tests
     {
         private IDbConnection db;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void FixtureSetUp()
         {
             LogManager.LogFactory = new ConsoleLogFactory(debugEnabled: true);

--- a/tests/ServiceStack.OrmLite.Tests/SqlServerProviderTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/SqlServerProviderTests.cs
@@ -19,13 +19,13 @@ namespace ServiceStack.OrmLite.Tests
     {
         private IDbConnection db;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void TestFixtureSetUp()
         {
             db = Config.OpenDbConnection();
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void TearDown()
         {
             db.Dispose();

--- a/tests/ServiceStack.OrmLite.Tests/TypeWithByteArrayFieldTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/TypeWithByteArrayFieldTests.cs
@@ -65,7 +65,7 @@ namespace ServiceStack.OrmLite.Tests
                 {
                     db.ExecuteSql("DROP PROCEDURE dbo.[SP_upload_file]");
                 }
-                catch (System.Exception ex) {}
+                catch (System.Exception) {}
 
                 db.ExecuteSql(@"
 CREATE PROCEDURE dbo.[SP_upload_file](          
@@ -105,7 +105,7 @@ end".Fmt(OrmLiteConfig.DialectProvider.ParamString));
                 {
                     db.ExecuteSql("DROP PROCEDURE dbo.[SP_upload_file]");
                 }
-                catch (System.Exception ex) { }
+                catch (System.Exception) { }
 
                 db.ExecuteSql(@"
 CREATE PROCEDURE dbo.[SP_upload_file](          

--- a/tests/ServiceStack.OrmLite.Tests/_TypeDescriptorMetadataTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/_TypeDescriptorMetadataTests.cs
@@ -13,14 +13,14 @@ namespace ServiceStack.OrmLite.Tests
     {
         private IDbConnection db;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public new void TestFixtureSetUp()
         {
             db = OpenDbConnection();
         }
 
-        [TestFixtureTearDown]
-        public void TestFixtureTearDown()
+        [OneTimeTearDown]
+        public new void TestFixtureTearDown()
         {
             db.Dispose();
         }
@@ -59,7 +59,7 @@ namespace ServiceStack.OrmLite.Tests
             db.DropAndCreateTable<DynamicCacheEntry>();
 
             Assert.That(db.GetLastSql().NormalizeSql(), 
-                Is.StringContaining("Data VARCHAR(7000)".NormalizeSql()));
+                Does.Contain("Data VARCHAR(7000)".NormalizeSql()));
             db.GetLastSql().Print();
         }
 
@@ -80,23 +80,23 @@ namespace ServiceStack.OrmLite.Tests
 
             if (Dialect == Dialect.Sqlite)
             {
-                Assert.That(sql, Is.StringContaining(" VARCHAR(1000000)"));
+                Assert.That(sql, Does.Contain(" VARCHAR(1000000)"));
             }
             else if (Dialect == Dialect.PostgreSql)
             {
-                Assert.That(sql, Is.StringContaining(" TEXT"));
+                Assert.That(sql, Does.Contain(" TEXT"));
             }
             else if (Dialect == Dialect.MySql)
             {
-                Assert.That(sql, Is.StringContaining(" LONGTEXT"));
+                Assert.That(sql, Does.Contain(" LONGTEXT"));
             }
             else if (Dialect == Dialect.Oracle)
             {
-                Assert.That(sql, Is.StringContaining(" VARCHAR2(4000)"));
+                Assert.That(sql, Does.Contain(" VARCHAR2(4000)"));
             }
             else if (Dialect == Dialect.SqlServer)
             {
-                Assert.That(sql, Is.StringContaining(" VARCHAR(MAX)"));
+                Assert.That(sql, Does.Contain(" VARCHAR(MAX)"));
             }
         }
 
@@ -125,27 +125,27 @@ namespace ServiceStack.OrmLite.Tests
 
             if (Dialect == Dialect.Sqlite)
             {
-                Assert.That(sql, Is.StringContaining(" NVARCHAR(1000000)"));
+                Assert.That(sql, Does.Contain(" NVARCHAR(1000000)"));
             }
             else if (Dialect == Dialect.PostgreSql)
             {
-                Assert.That(sql, Is.StringContaining(" TEXT"));
+                Assert.That(sql, Does.Contain(" TEXT"));
             }
             else if (Dialect == Dialect.MySql)
             {
-                Assert.That(sql, Is.StringContaining(" LONGTEXT"));
+                Assert.That(sql, Does.Contain(" LONGTEXT"));
             }
             else if (Dialect == Dialect.Oracle)
             {
-                Assert.That(sql, Is.StringContaining(" NVARCHAR2(4000)"));
+                Assert.That(sql, Does.Contain(" NVARCHAR2(4000)"));
             }
             else if (Dialect == Dialect.Firebird)
             {
-                Assert.That(sql, Is.StringContaining(" VARCHAR(10000)"));
+                Assert.That(sql, Does.Contain(" VARCHAR(10000)"));
             }
             else
             {
-                Assert.That(sql, Is.StringContaining(" NVARCHAR(MAX)"));
+                Assert.That(sql, Does.Contain(" NVARCHAR(MAX)"));
             }
         }
     }

--- a/tests/ServiceStack.OrmLite.Tests/project.json
+++ b/tests/ServiceStack.OrmLite.Tests/project.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     "NUnitLite": "3.5.0",
     "ServiceStack.OrmLite": "1.0.*",
@@ -30,14 +30,14 @@
     "ServiceStack.OrmLite.PostgreSQL": "1.0.*"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": "dnxcore50",
       "dependencies": {
-        "System.Runtime": "4.1.0",
-        "System.Runtime.Serialization.Xml": "4.1.1",
-        "System.Reflection": "4.1.0",
-        "System.Reflection.Primitives": "4.0.1",
-        "System.Runtime.Serialization.Primitives": "4.1.1"
+        "System.Runtime": "4.*",
+        "System.Runtime.Serialization.Xml": "4.*",
+        "System.Reflection": "4.*",
+        "System.Reflection.Primitives": "4.*",
+        "System.Runtime.Serialization.Primitives": "4.*"
       }
     }
   }


### PR DESCRIPTION
Added a MemoryOptimized attribute to allow for the creation of In-Memory OLTP tables in SQL Server 2014+. This required the the addition of a 2014 and 2016 provider as this syntax wasn't available in 2012.

With this addition, developers will be able to use SQL Server as both a data store and a cache store as illustrated in this article: [https://blogs.msdn.microsoft.com/sqlcat/2016/10/26/how-bwin-is-using-sql-server-2016-in-memory-oltp-to-achieve-unprecedented-performance-and-scale/](https://blogs.msdn.microsoft.com/sqlcat/2016/10/26/how-bwin-is-using-sql-server-2016-in-memory-oltp-to-achieve-unprecedented-performance-and-scale/).