### PR TITLE
Update to 3.1.8 as fails to find DLL at runtime.

### DIFF
--- a/NuGet.Core/ServiceStack.OrmLite.PostgreSQL.Core/ServiceStack.OrmLite.PostgreSQL.Core.nuspec
+++ b/NuGet.Core/ServiceStack.OrmLite.PostgreSQL.Core/ServiceStack.OrmLite.PostgreSQL.Core.nuspec
@@ -19,7 +19,7 @@
     <copyright>Copyright 2016 Service Stack</copyright>
     <dependencies>
       <group targetFramework=".NETStandard1.3">
-        <dependency id="Npgsql" version="[3.1.7, )" />
+        <dependency id="Npgsql" version="[3.1.8, )" />
         <dependency id="ServiceStack.Interfaces.Core" version="[1.0.0, )" />
         <dependency id="ServiceStack.Text.Core" version="[1.0.0, )" />
         <dependency id="ServiceStack.Common.Core" version="[1.0.0, )" />


### PR DESCRIPTION
Feel free to ignore PR if incorrect (still find my way around .NET Core).

When trying to use the `ServiceStack.OrmLite.PostgreSQL.Core` package, it fails at runtime due to not being able to find `Npgsql 3.1.8`. This happens for both local Windows dev and running on linux.

If I add the `Npgsql 3.1.8` specifically, it works fine. Possibly cause it's depending on wrong version in nuspec? 

https://github.com/ServiceStack/ServiceStack.OrmLite/blob/master/src/ServiceStack.OrmLite.PostgreSQL/project.json#L20

Or is there another way to get the downstream dependencies to be added to the `project.json`? (this could just be a tooling issue as well I guess).