### PR TITLE
Add support for [Default(OnUpdate=true)]

### DIFF
--- a/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
@@ -124,7 +124,7 @@ namespace ServiceStack.OrmLite.PostgreSQL
             return new SelectItemExpression(this, "xmin", field.FieldName);
         }
 
-        public override void AppendFieldCondition(StringBuilder sqlFilter, FieldDefinition fieldDef, IDbCommand cmd)
+        public override IDataParameter AppendFieldCondition(StringBuilder sqlFilter, FieldDefinition fieldDef, IDbCommand cmd)
         {
             var columnName = fieldDef.IsRowVersion
                 ? RowVersionFieldComparer
@@ -135,7 +135,7 @@ namespace ServiceStack.OrmLite.PostgreSQL
                 .Append("=")
                 .Append(this.GetParam(SanitizeFieldNameForParamName(fieldDef.FieldName)));
 
-            AddParameter(cmd, fieldDef);
+            return AddParameter(cmd, fieldDef);
         }
 
         public override string GetQuotedValue(string paramValue)

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServer2012OrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServer2012OrmLiteDialectProvider.cs
@@ -42,11 +42,11 @@ namespace ServiceStack.OrmLite.SqlServer
             return StringBuilderCache.ReturnAndFree(sb);
         }
 
-        public override void AppendFieldCondition(StringBuilder sqlFilter, FieldDefinition fieldDef, IDbCommand cmd)
+        public override IDataParameter AppendFieldCondition(StringBuilder sqlFilter, FieldDefinition fieldDef, IDbCommand cmd)
         {
             if (!isSpatialField(fieldDef))
             {
-                base.AppendFieldCondition(sqlFilter, fieldDef, cmd);
+                return base.AppendFieldCondition(sqlFilter, fieldDef, cmd);
             }
             else 
             {
@@ -56,7 +56,7 @@ namespace ServiceStack.OrmLite.SqlServer
                     .Append(this.GetParam(SanitizeFieldNameForParamName(fieldDef.FieldName)))
                     .Append(") = 1");
  
-                AddParameter(cmd, fieldDef);
+                return AddParameter(cmd, fieldDef);
             }
         }
 

--- a/src/ServiceStack.OrmLite/Expressions/WriteExpressionCommandExtensions.cs
+++ b/src/ServiceStack.OrmLite/Expressions/WriteExpressionCommandExtensions.cs
@@ -138,10 +138,13 @@ namespace ServiceStack.OrmLite
             var modelDef = typeof(T).GetModelDefinition();
             var fields = modelDef.FieldDefinitionsArray;
 
+            var updateFields = new List<FieldDefinition>();
             foreach (var setField in updateOnly.GetType().GetPublicProperties())
             {
                 var fieldDef = fields.FirstOrDefault(x => string.Equals(x.Name, setField.Name, StringComparison.OrdinalIgnoreCase));
-                if (fieldDef == null || fieldDef.ShouldSkipUpdate()) continue;
+                if (fieldDef == null) continue;
+                updateFields.Add(fieldDef);
+                if (fieldDef.ShouldSkipUpdate()) continue;
 
                 if (sql.Length > 0)
                     sql.Append(", ");
@@ -152,6 +155,8 @@ namespace ServiceStack.OrmLite
                     .Append("=")
                     .Append(dialectProvider.AddParam(dbCmd, value, fieldDef).ParameterName);
             }
+
+            dialectProvider.AddDefaultUpdateFields(dbCmd, modelDef, updateFields, sql, "");
 
             dbCmd.CommandText = $"UPDATE {dialectProvider.GetQuotedTableName(modelDef)} " +
                                 $"SET {StringBuilderCache.ReturnAndFree(sql)} {whereSql}";

--- a/src/ServiceStack.OrmLite/FieldDefinition.cs
+++ b/src/ServiceStack.OrmLite/FieldDefinition.cs
@@ -54,6 +54,8 @@ namespace ServiceStack.OrmLite
 
         public string DefaultValue { get; set; }
 
+        public bool UseDefaultOnUpdate { get; set; }
+
         public ForeignKeyConstraint ForeignKey { get; set; }
 
         public PropertyGetterDelegate GetValueFn { get; set; }
@@ -147,6 +149,7 @@ namespace ServiceStack.OrmLite
                 FieldLength = FieldLength,
                 Scale = Scale,
                 DefaultValue = DefaultValue,
+                UseDefaultOnUpdate = UseDefaultOnUpdate,
                 ForeignKey = ForeignKey,
                 GetValueFn = GetValueFn,
                 SetValueFn = SetValueFn,

--- a/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq.Expressions;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using ServiceStack.Text;
@@ -97,13 +98,15 @@ namespace ServiceStack.OrmLite
 
         void PrepareParameterizedInsertStatement<T>(IDbCommand cmd, ICollection<string> insertFields = null);
 
-        bool PrepareParameterizedUpdateStatement<T>(IDbCommand cmd, ICollection<string> updateFields = null);
+        ICollection<IDataParameter> PrepareParameterizedUpdateStatement<T>(IDbCommand cmd, ref bool hadRowVersion);
 
         bool PrepareParameterizedDeleteStatement<T>(IDbCommand cmd, IDictionary<string, object> delteFieldValues);
 
         void PrepareStoredProcedureStatement<T>(IDbCommand cmd, T obj);
 
         void SetParameterValues<T>(IDbCommand dbCmd, object obj);
+
+        void SetParameterValues<T>(IDbCommand dbCmd, ICollection<IDataParameter> parameters, object obj);
 
         void SetParameter(FieldDefinition fieldDef, IDbDataParameter p);
 
@@ -117,6 +120,8 @@ namespace ServiceStack.OrmLite
         void PrepareUpdateRowStatement<T>(IDbCommand dbCmd, Dictionary<string, object> args, string sqlFilter);
 
         void PrepareUpdateRowAddStatement<T>(IDbCommand dbCmd, Dictionary<string, object> args, string sqlFilter);
+
+        void AddDefaultUpdateFields(IDbCommand dbCmd, ModelDefinition modelDef, ICollection<FieldDefinition> updateFields, StringBuilder sql, string errorMessage);
 
         void PrepareInsertRowStatement<T>(IDbCommand dbCmd, Dictionary<string, object> args);
 

--- a/src/ServiceStack.OrmLite/ModelDefinition.cs
+++ b/src/ServiceStack.OrmLite/ModelDefinition.cs
@@ -24,6 +24,7 @@ namespace ServiceStack.OrmLite
             this.FieldDefinitions = new List<FieldDefinition>();
             this.IgnoredFieldDefinitions = new List<FieldDefinition>();
             this.CompositeIndexes = new List<CompositeIndexAttribute>();
