### PR TITLE
Fixed class name in reference attribute

### DIFF
--- a/src/T4/OrmLite.Poco.tt
+++ b/src/T4/OrmLite.Poco.tt
@@ -94,7 +94,7 @@ priorProperyNames.Add(col.PropertyName);
                  [Compute]        
  <# }  if (IncludeReferences && tbl.FKeys != null && tbl.FKeys.Any(x => x.FromColumn ==  col.PropertyName)) { 
  	   var toTable = MakeSingular ? tbl.FKeys.First(x => x.FromColumn == col.PropertyName).ToTableSingular : tbl.FKeys.First(x => x.FromColumn == col.PropertyName).ToTable;#>
-         [References(typeof(<#=toTable#>))]          
+         [References(typeof(<#=ClassPrefix + toTable + ClassSuffix#>))]          
 <# }  if (col.IsNullable != true && col.IsAutoIncrement != true) { #>
         [Required]
 <# } if (!col.IsPK){#>


### PR DESCRIPTION
Fixed an issue where the reference attribute would ignore the class prefix and suffix, causing a 'Cannot resolve symbol' error when IncludeReferences is true.