### PR TITLE
Update nuspec for Postgres Core

### DIFF
--- a/NuGet.Core/ServiceStack.OrmLite.PostgreSQL.Core/ServiceStack.OrmLite.PostgreSQL.Core.nuspec
+++ b/NuGet.Core/ServiceStack.OrmLite.PostgreSQL.Core/ServiceStack.OrmLite.PostgreSQL.Core.nuspec
@@ -19,7 +19,7 @@
     <copyright>Copyright 2016 Service Stack</copyright>
     <dependencies>
       <group targetFramework=".NETStandard1.3">
-        <dependency id="Npgsql" version="[3.1.9, )" />
+        <dependency id="Npgsql" version="[3.2.2, )" />
         <dependency id="ServiceStack.Interfaces.Core" version="[1.0.0, )" />
         <dependency id="ServiceStack.Text.Core" version="[1.0.0, )" />
         <dependency id="ServiceStack.Common.Core" version="[1.0.0, )" />


### PR DESCRIPTION
Fix nuspec for Postgres Core as currently 1.0.39 fails to build as it's unable to find 3.2.2 reference.