### PR TITLE
Fixed regression caused by last commit and fixed root issue.

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServerTests/Converters/ConvertersOrmLiteTestBase.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/Converters/ConvertersOrmLiteTestBase.cs
@@ -40,10 +40,12 @@ namespace ServiceStack.OrmLite.SqlServerTests.Converters
             Console.WriteLine(text);
         }
 
-        public virtual IDbConnection OpenDbConnection(string connString = null)
+        public virtual IDbConnection OpenDbConnection(string connString = null, IOrmLiteDialectProvider dialectProvider = null)
         {
+            dialectProvider = dialectProvider ?? OrmLiteConfig.DialectProvider;
             connString = connString ?? ConnectionString;
-            return connString.OpenDbConnection();
+
+            return new OrmLiteConnectionFactory(connString, dialectProvider).OpenDbConnection();
         }
     }
 }

--- a/src/ServiceStack.OrmLite.SqlServerTests/Expressions/ExpressionsTestBase.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/Expressions/ExpressionsTestBase.cs
@@ -16,12 +16,14 @@ namespace ServiceStack.OrmLite.SqlServerTests.Expressions
         //Avoid painful refactor to change all tests to use a using pattern
         private IDbConnection db;
 
-        public override IDbConnection OpenDbConnection(string connString = null)
+        public override IDbConnection OpenDbConnection(string connString = null, IOrmLiteDialectProvider dialectProvider = null)
         {
+            dialectProvider = dialectProvider ?? OrmLiteConfig.DialectProvider;
+
             if (db != null && db.State != ConnectionState.Open)
                 db = null;
 
-            return db ?? (db = base.OpenDbConnection(connString));
+            return db ?? (db = base.OpenDbConnection(connString, dialectProvider));
         }
 
         [TearDown]

--- a/src/ServiceStack.OrmLite.SqlServerTests/Issues/DeleteWithGeoTypesIssue.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/Issues/DeleteWithGeoTypesIssue.cs
@@ -34,7 +34,7 @@ namespace ServiceStack.OrmLite.SqlServerTests.Issues
                 var bar = db.Single<ModelWithGeo>(x => x.Name == "Bar");
                 db.SqlScalar<int>(
                     "DELETE FROM ModelWithGeo WHERE Id=@Id AND Location.STEquals(@Location) = 1", 
-                    new { bar.Id, bar.Name, bar.Location });
+                    new { Id = bar.Id, Location = bar.Location });
 
                 Assert.That(db.Select<ModelWithGeo>().Count, Is.EqualTo(2));
 

--- a/src/ServiceStack.OrmLite.SqlServerTests/OrmLiteTestBase.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/OrmLiteTestBase.cs
@@ -24,10 +24,11 @@ namespace ServiceStack.OrmLite.SqlServerTests
             Console.WriteLine(text);
         }
 
-        public virtual IDbConnection OpenDbConnection(string connString = null)
+        public virtual IDbConnection OpenDbConnection(string connString = null, IOrmLiteDialectProvider dialectProvider = null)
         {
+            dialectProvider = dialectProvider ?? OrmLiteConfig.DialectProvider;
             connString = connString ?? ConnectionString;
-            return connString.OpenDbConnection();
+            return new OrmLiteConnectionFactory(connString, dialectProvider).OpenDbConnection();
         }
     }
 }

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -764,7 +764,12 @@ namespace ServiceStack.OrmLite
                     if (sql.Length > 0)
                         sql.Append(", ");
 
-                    AppendFieldCondition(sql, fieldDef, cmd);
+                    sql
+                        .Append(GetQuotedColumnName(fieldDef.FieldName))
+                        .Append("=")
+                        .Append(this.GetParam(SanitizeFieldNameForParamName(fieldDef.FieldName)));
+
+                    AddParameter(cmd, fieldDef);
                 }
                 catch (Exception ex)
                 {
@@ -780,6 +785,13 @@ namespace ServiceStack.OrmLite
             }
 
             return hadRowVesion;
+        }
+
+        public virtual void AppendNullFieldCondition(StringBuilder sqlFilter, FieldDefinition fieldDef)
+        {
+            sqlFilter
+                .Append(GetQuotedColumnName(fieldDef.FieldName))
+                .Append(" IS NULL");
         }
 
         public virtual void AppendFieldCondition(StringBuilder sqlFilter, FieldDefinition fieldDef, IDbCommand cmd)
@@ -827,9 +839,7 @@ namespace ServiceStack.OrmLite
                     }
                     else
                     {
-                        sqlFilter
-                            .Append(GetQuotedColumnName(fieldDef.FieldName))
-                            .Append(" IS NULL");
+                        AppendNullFieldCondition(sqlFilter, fieldDef);
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION
1. Fixed previously existing issue in construction of Update command where AppendFieldCondition was being called instead of Field = Parameter. (line 767 in OrmLiteDialectProviderBase.cs)
2. Added a new virtual AppendNullFieldCondition method to OrmLiteDialectProviderBase.cs to handle Spatial null conditions (uses a boolean property and not the IS NULL syntax).
3. Added AppendFieldCondition and AppendNullFieldCondition overrides to SqlServer2012OrmLiteDialectProvider.
4. Made dialect provider an optional parameter in the OpenDbConnection method on the SqlServerTests.