### PR TITLE
Fix the default value of the "token" parameter in Async methods

### DIFF
--- a/src/ServiceStack.OrmLite.MySql/MySqlDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.MySql/MySqlDialectProvider.cs
@@ -224,32 +224,32 @@ namespace ServiceStack.OrmLite.MySql
         }
 
 #if ASYNC
-        public override Task OpenAsync(IDbConnection db, CancellationToken token)
+        public override Task OpenAsync(IDbConnection db, CancellationToken token = default(CancellationToken))
         {
             return Unwrap(db).OpenAsync(token);
         }
 
-        public override Task<IDataReader> ExecuteReaderAsync(IDbCommand cmd, CancellationToken token)
+        public override Task<IDataReader> ExecuteReaderAsync(IDbCommand cmd, CancellationToken token = default(CancellationToken))
         {
             return Unwrap(cmd).ExecuteReaderAsync(token).Then(x => (IDataReader)x);
         }
 
-        public override Task<int> ExecuteNonQueryAsync(IDbCommand cmd, CancellationToken token)
+        public override Task<int> ExecuteNonQueryAsync(IDbCommand cmd, CancellationToken token = default(CancellationToken))
         {
             return Unwrap(cmd).ExecuteNonQueryAsync(token);
         }
 
-        public override Task<object> ExecuteScalarAsync(IDbCommand cmd, CancellationToken token)
+        public override Task<object> ExecuteScalarAsync(IDbCommand cmd, CancellationToken token = default(CancellationToken))
         {
             return Unwrap(cmd).ExecuteScalarAsync(token);
         }
 
-        public override Task<bool> ReadAsync(IDataReader reader, CancellationToken token)
+        public override Task<bool> ReadAsync(IDataReader reader, CancellationToken token = default(CancellationToken))
         {
             return Unwrap(reader).ReadAsync(token);
         }
 
-        public override async Task<List<T>> ReaderEach<T>(IDataReader reader, Func<T> fn, CancellationToken token)
+        public override async Task<List<T>> ReaderEach<T>(IDataReader reader, Func<T> fn, CancellationToken token = default(CancellationToken))
         {
             try
             {
@@ -267,7 +267,7 @@ namespace ServiceStack.OrmLite.MySql
             }
         }
 
-        public override async Task<Return> ReaderEach<Return>(IDataReader reader, Action fn, Return source, CancellationToken token)
+        public override async Task<Return> ReaderEach<Return>(IDataReader reader, Action fn, Return source, CancellationToken token = default(CancellationToken))
         {
             try
             {
@@ -283,7 +283,7 @@ namespace ServiceStack.OrmLite.MySql
             }
         }
 