+            this.UpdateDefaultFieldDefinitions = new List<FieldDefinition>();
         }
 
         public const string RowVersionName = "RowVersion";
@@ -76,6 +77,8 @@ namespace ServiceStack.OrmLite
         public FieldDefinition[] IgnoredFieldDefinitionsArray { get; private set; }
 
         public FieldDefinition[] AllFieldDefinitionsArray { get; private set; }
+
+        public List<FieldDefinition> UpdateDefaultFieldDefinitions { get; private set; }
 
         private readonly object fieldDefLock = new object();
         private Dictionary<string, FieldDefinition> fieldDefinitionMap;

--- a/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
@@ -121,6 +121,7 @@ namespace ServiceStack.OrmLite
                 var stringLengthAttr = propertyInfo.CalculateStringLength(decimalAttribute);
 
                 var defaultValueAttr = propertyInfo.FirstAttribute<DefaultAttribute>();
+                var useDefaultOnUpdate = defaultValueAttr?.OnUpdate ?? false;
 
                 var referencesAttr = propertyInfo.FirstAttribute<ReferencesAttribute>();
                 var referenceAttr = propertyInfo.FirstAttribute<ReferenceAttribute>();
@@ -147,6 +148,7 @@ namespace ServiceStack.OrmLite
                     IsRowVersion = isRowVersion,
                     FieldLength = stringLengthAttr?.MaximumLength,
                     DefaultValue = defaultValueAttr?.DefaultValue,
+                    UseDefaultOnUpdate = useDefaultOnUpdate,
                     ForeignKey = fkAttr == null
                         ? referencesAttr != null ? new ForeignKeyConstraint(referencesAttr.Type) : null
                         : new ForeignKeyConstraint(fkAttr.Type, fkAttr.OnDelete, fkAttr.OnUpdate, fkAttr.ForeignKeyName),
@@ -169,6 +171,8 @@ namespace ServiceStack.OrmLite
                     modelDef.IgnoredFieldDefinitions.Add(fieldDefinition);
                 else
                     modelDef.FieldDefinitions.Add(fieldDefinition);
+                if (useDefaultOnUpdate)
+                    modelDef.UpdateDefaultFieldDefinitions.Add(fieldDefinition);
 
                 if (isRowVersion)
                     modelDef.RowVersion = fieldDefinition;

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -17,6 +17,7 @@ using System.Data.SqlClient;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using ServiceStack.DataAnnotations;
@@ -716,12 +717,13 @@ namespace ServiceStack.OrmLite
         {
             dbCmd.Parameters.Clear();
             var dialectProvider = dbCmd.GetDialectProvider();
-            dialectProvider.PrepareParameterizedUpdateStatement<T>(dbCmd);
+            var hadRowVersion = false;
+            var parameters = dialectProvider.PrepareParameterizedUpdateStatement<T>(dbCmd, ref hadRowVersion);
 
             if (string.IsNullOrEmpty(dbCmd.CommandText))
                 return null;
 
-            dialectProvider.SetParameterValues<T>(dbCmd, item);
+            dialectProvider.SetParameterValues<T>(dbCmd, parameters, item);
 
             return MergeParamsIntoSql(dbCmd.CommandText, ToArray(dbCmd.Parameters));
         }
@@ -748,14 +750,13 @@ namespace ServiceStack.OrmLite
             return sql;
         }
 
-        public virtual bool PrepareParameterizedUpdateStatement<T>(IDbCommand cmd, ICollection<string> updateFields = null)
+        public virtual ICollection<IDataParameter> PrepareParameterizedUpdateStatement<T>(IDbCommand cmd, ref bool hadRowVersion)
         {
             var sql = StringBuilderCache.Allocate();
             var sqlFilter = StringBuilderCacheAlt.Allocate();
             var modelDef = typeof(T).GetModelDefinition();
-            var hadRowVesion = false;
-            var updateAllFields = updateFields == null || updateFields.Count == 0;
 
+            var parameters = new List<IDataParameter>();
             cmd.Parameters.Clear();
 
             foreach (var fieldDef in modelDef.FieldDefinitions)
@@ -765,31 +766,32 @@ namespace ServiceStack.OrmLite
 
                 try
                 {
-                    if ((fieldDef.IsPrimaryKey || fieldDef.IsRowVersion) && updateAllFields)
+                    if (fieldDef.IsPrimaryKey || fieldDef.IsRowVersion)
                     {
                         if (sqlFilter.Length > 0)
                             sqlFilter.Append(" AND ");
 
-                        AppendFieldCondition(sqlFilter, fieldDef, cmd);
+                        parameters.Add(AppendFieldCondition(sqlFilter, fieldDef, cmd));
 
                         if (fieldDef.IsRowVersion)
-                            hadRowVesion = true;
+                            hadRowVersion = true;
 
                         continue;
                     }
 
-                    if (!updateAllFields && !updateFields.Contains(fieldDef.Name, StringComparer.OrdinalIgnoreCase))
-                        continue;
+                    if (fieldDef.UseDefaultOnUpdate)
+                    {
+                        AddDefaultUpdateField(cmd, fieldDef, sql);
+                    }
+                    else
+                    {
+                        if (sql.Length > 0)
+                            sql.Append(", ");
 
-                    if (sql.Length > 0)
-                        sql.Append(", ");
-
-                    sql
-                        .Append(GetQuotedColumnName(fieldDef.FieldName))
-                        .Append("=")
-                        .Append(this.GetParam(SanitizeFieldNameForParamName(fieldDef.FieldName)));
-
-                    AddParameter(cmd, fieldDef);
+                        sql.Append(GetQuotedColumnName(fieldDef.FieldName)).Append("=")
+                           .Append(this.GetParam(SanitizeFieldNameForParamName(fieldDef.FieldName)));
+                        parameters.Add(AddParameter(cmd, fieldDef));
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -804,7 +806,7 @@ namespace ServiceStack.OrmLite
                                   $"SET {StringBuilderCache.ReturnAndFree(sql)} {(strFilter.Length > 0 ? "WHERE " + strFilter : "")}";
             }
 
-            return hadRowVesion;
+            return parameters;
         }
 
         public virtual void AppendNullFieldCondition(StringBuilder sqlFilter, FieldDefinition fieldDef)
@@ -814,14 +816,14 @@ namespace ServiceStack.OrmLite
                 .Append(" IS NULL");
         }
 
