### PR TITLE
Changed the ParamNameFilter to a instance variable on the Dialect Provider

### DIFF
--- a/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
@@ -51,6 +51,8 @@ namespace ServiceStack.OrmLite
 
         IStringSerializer StringSerializer { get; set; }
 
+        Func<string, string> ParamNameFilter { get; set; }
+
         /// <summary>
         /// Quote the string so that it can be used inside an SQL-expression
         /// Escape quotes inside the string

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -198,6 +198,8 @@ namespace ServiceStack.OrmLite
 
         public IStringSerializer StringSerializer { get; set; }
 
+        public Func<string, string> ParamNameFilter { get; set; } = OrmLiteConfig.ParamNameFilter;
+
         public string DefaultValueFormat = " DEFAULT ({0})";
 
         private EnumConverter enumConverter;
@@ -910,10 +912,10 @@ namespace ServiceStack.OrmLite
 
                 if (fieldDef == null)
                 {
-                    if (OrmLiteConfig.ParamNameFilter != null)
+                    if (ParamNameFilter != null)
                     {
                         fieldDef = modelDef.GetFieldDefinition(name => 
-                            string.Equals(OrmLiteConfig.ParamNameFilter(name), fieldName, StringComparison.OrdinalIgnoreCase));
+                            string.Equals(ParamNameFilter(name), fieldName, StringComparison.OrdinalIgnoreCase));
                     }
 
                     if (fieldDef == null)

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderExtensions.cs
@@ -8,7 +8,7 @@ namespace ServiceStack.OrmLite
     {
         public static string GetParam(this IOrmLiteDialectProvider dialect, string name)
         {
-            return dialect.ParamString + (OrmLiteConfig.ParamNameFilter?.Invoke(name) ?? name);
+            return dialect.ParamString + (dialect.ParamNameFilter?.Invoke(name) ?? name);
         }
 
         public static string GetParam(this IOrmLiteDialectProvider dialect, int indexNo = 0)


### PR DESCRIPTION
This is to support being able to use ormlite in an application querying both sql server and oracle databases where the Oracle data provider is Devart.

Currently to use OrmLite with Devart, we need to set:
``
OrmLiteConfig.ParamNameFilter = paramName => $":{paramName}"
``
But because OrmLiteConfig is static, this breaks a separate Sql Server connection running in the same application.

This change would allow the ParamNameFilter to be overwritten for a specific dialect provider, if required.