-        public override async Task<T> ReaderRead<T>(IDataReader reader, Func<T> fn, CancellationToken token)
+        public override async Task<T> ReaderRead<T>(IDataReader reader, Func<T> fn, CancellationToken token = default(CancellationToken))
         {
             try
             {

--- a/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.PostgreSQL/PostgreSQLDialectProvider.cs
@@ -339,32 +339,32 @@ namespace ServiceStack.OrmLite.PostgreSQL
         }
 
 #if ASYNC
-        public override Task OpenAsync(IDbConnection db, CancellationToken token)
+        public override Task OpenAsync(IDbConnection db, CancellationToken token = default(CancellationToken))
         {
             return Unwrap(db).OpenAsync(token);
         }
 
-        public override Task<IDataReader> ExecuteReaderAsync(IDbCommand cmd, CancellationToken token)
+        public override Task<IDataReader> ExecuteReaderAsync(IDbCommand cmd, CancellationToken token = default(CancellationToken))
         {
             return Unwrap(cmd).ExecuteReaderAsync(token).Then(x => (IDataReader)x);
         }
 
-        public override Task<int> ExecuteNonQueryAsync(IDbCommand cmd, CancellationToken token)
+        public override Task<int> ExecuteNonQueryAsync(IDbCommand cmd, CancellationToken token = default(CancellationToken))
         {
             return Unwrap(cmd).ExecuteNonQueryAsync(token);
         }
 
-        public override Task<object> ExecuteScalarAsync(IDbCommand cmd, CancellationToken token)
+        public override Task<object> ExecuteScalarAsync(IDbCommand cmd, CancellationToken token = default(CancellationToken))
         {
             return Unwrap(cmd).ExecuteScalarAsync(token);
         }
 
-        public override Task<bool> ReadAsync(IDataReader reader, CancellationToken token)
+        public override Task<bool> ReadAsync(IDataReader reader, CancellationToken token = default(CancellationToken))
         {
             return Unwrap(reader).ReadAsync(token);
         }
 
-        public override async Task<List<T>> ReaderEach<T>(IDataReader reader, Func<T> fn, CancellationToken token)
+        public override async Task<List<T>> ReaderEach<T>(IDataReader reader, Func<T> fn, CancellationToken token = default(CancellationToken))
         {
             try
             {
@@ -382,7 +382,7 @@ namespace ServiceStack.OrmLite.PostgreSQL
             }
         }
 
-        public override async Task<Return> ReaderEach<Return>(IDataReader reader, Action fn, Return source, CancellationToken token)
+        public override async Task<Return> ReaderEach<Return>(IDataReader reader, Action fn, Return source, CancellationToken token = default(CancellationToken))
         {
             try
             {
@@ -398,7 +398,7 @@ namespace ServiceStack.OrmLite.PostgreSQL
             }
         }
 
-        public override async Task<T> ReaderRead<T>(IDataReader reader, Func<T> fn, CancellationToken token)
+        public override async Task<T> ReaderRead<T>(IDataReader reader, Func<T> fn, CancellationToken token = default(CancellationToken))
         {
             try
             {

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
@@ -362,17 +362,22 @@ namespace ServiceStack.OrmLite.SqlServer
         protected SqlDataReader Unwrap(IDataReader reader) => (SqlDataReader)reader;
 
 #if ASYNC
-        public override Task OpenAsync(IDbConnection db, CancellationToken token) => Unwrap(db).OpenAsync(token);
+        public override Task OpenAsync(IDbConnection db, CancellationToken token = default(CancellationToken))
+            => Unwrap(db).OpenAsync(token);
 
-        public override Task<IDataReader> ExecuteReaderAsync(IDbCommand cmd, CancellationToken token) => Unwrap(cmd).ExecuteReaderAsync(token).Then(x => (IDataReader)x);
+        public override Task<IDataReader> ExecuteReaderAsync(IDbCommand cmd, CancellationToken token = default(CancellationToken))
+            => Unwrap(cmd).ExecuteReaderAsync(token).Then(x => (IDataReader)x);
 
-        public override Task<int> ExecuteNonQueryAsync(IDbCommand cmd, CancellationToken token) => Unwrap(cmd).ExecuteNonQueryAsync(token);
+        public override Task<int> ExecuteNonQueryAsync(IDbCommand cmd, CancellationToken token = default(CancellationToken))
+            => Unwrap(cmd).ExecuteNonQueryAsync(token);
 
-        public override Task<object> ExecuteScalarAsync(IDbCommand cmd, CancellationToken token) => Unwrap(cmd).ExecuteScalarAsync(token);
+        public override Task<object> ExecuteScalarAsync(IDbCommand cmd, CancellationToken token = default(CancellationToken))
+            => Unwrap(cmd).ExecuteScalarAsync(token);
 
-        public override Task<bool> ReadAsync(IDataReader reader, CancellationToken token) => Unwrap(reader).ReadAsync(token);
+        public override Task<bool> ReadAsync(IDataReader reader, CancellationToken token = default(CancellationToken))
+            => Unwrap(reader).ReadAsync(token);
 
-        public override async Task<List<T>> ReaderEach<T>(IDataReader reader, Func<T> fn, CancellationToken token)
+        public override async Task<List<T>> ReaderEach<T>(IDataReader reader, Func<T> fn, CancellationToken token = default(CancellationToken))
         {
             try
             {
@@ -390,7 +395,7 @@ namespace ServiceStack.OrmLite.SqlServer
             }
         }
 
-        public override async Task<Return> ReaderEach<Return>(IDataReader reader, Action fn, Return source, CancellationToken token)
+        public override async Task<Return> ReaderEach<Return>(IDataReader reader, Action fn, Return source, CancellationToken token = default(CancellationToken))
         {
             try
             {
@@ -406,7 +411,7 @@ namespace ServiceStack.OrmLite.SqlServer
             }
         }
 
-        public override async Task<T> ReaderRead<T>(IDataReader reader, Func<T> fn, CancellationToken token)
+        public override async Task<T> ReaderRead<T>(IDataReader reader, Func<T> fn, CancellationToken token = default(CancellationToken))
         {
             try
             {


### PR DESCRIPTION
Fix the default value of the "token" parameter in Async methods of classes derived from OrmLiteDialectProviderBase to match those in the base class. Without this calling the methods via an instance of the derived class requires specifying a CancellationToken.