-        public virtual void AppendFieldCondition(StringBuilder sqlFilter, FieldDefinition fieldDef, IDbCommand cmd)
+        public virtual IDataParameter AppendFieldCondition(StringBuilder sqlFilter, FieldDefinition fieldDef, IDbCommand cmd)
         {
             sqlFilter
                 .Append(GetQuotedColumnName(fieldDef.FieldName))
                 .Append("=")
                 .Append(this.GetParam(SanitizeFieldNameForParamName(fieldDef.FieldName)));
 
-            AddParameter(cmd, fieldDef);
+            return AddParameter(cmd, fieldDef);
         }
 
         public virtual bool PrepareParameterizedDeleteStatement<T>(IDbCommand cmd, IDictionary<string, object> deleteFields)
@@ -900,24 +902,40 @@ namespace ServiceStack.OrmLite
 
             foreach (IDataParameter p in dbCmd.Parameters)
             {
-                FieldDefinition fieldDef;
-                var fieldName = this.ToFieldName(p.ParameterName);
-                fieldMap.TryGetValue(fieldName, out fieldDef);
+                SetParameterValue<T>(dbCmd, modelDef, fieldMap, p, obj);
+            }
+        }
 
-                if (fieldDef == null)
+        public virtual void SetParameterValues<T>(IDbCommand dbCmd, ICollection<IDataParameter> parameters, object obj)
+        {
+            var modelDef = GetModel(typeof(T));
+            var fieldMap = GetFieldDefinitionMap(modelDef);
+
+            foreach (var p in parameters)
+            {
+                SetParameterValue<T>(dbCmd, modelDef, fieldMap, p, obj);
+            }
+        }
+
+        protected virtual void SetParameterValue<T>(IDbCommand dbCmd, ModelDefinition modelDef, Dictionary<string, FieldDefinition> fieldMap, IDataParameter p, object obj)
+        {
+            FieldDefinition fieldDef;
+            var fieldName = this.ToFieldName(p.ParameterName);
+            fieldMap.TryGetValue(fieldName, out fieldDef);
+
+            if (fieldDef == null)
+            {
+                if (OrmLiteConfig.ParamNameFilter != null)
                 {
-                    if (OrmLiteConfig.ParamNameFilter != null)
-                    {
-                        fieldDef = modelDef.GetFieldDefinition(name => 
-                            string.Equals(OrmLiteConfig.ParamNameFilter(name), fieldName, StringComparison.OrdinalIgnoreCase));
-                    }
-
-                    if (fieldDef == null)
-                        throw new ArgumentException("Field Definition '{0}' was not found".Fmt(fieldName));
+                    fieldDef = modelDef.GetFieldDefinition(name =>
+                        string.Equals(OrmLiteConfig.ParamNameFilter(name), fieldName, StringComparison.OrdinalIgnoreCase));
                 }
 
-                SetParameterValue<T>(fieldDef, p, obj);
+                if (fieldDef == null)
+                    throw new ArgumentException("Field Definition '{0}' was not found".Fmt(fieldName));
             }
+
+            SetParameterValue<T>(fieldDef, p, obj);
         }
 
         public Dictionary<string, FieldDefinition> GetFieldDefinitionMap(ModelDefinition modelDef)
@@ -995,7 +1013,7 @@ namespace ServiceStack.OrmLite
                 return DBNull.Value;
 
             var unquotedVal = GetQuotedValue(value, fieldDef.FieldType)
-                .TrimStart('\'').TrimEnd('\''); ;
+                .TrimStart('\'').TrimEnd('\'');
 
             if (string.IsNullOrEmpty(unquotedVal))
                 return DBNull.Value;
@@ -1021,10 +1039,11 @@ namespace ServiceStack.OrmLite
 
         public virtual void PrepareUpdateRowStatement(IDbCommand dbCmd, object objWithProperties, ICollection<string> updateFields = null)
         {
+            if (updateFields == null) updateFields = new List<string>();
             var sql = StringBuilderCache.Allocate();
             var sqlFilter = StringBuilderCacheAlt.Allocate();
             var modelDef = objWithProperties.GetType().GetModelDefinition();
-            var updateAllFields = updateFields == null || updateFields.Count == 0;
+            var updateAllFields = updateFields.Count == 0;
 
             foreach (var fieldDef in modelDef.FieldDefinitions)
             {
@@ -1046,16 +1065,18 @@ namespace ServiceStack.OrmLite
                         continue;
                     }
 
-                    if (!updateAllFields && !updateFields.Contains(fieldDef.Name, StringComparer.OrdinalIgnoreCase) || fieldDef.AutoIncrement)
-                        continue;
+                    if (fieldDef.UseDefaultOnUpdate && !updateFields.Contains(fieldDef.Name, StringComparer.OrdinalIgnoreCase))
+                    {
+                        AddDefaultUpdateField(dbCmd, fieldDef, sql);
+                    }
+                    else if ((updateAllFields || updateFields.Contains(fieldDef.Name, StringComparer.OrdinalIgnoreCase)) && !fieldDef.AutoIncrement)
+                    {
+                        if (sql.Length > 0)
+                            sql.Append(", ");
 
-                    if (sql.Length > 0)
-                        sql.Append(", ");
-
-                    sql
-                        .Append(GetQuotedColumnName(fieldDef.FieldName))
-                        .Append("=")
-                        .Append(this.AddParam(dbCmd, fieldDef.GetValue(objWithProperties), fieldDef).ParameterName);
+                        sql.Append(GetQuotedColumnName(fieldDef.FieldName)).Append("=")
+                           .Append(this.AddParam(dbCmd, fieldDef.GetValue(objWithProperties), fieldDef).ParameterName);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -1076,9 +1097,11 @@ namespace ServiceStack.OrmLite
             var sql = StringBuilderCache.Allocate();
             var modelDef = typeof(T).GetModelDefinition();
 
+            var updateFields = new List<FieldDefinition>();
             foreach (var entry in args)
             {
                 var fieldDef = modelDef.GetFieldDefinition(entry.Key);
+                updateFields.Add(fieldDef);
                 if (fieldDef.ShouldSkipUpdate() || fieldDef.AutoIncrement)
                     continue;
 
@@ -1100,6 +1123,8 @@ namespace ServiceStack.OrmLite
                 }
             }
 
+            AddDefaultUpdateFields(dbCmd, modelDef, updateFields, sql, "ERROR in PrepareUpdateRowStatement(cmd,args): ");
+
             dbCmd.CommandText = $"UPDATE {GetQuotedTableName(modelDef)} " +
                                 $"SET {StringBuilderCache.ReturnAndFree(sql)}{(string.IsNullOrEmpty(sqlFilter) ? "" : " ")}{sqlFilter}";
 
@@ -1107,14 +1132,50 @@ namespace ServiceStack.OrmLite
                 throw new Exception("No valid update properties provided (e.g. () => new Person { Age = 27 }): " + dbCmd.CommandText);
         }
 
