### PR TITLE
Fix ToUpdateStatement and ToInsertStatement with subset named columns

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle.Tests/ServiceStack.OrmLite.Oracle.Tests.csproj
+++ b/src/ServiceStack.OrmLite.Oracle.Tests/ServiceStack.OrmLite.Oracle.Tests.csproj
@@ -400,6 +400,9 @@
     <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\TestHelpers.cs">
       <Link>TestHelpers.cs</Link>
     </Compile>
+    <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\ToInsertAndUpdateStatementTests.cs">
+      <Link>ToInsertAndUpdateStatementTests.cs</Link>
+    </Compile>
     <Compile Include="..\..\tests\ServiceStack.OrmLite.Tests\TypeDescriptorMetadataTests.cs">
       <Link>TypeDescriptorMetadataTests.cs</Link>
     </Compile>

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -17,6 +17,7 @@ using System.Data.SqlClient;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using ServiceStack.DataAnnotations;
@@ -743,7 +744,7 @@ namespace ServiceStack.OrmLite
                 var quotedValue = dbParam.Value != null
                     ? GetQuotedValue(dbParam.Value, dbParam.Value.GetType())
                     : "null";
-                sql = sql.Replace(dbParam.ParameterName, quotedValue);
+                sql = Regex.Replace(sql, dbParam.ParameterName + @"(,|\s|\)|$)", quotedValue + "$1");
             }
             return sql;
         }


### PR DESCRIPTION
@mythz Here is a simple little fix to `ToUpdateStatement` and `ToInsertStatement` which fail when one field in the poco has a name which is a leading subset of another field. I ran into it with my update changes. I think it is safe enough as field names should not contain special regular expression characters. Cheers, Bruce