### PR TITLE
Update SqliteOrmLiteDialectProviderBase.cs

### DIFF
--- a/src/ServiceStack.OrmLite.Sqlite/SqliteOrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite.Sqlite/SqliteOrmLiteDialectProviderBase.cs
@@ -140,6 +140,12 @@ namespace ServiceStack.OrmLite.Sqlite
 
         protected abstract IDbConnection CreateConnection(string connectionString);
 
+        public override string GetSchemaName(string schema) {
+            return schema != null
+                ? schema.Replace(".", "_")
+                : schema;
+        }
+
         public override string GetTableName(string table, string schema=null)
         {
             return schema != null


### PR DESCRIPTION
When using the in memory db for Sqlite, schemas with a period cause the object to not be found as cross database operations are not supported. This change will prevent this error by injecting an underscore. Similar to the implementation found in GetTableName.