+        public virtual void AddDefaultUpdateFields(IDbCommand dbCmd, ModelDefinition modelDef, ICollection<FieldDefinition> updateFields, StringBuilder sql, string errorMessage)
+        {
+            foreach (var fieldDef in modelDef.UpdateDefaultFieldDefinitions.Where(def => !updateFields.Contains(def)))
+            {
+                try
+                {
+                    AddDefaultUpdateField(dbCmd, fieldDef, sql);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(errorMessage + ex.Message, ex);
+                }
+            }
+        }
+
+        public void AddDefaultUpdateField(IDbCommand dbCmd, FieldDefinition fieldDef, StringBuilder sql)
+        {
+            if (sql.Length > 0)
+                sql.Append(", ");
+
+            sql.Append(GetQuotedColumnName(fieldDef.FieldName)).Append("=");
+            var defaultValue = GetDefaultValue(fieldDef);
+            if (fieldDef.DefaultValue.StartsWith("{") || fieldDef.DefaultValue.StartsWith("'"))
+            {
+                sql.Append(defaultValue);
+            }
+            else
+            {
+                sql.Append(this.GetParam(SanitizeFieldNameForParamName(fieldDef.FieldName)));
+                var parameter = AddParameter(dbCmd, fieldDef);
+                parameter.Value = defaultValue;
+            }
+        }
+
         public virtual void PrepareUpdateRowAddStatement<T>(IDbCommand dbCmd, Dictionary<string, object> args, string sqlFilter)
         {
             var sql = StringBuilderCache.Allocate();
             var modelDef = typeof(T).GetModelDefinition();
 
+            var updateFields = new List<FieldDefinition>();
             foreach (var entry in args)
             {
                 var fieldDef = modelDef.GetFieldDefinition(entry.Key);
+                updateFields.Add(fieldDef);
                 if (fieldDef.ShouldSkipUpdate() || fieldDef.AutoIncrement || fieldDef.IsPrimaryKey ||
                     fieldDef.IsRowVersion || fieldDef.Name == OrmLiteConfig.IdField)
                     continue;
@@ -1150,6 +1211,8 @@ namespace ServiceStack.OrmLite
                     Log.Error("ERROR in PrepareUpdateRowAddStatement(): " + ex.Message, ex);
                 }
             }
+
+            AddDefaultUpdateFields(dbCmd, modelDef, updateFields, sql, "ERROR in PrepareUpdateRowAddStatement(): ");
 
             dbCmd.CommandText = $"UPDATE {GetQuotedTableName(modelDef)} " +
                                 $"SET {StringBuilderCache.ReturnAndFree(sql)}{(string.IsNullOrEmpty(sqlFilter) ? "" : " ")}{sqlFilter}";

--- a/src/ServiceStack.OrmLite/OrmLiteWriteCommandExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteWriteCommandExtensions.cs
@@ -355,11 +355,12 @@ namespace ServiceStack.OrmLite
             OrmLiteConfig.UpdateFilter?.Invoke(dbCmd, obj);
 
             var dialectProvider = dbCmd.GetDialectProvider();
-            var hadRowVersion = dialectProvider.PrepareParameterizedUpdateStatement<T>(dbCmd);
+            var hadRowVersion = false;
+            var parameters = dialectProvider.PrepareParameterizedUpdateStatement<T>(dbCmd, ref hadRowVersion);
             if (string.IsNullOrEmpty(dbCmd.CommandText))
                 return 0;
 
-            dialectProvider.SetParameterValues<T>(dbCmd, obj);
+            dialectProvider.SetParameterValues<T>(dbCmd, parameters, obj);
 
             var rowsUpdated = dbCmd.ExecNonQuery();
 
@@ -386,7 +387,8 @@ namespace ServiceStack.OrmLite
 
                 var dialectProvider = dbCmd.GetDialectProvider();
 
-                var hadRowVersion = dialectProvider.PrepareParameterizedUpdateStatement<T>(dbCmd);
+                var hadRowVersion = false;
+                var parameters = dialectProvider.PrepareParameterizedUpdateStatement<T>(dbCmd, ref hadRowVersion);
                 if (string.IsNullOrEmpty(dbCmd.CommandText))
                     return 0;
 
