### PR TITLE
Resolved continued issue #474

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerGeographyTypeConverter.cs
+++ b/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerGeographyTypeConverter.cs
@@ -9,10 +9,7 @@ namespace ServiceStack.OrmLite.SqlServer.Converters
     /// </summary>
     public class SqlServerGeographyTypeConverter : SqlServerSpatialTypeConverter
     {
-        public override string ColumnDefinition
-        {
-            get { return "geography"; }
-        }
+        public override string ColumnDefinition => "GEOGRAPHY";
 
         public override object FromDbValue(Type fieldType, object value)
         {

--- a/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerGeometryTypeConverter.cs
+++ b/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerGeometryTypeConverter.cs
@@ -9,10 +9,7 @@ namespace ServiceStack.OrmLite.SqlServer.Converters
     /// </summary>
     public class SqlServerGeometryTypeConverter : SqlServerSpatialTypeConverter
     {
-        public override string ColumnDefinition
-        {
-            get { return "geometry"; }
-        }
+        public override string ColumnDefinition => "GEOMETRY";
 
         public override object FromDbValue(Type fieldType, object value)
         {

--- a/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerHierarchyIdTypeConverter.cs
+++ b/src/ServiceStack.OrmLite.SqlServer.Converters/SqlServerHierarchyIdTypeConverter.cs
@@ -14,15 +14,9 @@ namespace ServiceStack.OrmLite.SqlServer.Converters
         public SqlServerHierarchyIdTypeConverter() : base()
         { }
 
-        public override string ColumnDefinition
-        {
-            get { return "hierarchyid"; }
-        }
+        public override string ColumnDefinition => "HIERARCHYID";
 
-        public override DbType DbType
-        {
-            get { return DbType.Object; }
-        }
+        public override DbType DbType => DbType.Object;
 
         public override void InitDbParam(IDbDataParameter p, Type fieldType)
         {

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServer2012OrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServer2012OrmLiteDialectProvider.cs
@@ -1,12 +1,10 @@
-﻿using System.Data;
-using System.Text;
-using ServiceStack.Text;
+﻿using ServiceStack.Text;
 
 namespace ServiceStack.OrmLite.SqlServer
 {
     public class SqlServer2012OrmLiteDialectProvider : SqlServerOrmLiteDialectProvider
     {
-        public static new SqlServer2012OrmLiteDialectProvider Instance = new SqlServer2012OrmLiteDialectProvider();
+        public new static SqlServer2012OrmLiteDialectProvider Instance = new SqlServer2012OrmLiteDialectProvider();
 
         public override string ToSelectStatement(ModelDefinition modelDef,
             string selectExpression,
@@ -40,24 +38,6 @@ namespace ServiceStack.OrmLite.SqlServer
             }
 
             return StringBuilderCache.ReturnAndFree(sb);
-        }
-
-        public override void AppendFieldCondition(StringBuilder sqlFilter, FieldDefinition fieldDef, IDbCommand cmd)
-        {
-            if (fieldDef.FieldType.Name == "SqlGeography")
-            {
-                sqlFilter
-                    .Append(GetQuotedColumnName(fieldDef.FieldName))
-                    .Append(".STEquals(")
-                    .Append(this.GetParam(SanitizeFieldNameForParamName(fieldDef.FieldName)))
-                    .Append(") = 1");
-
-                AddParameter(cmd, fieldDef);
-            }
-            else
-            {
-                base.AppendFieldCondition(sqlFilter, fieldDef, cmd);
-            }
         }
     }
 }

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServer2016OrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServer2016OrmLiteDialectProvider.cs
@@ -7,6 +7,6 @@ namespace ServiceStack.OrmLite.SqlServer
 {
     public class SqlServer2016OrmLiteDialectProvider : SqlServer2014OrmLiteDialectProvider
     {
-        public static new SqlServer2016OrmLiteDialectProvider Instance = new SqlServer2016OrmLiteDialectProvider();
+        public new static SqlServer2016OrmLiteDialectProvider Instance = new SqlServer2016OrmLiteDialectProvider();
     }
 }

--- a/src/ServiceStack.OrmLite.SqlServerTests/Converters/SpatialsTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/Converters/SpatialsTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Microsoft.SqlServer.Types;
 using NUnit.Framework;
 using ServiceStack.DataAnnotations;
@@ -12,81 +13,104 @@ namespace ServiceStack.OrmLite.SqlServerTests.Converters
         [Test]
         public void Can_insert_and_retrieve_SqlGeography()
         {
-            using (var db = OpenDbConnection())
-            {
-                db.DropAndCreateTable<GeoTest>();
+            Db.DropAndCreateTable<GeoTest>();
 
-                // Statue of Liberty
-                var geo = SqlGeography.Point(40.6898329, -74.0452177, 4326);
+            // Statue of Liberty
+            var geo = SqlGeography.Point(40.6898329, -74.0452177, 4326);
 
-                db.Insert(new GeoTest {Id = 1, Location = geo, NullLocation = SqlGeography.Null});
+            Db.Insert(new GeoTest {Id = 1, Location = geo, NullLocation = SqlGeography.Null});
 
-                var result = db.SingleById<GeoTest>(1);
+            var result = Db.SingleById<GeoTest>(1);
 
-                Assert.AreEqual(geo.Lat, result.Location.Lat);
-                Assert.AreEqual(geo.Long, result.Location.Long);
-                Assert.AreEqual(geo.STSrid, result.Location.STSrid);
+            Assert.AreEqual(geo.Lat, result.Location.Lat);
+            Assert.AreEqual(geo.Long, result.Location.Long);
+            Assert.AreEqual(geo.STSrid, result.Location.STSrid);
 
-                // Converter always resolves to null even when Null property inserted into database
-                Assert.AreEqual(null, result.NullLocation);
+            // Converter always resolves to null even when Null property inserted into database
+            Assert.AreEqual(null, result.NullLocation);
 
-                result.PrintDump();
-            }
+            result.PrintDump();
         }
 
         [Test]
         public void Can_insert_and_retrieve_SqlGeometry()
         {
-            using (var db = OpenDbConnection())
-            {
-                db.DropAndCreateTable<GeoTest>();
+            Db.DropAndCreateTable<GeoTest>();
 
-                // A simple line from (0,0) to (4,4)  Length = SQRT(2 * 4^2)
-                var wkt = new System.Data.SqlTypes.SqlChars("LINESTRING(0 0, 4 4)".ToCharArray());
-                var shape = SqlGeometry.STLineFromText(wkt, 0);
+            // A simple line from (0,0) to (4,4)  Length = SQRT(2 * 4^2)
+            var wkt = new System.Data.SqlTypes.SqlChars("LINESTRING(0 0, 4 4)".ToCharArray());
+            var shape = SqlGeometry.STLineFromText(wkt, 0);
 
-                db.Insert(new GeoTest { Id = 1, Shape = shape});
+            Db.Insert(new GeoTest { Id = 1, Shape = shape});
 
-                var result = db.SingleById<GeoTest>(1).Shape;
+            var result = Db.SingleById<GeoTest>(1).Shape;
 
-                var lengths = db.Column<double>("select Shape.STLength() AS Length from GeoTest");
+            var lengths = Db.Column<double>("select Shape.STLength() AS Length from GeoTest");
 
-                Assert.AreEqual((double) result.STLength(), lengths.First());
+            Assert.AreEqual((double) result.STLength(), lengths.First());
 
-                Assert.AreEqual(shape.STStartPoint().STX, result.STStartPoint().STX);
-                Assert.AreEqual(shape.STStartPoint().STY, result.STStartPoint().STY);
+            Assert.AreEqual(shape.STStartPoint().STX, result.STStartPoint().STX);
+            Assert.AreEqual(shape.STStartPoint().STY, result.STStartPoint().STY);
 
-                Assert.AreEqual(shape.STEndPoint().STX, result.STEndPoint().STX);
-                Assert.AreEqual(shape.STEndPoint().STY, result.STEndPoint().STY);
+            Assert.AreEqual(shape.STEndPoint().STX, result.STEndPoint().STX);
+            Assert.AreEqual(shape.STEndPoint().STY, result.STEndPoint().STY);
 
-                Assert.AreEqual(2, (int) result.STNumPoints());
+            Assert.AreEqual(2, (int) result.STNumPoints());
 
-                result.PrintDump();
-            }
+            result.PrintDump();
         }
 
         [Test]
         public void Can_insert_SqlGeography_and_SqlGeometry()
         {
-            using (var db = OpenDbConnection())
+            Db.DropAndCreateTable<GeoTest>();
+
+            // Statue of Liberty
+            var geo = SqlGeography.Point(40.6898329, -74.0452177, 4326);
+
+            // A simple line from (0,0) to (4,4)  Length = SQRT(2 * 4^2)
+            var wkt = new System.Data.SqlTypes.SqlChars("LINESTRING(0 0, 4 4)".ToCharArray());
+            var shape = SqlGeometry.STLineFromText(wkt, 0);
+
+            Db.Insert(new GeoTest { Id = 1, Location = geo, Shape = shape });
+
+            shape = Db.SingleById<GeoTest>(1).Shape;
+
+            Assert.That(shape, Is.Not.Null);
+
+            new { shape.STEndPoint().STX, shape.STEndPoint().STY }.PrintDump();
+        }
+
+        [Test]
+        public void Can_insert_and_update_SqlGeography()
+        {
+            Db.DropAndCreateTable<ModelWithSqlGeography>();
+
+            var wkt = "POINT(38.028495788574205 55.895460650576936)";
+            var geo = SqlGeography.STGeomFromText(new System.Data.SqlTypes.SqlChars(wkt), 4326);
+
+            var obj = new ModelWithSqlGeography { Name = "Test", Created = DateTime.UtcNow, Geo = geo };
+
+            var id = (int)Db.Insert(obj, selectIdentity: true);
+            obj.ID = id;
+
+            try
             {
-                db.DropAndCreateTable<GeoTest>();
-
-                // Statue of Liberty
-                var geo = SqlGeography.Point(40.6898329, -74.0452177, 4326);
-
-                // A simple line from (0,0) to (4,4)  Length = SQRT(2 * 4^2)
-                var wkt = new System.Data.SqlTypes.SqlChars("LINESTRING(0 0, 4 4)".ToCharArray());
-                var shape = SqlGeometry.STLineFromText(wkt, 0);
-
-                db.Insert(new GeoTest { Id = 1, Location = geo, Shape = shape });
-
-                shape = db.SingleById<GeoTest>(1).Shape;
-
-                Assert.That(shape, Is.Not.Null);
-
-                new { shape.STEndPoint().STX, shape.STEndPoint().STY }.PrintDump();
+                // Update of POCO with SqlGeography proprety should work
+                obj.Name = "Test - modified";
+                obj.Edited = DateTime.UtcNow;
+                Db.Update(obj);                    
             }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.ToString());
+            }
+            finally
+            {
+                // GetLastSql shouldn't return null after exception
+                var lastSql = Db.GetLastSql();
+                Assert.IsNotNull(lastSql);
+            }                
         }
     }
 
@@ -99,5 +123,16 @@ namespace ServiceStack.OrmLite.SqlServerTests.Converters
         public SqlGeography NullLocation { get; set; }
 
         public SqlGeometry Shape { get; set; }
+    }
+
+    public class ModelWithSqlGeography
+    {
+        [AutoIncrement]
+        public int ID { get; set; }
+        [StringLength(255)]
+        public string Name { get; set; }
+        public DateTime Created { get; set; }
+        public DateTime? Edited { get; set; }
+        public SqlGeography Geo { get; set; }
     }
 }


### PR DESCRIPTION
Fixed issue with the updating of SqlGeography types with SqlServer 2012 dialect provider. No longer needs a AppendCustomCondition override as converter handles this appropriately. Added unit test and cleaned up a few other small items.