@@ -394,7 +396,7 @@ namespace ServiceStack.OrmLite
                 {
                     OrmLiteConfig.UpdateFilter?.Invoke(dbCmd, obj);
 
-                    dialectProvider.SetParameterValues<T>(dbCmd, obj);
+                    dialectProvider.SetParameterValues<T>(dbCmd, parameters, obj);
 
                     var rowsUpdated = dbCmd.ExecNonQuery();
                     if (hadRowVersion && rowsUpdated == 0) 

--- a/tests/ServiceStack.OrmLite.Tests/Async/DefaultValueOnUpdateTestsAsync.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Async/DefaultValueOnUpdateTestsAsync.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Data;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using ServiceStack.DataAnnotations;
 using ServiceStack.Text;
 
-namespace ServiceStack.OrmLite.Tests
+namespace ServiceStack.OrmLite.Tests.Async
 {
     public class DefaultValues
     {
@@ -38,60 +39,30 @@ namespace ServiceStack.OrmLite.Tests
         public DateTime? NCreatedDateUtc { get; set; }
     }
 
-    [TestFixture]
-    public class DefaultValueTests : OrmLiteTestBase
+    public class DefaultValueOnUpdateTestsAsync : OrmLiteTestBase
     {
         [Test]
-        public void Can_create_table_with_DefaultValues()
-        {
-            using (var db = OpenDbConnection())
-            {
-                db.DropAndCreateTable<DefaultValues>();
-
-                db.GetLastSql().Print();
-
-                db.Insert(new DefaultValues { Id = 1 });
-
-                var row = db.SingleById<DefaultValues>(1);
-
-                row.PrintDump();
-                AssertRowEqualExcludingDates(row, new DefaultValues {DefaultInt = 1, DefaultIntNonUpdate = 1, NDefaultInt = 1, DefaultDouble = 1.1, NDefaultDouble = 1.1, DefaultString = "String"});
-
-                var expectedDate = Dialect != Dialect.MySql && Dialect != Dialect.Firebird
-                    ? DateTime.UtcNow.Date
-                    : DateTime.Now.Date; //MySql CURRENT_TIMESTAMP == LOCAL_TIME
-
-                Assert.That(row.CreatedDateUtc, Is.GreaterThan(expectedDate));
-                Assert.That(row.NCreatedDateUtc, Is.GreaterThan(expectedDate));
-                Assert.That(row.UpdatedDateUtc, Is.GreaterThan(expectedDate));
-            }
-        }
-
-        private void AssertRowEqualExcludingDates(DefaultValues actual, DefaultValues expected)
-        {
-            Assert.That(actual.DefaultInt, Is.EqualTo(expected.DefaultInt));
-            Assert.That(actual.DefaultIntNonUpdate, Is.EqualTo(expected.DefaultIntNonUpdate));
-            Assert.That(actual.NDefaultInt, Is.EqualTo(expected.NDefaultInt));
-            Assert.That(actual.DefaultDouble, Is.EqualTo(expected.DefaultDouble).Within(.1d));
-            Assert.That(actual.NDefaultDouble, Is.EqualTo(expected.NDefaultDouble).Within(.1d));
-            Assert.That(actual.DefaultString, Is.EqualTo(expected.DefaultString));
-        }
-
-        [Test]
-        public void Can_Update_with_DefaultValues()
+        public async Task Can_Update_with_DefaultValues_Async()
         {
             using (var db = OpenDbConnection())
             {
                 CreateAndInitializeToNonDefaultValues(db);
 
-                var count = db.Update(new DefaultValues {Id = 1});
+                var count = await db.UpdateAsync(new DefaultValues { Id = 1 });
                 Assert.That(count, Is.EqualTo(1));
 
-                var row = db.SingleById<DefaultValues>(1);
+                var row = await db.SingleByIdAsync<DefaultValues>(1);
 
                 row.PrintDump();
-                AssertRowEqualExcludingDates(row, new DefaultValues { DefaultInt = 1, DefaultIntNonUpdate = 0,
-                    NDefaultInt = 1, DefaultDouble = 1.1, NDefaultDouble = 1.1, DefaultString = "String" });
+                AssertRowEqualExcludingDates(row, new DefaultValues
+                {
+                    DefaultInt = 1,
+                    DefaultIntNonUpdate = 0,
+                    NDefaultInt = 1,
+                    DefaultDouble = 1.1,
+                    NDefaultDouble = 1.1,
+                    DefaultString = "String"
+                });
 
                 var expectedDate = Dialect != Dialect.MySql && Dialect != Dialect.Firebird
                     ? DateTime.UtcNow.Date
@@ -147,22 +118,39 @@ namespace ServiceStack.OrmLite.Tests
             return insertValues;
         }
 
+        private void AssertRowEqualExcludingDates(DefaultValues actual, DefaultValues expected)
+        {
+            Assert.That(actual.DefaultInt, Is.EqualTo(expected.DefaultInt));
+            Assert.That(actual.DefaultIntNonUpdate, Is.EqualTo(expected.DefaultIntNonUpdate));
+            Assert.That(actual.NDefaultInt, Is.EqualTo(expected.NDefaultInt));
+            Assert.That(actual.DefaultDouble, Is.EqualTo(expected.DefaultDouble).Within(.1d));
+            Assert.That(actual.NDefaultDouble, Is.EqualTo(expected.NDefaultDouble).Within(.1d));
+            Assert.That(actual.DefaultString, Is.EqualTo(expected.DefaultString));
+        }
+
         [Test]
-        public void Can_Update_with_someValuesAndSomeDefaultValues()
+        public async Task Can_Update_with_someValuesAndSomeDefaultValues_Async()
         {
             using (var db = OpenDbConnection())
             {
                 CreateAndInitializeToNonDefaultValues(db);
 
                 var createdDate = new DateTime(2005, 11, 27, 15, 1, 1, DateTimeKind.Utc);
-                var count = db.Update(new DefaultValues { Id = 1, DefaultIntNonUpdate = 47, CreatedDateUtc = createdDate});
+                var count = await db.UpdateAsync(new DefaultValues { Id = 1, DefaultIntNonUpdate = 47, CreatedDateUtc = createdDate });
                 Assert.That(count, Is.EqualTo(1));
 
-                var row = db.SingleById<DefaultValues>(1);
+                var row = await db.SingleByIdAsync<DefaultValues>(1);
 
                 row.PrintDump();
-                AssertRowEqualExcludingDates(row, new DefaultValues {DefaultInt = 1, DefaultIntNonUpdate = 47,
-                    NDefaultInt = 1, DefaultDouble = 1.1, NDefaultDouble = 1.1, DefaultString = "String"});
+                AssertRowEqualExcludingDates(row, new DefaultValues
+                {
+                    DefaultInt = 1,
+                    DefaultIntNonUpdate = 47,
+                    NDefaultInt = 1,
+                    DefaultDouble = 1.1,
+                    NDefaultDouble = 1.1,
+                    DefaultString = "String"
+                });
 
                 var expectedDate = Dialect != Dialect.MySql && Dialect != Dialect.Firebird
                     ? DateTime.UtcNow.Date
@@ -175,20 +163,27 @@ namespace ServiceStack.OrmLite.Tests
         }
 
         [Test]
-        public void Can_Update_OnlyStyle_with_DefaultValues()
+        public async Task Can_Update_OnlyStyle_with_DefaultValues_Async()
         {
             using (var db = OpenDbConnection())
             {
                 var insertValues = CreateAndInitializeToNonDefaultValues(db);
 
-                var count = db.Update<DefaultValues>(new { DefaultDouble = 2.2, DefaultString = "Fred" });
+                var count = await db.UpdateAsync<DefaultValues>(new { DefaultDouble = 2.2, DefaultString = "Fred" });
                 Assert.That(count, Is.EqualTo(1));
 
-                var row = db.SingleById<DefaultValues>(1);
+                var row = await db.SingleByIdAsync<DefaultValues>(1);
 
                 row.PrintDump();
-                AssertRowEqualExcludingDates(row, new DefaultValues {DefaultInt = 1, DefaultIntNonUpdate = insertValues.DefaultIntNonUpdate,
-                    NDefaultInt = 1, DefaultDouble = 2.2, NDefaultDouble = 1.1, DefaultString = "Fred"});
+                AssertRowEqualExcludingDates(row, new DefaultValues
+                {
+                    DefaultInt = 1,
+                    DefaultIntNonUpdate = insertValues.DefaultIntNonUpdate,
+                    NDefaultInt = 1,
+                    DefaultDouble = 2.2,
+                    NDefaultDouble = 1.1,
+                    DefaultString = "Fred"
+                });
 
                 var expectedDate = Dialect != Dialect.MySql && Dialect != Dialect.Firebird
                     ? DateTime.UtcNow.Date
@@ -201,14 +196,14 @@ namespace ServiceStack.OrmLite.Tests
         }
 
         [Test]
-        public void Can_Update_several_with_DefaultValues()
+        public async Task Can_Update_several_with_DefaultValues_Async()
         {
             using (var db = OpenDbConnection())
             {
                 CreateAndInitializeToNonDefaultValues(db);
                 InitializeToNonDefaultValues(db, 2);
 
-                var count = db.Update(new DefaultValues {Id = 1}, new DefaultValues {Id = 2, DefaultIntNonUpdate = 43354});
+                var count = await db.UpdateAsync(new DefaultValues { Id = 1 }, new DefaultValues { Id = 2, DefaultIntNonUpdate = 43354 });
                 Assert.That(count, Is.EqualTo(2));
 
                 VerifyRow(db, 1, 0, DateTime.MinValue);
@@ -216,13 +211,20 @@ namespace ServiceStack.OrmLite.Tests
             }
         }
 
-        private void VerifyRow(IDbConnection db, int id, int nonUpdateInt, DateTime createdDate)
+        private async void VerifyRow(IDbConnection db, int id, int nonUpdateInt, DateTime createdDate)
         {
-            var row = db.SingleById<DefaultValues>(id);
+            var row = await db.SingleByIdAsync<DefaultValues>(id);
 
             row.PrintDump();
-            AssertRowEqualExcludingDates(row, new DefaultValues {DefaultInt = 1, DefaultIntNonUpdate = nonUpdateInt,
-                NDefaultInt = 1, DefaultDouble = 1.1, NDefaultDouble = 1.1, DefaultString = "String"});
+            AssertRowEqualExcludingDates(row, new DefaultValues
+            {
+                DefaultInt = 1,
+                DefaultIntNonUpdate = nonUpdateInt,
+                NDefaultInt = 1,
+                DefaultDouble = 1.1,
+                NDefaultDouble = 1.1,
+                DefaultString = "String"
+            });
 
             var expectedDate = Dialect != Dialect.MySql && Dialect != Dialect.Firebird
                 ? DateTime.UtcNow.Date
@@ -234,14 +236,14 @@ namespace ServiceStack.OrmLite.Tests
         }
 
         [Test]
-        public void Can_UpdateAll_with_DefaultValues()
+        public async Task Can_UpdateAll_with_DefaultValues_Async()
         {
             using (var db = OpenDbConnection())
             {
                 CreateAndInitializeToNonDefaultValues(db);
                 InitializeToNonDefaultValues(db, 2);
 
-                var count = db.UpdateAll(new [] {new DefaultValues { Id = 1 }, new DefaultValues { Id = 2, DefaultIntNonUpdate = 43354 }});
+                var count = await db.UpdateAllAsync(new[] { new DefaultValues { Id = 1 }, new DefaultValues { Id = 2, DefaultIntNonUpdate = 43354 } });
                 Assert.That(count, Is.EqualTo(2));
 
                 VerifyRow(db, 1, 0, DateTime.MinValue);
@@ -250,7 +252,7 @@ namespace ServiceStack.OrmLite.Tests
         }
 
         [Test]
-        public void Can_UpdateOnly_SqlExpression_with_DefaultValues()
+        public async Task Can_UpdateOnly_SqlExpression_with_DefaultValues_Async()
         {
             using (var db = OpenDbConnection())
             {
@@ -258,15 +260,22 @@ namespace ServiceStack.OrmLite.Tests
 
                 var sql = db.From<DefaultValues>();
                 var createdDate = new DateTime(2013, 3, 7, 5, 23, 47, DateTimeKind.Utc);
-                var count = db.UpdateOnly(new DefaultValues { Id = 1, DefaultInt = 8733,
-                    CreatedDateUtc = createdDate}, sql.Update(p => new { p.DefaultInt, p.CreatedDateUtc }));
+                var count = await db.UpdateOnlyAsync(new DefaultValues { Id = 1, DefaultInt = 8733, CreatedDateUtc = createdDate },
+                    sql.Update(p => new { p.DefaultInt, p.CreatedDateUtc }));
                 Assert.That(count, Is.EqualTo(1));
 
-                var row = db.SingleById<DefaultValues>(1);
+                var row = await db.SingleByIdAsync<DefaultValues>(1);
 
                 row.PrintDump();
-                AssertRowEqualExcludingDates(row, new DefaultValues { DefaultInt = 8733, DefaultIntNonUpdate = insertValues.DefaultIntNonUpdate,
-                    NDefaultInt = 1, DefaultDouble = 1.1, NDefaultDouble = 1.1, DefaultString = "String" });
+                AssertRowEqualExcludingDates(row, new DefaultValues
+                {
+                    DefaultInt = 8733,
+                    DefaultIntNonUpdate = insertValues.DefaultIntNonUpdate,
+                    NDefaultInt = 1,
+                    DefaultDouble = 1.1,
+                    NDefaultDouble = 1.1,
+                    DefaultString = "String"
+                });
 
                 var expectedDate = Dialect != Dialect.MySql && Dialect != Dialect.Firebird
                     ? DateTime.UtcNow.Date
@@ -279,22 +288,29 @@ namespace ServiceStack.OrmLite.Tests
         }
 
         [Test]
-        public void Can_UpdateOnly_OnlyFields_with_DefaultValues()
+        public async Task Can_UpdateOnly_OnlyFields_with_DefaultValues_Async()
         {
             using (var db = OpenDbConnection())
             {
                 var insertValues = CreateAndInitializeToNonDefaultValues(db);
 
                 var createdDate = new DateTime(2013, 3, 7, 5, 23, 47, DateTimeKind.Utc);
-                var count = db.UpdateOnly(new DefaultValues { Id = 1, DefaultInt = 8733, CreatedDateUtc = createdDate },
+                var count = await db.UpdateOnlyAsync(new DefaultValues { Id = 1, DefaultInt = 8733, CreatedDateUtc = createdDate },
                     onlyFields: p => new { p.DefaultInt, p.CreatedDateUtc });
                 Assert.That(count, Is.EqualTo(1));
 
-                var row = db.SingleById<DefaultValues>(1);
+                var row = await db.SingleByIdAsync<DefaultValues>(1);
 
                 row.PrintDump();
-                AssertRowEqualExcludingDates(row, new DefaultValues {DefaultInt = 8733, DefaultIntNonUpdate = insertValues.DefaultIntNonUpdate,
-                    NDefaultInt = 1, DefaultDouble = 1.1, NDefaultDouble = 1.1, DefaultString = "String"});
+                AssertRowEqualExcludingDates(row, new DefaultValues
+                {
+                    DefaultInt = 8733,
+                    DefaultIntNonUpdate = insertValues.DefaultIntNonUpdate,
+                    NDefaultInt = 1,
+                    DefaultDouble = 1.1,
+                    NDefaultDouble = 1.1,
+                    DefaultString = "String"
+                });
 
                 var expectedDate = Dialect != Dialect.MySql && Dialect != Dialect.Firebird
                     ? DateTime.UtcNow.Date
@@ -307,21 +323,28 @@ namespace ServiceStack.OrmLite.Tests
         }
 
         [Test]
-        public void Can_UpdateOnly_Expression_with_DefaultValues()
+        public async Task Can_UpdateOnly_Expression_with_DefaultValues_Async()
         {
             using (var db = OpenDbConnection())
             {
                 var insertValues = CreateAndInitializeToNonDefaultValues(db);
 
                 var createdDate = new DateTime(2013, 3, 7, 5, 23, 47, DateTimeKind.Utc);
-                var count = db.UpdateOnly(() => new DefaultValues { DefaultInt = 8733, CreatedDateUtc = createdDate }, p => p.Id == 1);
+                var count = await db.UpdateOnlyAsync(() => new DefaultValues { DefaultInt = 8733, CreatedDateUtc = createdDate }, p => p.Id == 1);
                 Assert.That(count, Is.EqualTo(1));
 
-                var row = db.SingleById<DefaultValues>(1);
+                var row = await db.SingleByIdAsync<DefaultValues>(1);
 
                 row.PrintDump();
-                AssertRowEqualExcludingDates(row, new DefaultValues {DefaultInt = 8733, DefaultIntNonUpdate = insertValues.DefaultIntNonUpdate,
-                    NDefaultInt = 1, DefaultDouble = 1.1, NDefaultDouble = 1.1, DefaultString = "String"});
+                AssertRowEqualExcludingDates(row, new DefaultValues
+                {
+                    DefaultInt = 8733,
+                    DefaultIntNonUpdate = insertValues.DefaultIntNonUpdate,
+                    NDefaultInt = 1,
+                    DefaultDouble = 1.1,
+                    NDefaultDouble = 1.1,
+                    DefaultString = "String"
+                });
 
                 var expectedDate = Dialect != Dialect.MySql && Dialect != Dialect.Firebird
                     ? DateTime.UtcNow.Date
@@ -334,22 +357,29 @@ namespace ServiceStack.OrmLite.Tests
         }
 
         [Test]
-        public void Can_UpdateOnly_StringFieldList_with_DefaultValues()
+        public async Task Can_UpdateOnly_StringFieldList_with_DefaultValues_Async()
         {
             using (var db = OpenDbConnection())
             {
                 var insertValues = CreateAndInitializeToNonDefaultValues(db);
 
                 var createdDate = new DateTime(2013, 3, 7, 5, 23, 47, DateTimeKind.Utc);
-                var count = db.UpdateOnly(new DefaultValues { Id = 1, DefaultInt = 8733, CreatedDateUtc = createdDate },
-                    new[]{ "DefaultInt", "CreatedDateUtc" });
+                var count = await db.UpdateOnlyAsync(new DefaultValues { Id = 1, DefaultInt = 8733, CreatedDateUtc = createdDate },
+                    new[] { "DefaultInt", "CreatedDateUtc" });
                 Assert.That(count, Is.EqualTo(1));
 
-                var row = db.SingleById<DefaultValues>(1);
+                var row = await db.SingleByIdAsync<DefaultValues>(1);
 
                 row.PrintDump();
-                AssertRowEqualExcludingDates(row, new DefaultValues {DefaultInt = 8733, DefaultIntNonUpdate = insertValues.DefaultIntNonUpdate,
-                    NDefaultInt = 1, DefaultDouble = 1.1, NDefaultDouble = 1.1, DefaultString = "String"});
+                AssertRowEqualExcludingDates(row, new DefaultValues
+                {
+                    DefaultInt = 8733,
+                    DefaultIntNonUpdate = insertValues.DefaultIntNonUpdate,
+                    NDefaultInt = 1,
+                    DefaultDouble = 1.1,
+                    NDefaultDouble = 1.1,
+                    DefaultString = "String"
+                });
 
                 var expectedDate = Dialect != Dialect.MySql && Dialect != Dialect.Firebird
                     ? DateTime.UtcNow.Date
@@ -362,21 +392,28 @@ namespace ServiceStack.OrmLite.Tests
         }
 
         [Test]
-        public void Can_UpdateAdd_with_DefaultValues()
+        public async Task Can_UpdateAdd_with_DefaultValues_Async()
         {
             using (var db = OpenDbConnection())
             {
                 var insertValues = CreateAndInitializeToNonDefaultValues(db);
 
                 var createdDate = new DateTime(2013, 3, 7, 5, 23, 47, DateTimeKind.Utc);
-                var count = db.UpdateAdd(() => new DefaultValues {DefaultInt = 8733, CreatedDateUtc = createdDate}, p => p.Id == 1);
+                var count = await db.UpdateAddAsync(() => new DefaultValues { DefaultInt = 8733, CreatedDateUtc = createdDate }, p => p.Id == 1);
                 Assert.That(count, Is.EqualTo(1));
 
-                var row = db.SingleById<DefaultValues>(1);
+                var row = await db.SingleByIdAsync<DefaultValues>(1);
 
                 row.PrintDump();
-                AssertRowEqualExcludingDates(row, new DefaultValues {DefaultInt = 8733 + insertValues.DefaultInt,
-                    DefaultIntNonUpdate = insertValues.DefaultIntNonUpdate, NDefaultInt = 1, DefaultDouble = 1.1, NDefaultDouble = 1.1, DefaultString = "String"});
+                AssertRowEqualExcludingDates(row, new DefaultValues
+                {
+                    DefaultInt = 8733 + insertValues.DefaultInt,
+                    DefaultIntNonUpdate = insertValues.DefaultIntNonUpdate,
+                    NDefaultInt = 1,
+                    DefaultDouble = 1.1,
+                    NDefaultDouble = 1.1,
+                    DefaultString = "String"
+                });
 
                 var expectedDate = Dialect != Dialect.MySql && Dialect != Dialect.Firebird
                     ? DateTime.UtcNow.Date
@@ -389,21 +426,28 @@ namespace ServiceStack.OrmLite.Tests
         }
 
         [Test]
-        public void Can_UpdateAdd_SqlExpression_with_DefaultValues()
+        public async Task Can_UpdateAdd_SqlExpression_with_DefaultValues_Async()
         {
             using (var db = OpenDbConnection())
             {
                 var insertValues = CreateAndInitializeToNonDefaultValues(db);
 
                 var createdDate = new DateTime(2013, 3, 7, 5, 23, 47, DateTimeKind.Utc);
-                var count = db.UpdateAdd(() => new DefaultValues { DefaultInt = 8733, CreatedDateUtc = createdDate }, db.From<DefaultValues>().Where(p => p.Id == 1));
+                var count = await db.UpdateAddAsync(() => new DefaultValues { DefaultInt = 8733, CreatedDateUtc = createdDate }, db.From<DefaultValues>().Where(p => p.Id == 1));
                 Assert.That(count, Is.EqualTo(1));
 
-                var row = db.SingleById<DefaultValues>(1);
+                var row = await db.SingleByIdAsync<DefaultValues>(1);
 
                 row.PrintDump();
-                AssertRowEqualExcludingDates(row, new DefaultValues {DefaultInt = 8733 + insertValues.DefaultInt,
-                    DefaultIntNonUpdate = insertValues.DefaultIntNonUpdate, NDefaultInt = 1, DefaultDouble = 1.1, NDefaultDouble = 1.1, DefaultString = "String"});
+                AssertRowEqualExcludingDates(row, new DefaultValues
+                {
+                    DefaultInt = 8733 + insertValues.DefaultInt,
+                    DefaultIntNonUpdate = insertValues.DefaultIntNonUpdate,
+                    NDefaultInt = 1,
+                    DefaultDouble = 1.1,
+                    NDefaultDouble = 1.1,
+                    DefaultString = "String"
+                });
 
                 var expectedDate = Dialect != Dialect.MySql && Dialect != Dialect.Firebird
                     ? DateTime.UtcNow.Date
@@ -416,16 +460,16 @@ namespace ServiceStack.OrmLite.Tests
         }
 
         [Test]
-        public void Can_Save_whichDoesUpdate_With_DefaultValues()
+        public async Task Can_Save_whichDoesUpdate_With_DefaultValues_Async()
         {
             using (var db = OpenDbConnection())
             {
                 CreateAndInitializeToNonDefaultValues(db);
 
-                var newRow = db.Save(new DefaultValues { Id = 1 });
+                var newRow = await db.SaveAsync(new DefaultValues { Id = 1 });
                 Assert.That(newRow, Is.False);
 
-                var row = db.SingleById<DefaultValues>(1);
+                var row = await db.SingleByIdAsync<DefaultValues>(1);
 
                 row.PrintDump();
                 AssertRowEqualExcludingDates(row, new DefaultValues
@@ -449,14 +493,14 @@ namespace ServiceStack.OrmLite.Tests
         }
 
         [Test]
-        public void Can_SaveAll_whichDoesUpdate_with_DefaultValues()
+        public async Task Can_SaveAll_whichDoesUpdate_with_DefaultValues_Async()
         {
             using (var db = OpenDbConnection())
             {
                 CreateAndInitializeToNonDefaultValues(db);
                 InitializeToNonDefaultValues(db, 2);
 
-                var count = db.SaveAll(new[] { new DefaultValues { Id = 1 }, new DefaultValues { Id = 2, DefaultIntNonUpdate = 43354 } });
+                var count = await db.SaveAllAsync(new[] { new DefaultValues { Id = 1 }, new DefaultValues { Id = 2, DefaultIntNonUpdate = 43354 } });
                 Assert.That(count, Is.EqualTo(0));
 
                 VerifyRow(db, 1, 0, DateTime.MinValue);

--- a/tests/ServiceStack.OrmLite.Tests/OrmLiteTestBase.cs
+++ b/tests/ServiceStack.OrmLite.Tests/OrmLiteTestBase.cs
@@ -4,6 +4,7 @@ using System.Data.Common;
 using System.IO;
 using NUnit.Framework;
 using ServiceStack.Logging;
+using ServiceStack.OrmLite.SqlServer.Converters;
 #if !NETCORE
 using ServiceStack.OrmLite.Oracle;
 #endif
@@ -132,9 +133,13 @@ namespace ServiceStack.OrmLite.Tests
                     dbFactory.AutoDisposeConnection = false;
                     return dbFactory;
                 case Dialect.SqlServer:
-                    return Init(Config.SqlServerBuildDb, SqlServerDialect.Provider);
+                    dbFactory = Init(Config.SqlServerBuildDb, SqlServerDialect.Provider);
+                    OrmLiteConfig.DialectProvider.RegisterConverter<DateTime>(new SqlServerDateTime2Converter());
+                    return dbFactory;
                 case Dialect.SqlServer2012:
-                    return Init(Config.SqlServerBuildDb, SqlServer2012Dialect.Provider);
+                    dbFactory = Init(Config.SqlServerBuildDb, SqlServer2012Dialect.Provider);
+                    OrmLiteConfig.DialectProvider.RegisterConverter<DateTime>(new SqlServerDateTime2Converter());
+                    return dbFactory;
                 case Dialect.MySql:
                     return Init(Config.MySqlDb, MySqlDialect.Provider);
                 case Dialect.PostgreSql:

--- a/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
+++ b/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Async\AsyncTests.cs" />
     <Compile Include="Async\AutoQueryTestsAsync.cs" />
     <Compile Include="Async\CustomSqlTestsAsync.cs" />
+    <Compile Include="Async\DefaultValueOnUpdateTestsAsync.cs" />
     <Compile Include="Async\Issues\LoadSelectAmbiguousColumnIssue.cs" />
     <Compile Include="Async\Issues\PredicateBuilderIssue.cs" />
     <Compile Include="Async\Issues\SqlServerComputedColumnIssue.cs" />


### PR DESCRIPTION
@mythz here is the OnUpdate pull request again, with no extraneous stuff in it. I did some refactoring to remove duplication and speed up the sql generation. I would really appreciate if you would consider this as we really need it in quite a number of places in our product and really want to avoid bypassing OrmLite in those places. As I said in an earlier message today, the ability to set a column to a database-supplied date on update is really very useful and I'm sure others will use it, once they see that the capability exists in OrmLite in an easy to use way.

However, I'd be happy to discuss this, and I'd very much appreciate doing that quickly as I have vacation planned from Friday through to after New Years.

Thanks, Bruce