### PR TITLE
Allow ORMLite Extensions to be used without global dialect provider.

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
@@ -114,10 +114,10 @@ namespace ServiceStack.OrmLite.SqlServer
         public override bool DoesTableExist(IDbCommand dbCmd, string tableName, string schema = null)
         {
             var sql = "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = {0}"
-                .SqlFmt(tableName);
+                .SqlFmt(this, tableName);
 
             if (schema != null)
-                sql += " AND TABLE_SCHEMA = {0}".SqlFmt(schema);
+                sql += " AND TABLE_SCHEMA = {0}".SqlFmt(this, schema);
 
             var result = dbCmd.ExecLongScalar(sql);
 
@@ -127,7 +127,7 @@ namespace ServiceStack.OrmLite.SqlServer
         public override bool DoesColumnExist(IDbConnection db, string columnName, string tableName, string schema = null)
         {
             var sql = "SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = @tableName AND COLUMN_NAME = @columnName"
-                .SqlFmt(tableName, columnName);
+                .SqlFmt(this, tableName, columnName);
 
             if (schema != null)
                 sql += " AND TABLE_SCHEMA = @schema";

--- a/src/ServiceStack.OrmLite.SqlServerTests/TypedExtensionTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/TypedExtensionTests.cs
@@ -1,0 +1,68 @@
+﻿using System.Configuration;
+using NUnit.Framework;
+using ServiceStack.DataAnnotations;
+using ServiceStack.OrmLite.SqlServer;
+
+namespace ServiceStack.OrmLite.SqlServerTests
+{
+    public class TypedExtensionTests
+    {
+        public class TestDao
+        {
+            [PrimaryKey]
+            public int Id { get; set; }
+
+            public string Thing { get; set; }
+        }
+
+        private IOrmLiteDialectProvider provider;
+        private OrmLiteConnectionFactory factory;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            provider = new SqlServer2014OrmLiteDialectProvider();
+            factory = new OrmLiteConnectionFactory(ConfigurationManager.ConnectionStrings["testDb"].ConnectionString, provider, false);
+        }
+
+        [OneTimeTearDown]
+        public void Teardown()
+        {
+            OrmLiteConfig.DialectProvider = provider;
+
+            using (var connection = factory.OpenDbConnection())
+            {
+                if (connection.TableExists<TestDao>())
+                {
+                    connection.DropTable<TestDao>();
+                }
+            }
+        }
+
+        [Test]
+        public void GivenAnOrmLiteTypedConnectionFactory_WhenUsingOrmLiteExtensionsAndGlobalProviderNotSet_ThenArgumentNullExceptionIsNotThrown()
+        {
+            using (var connection = factory.OpenDbConnection())
+            {
+                Assert.That(() =>
+                {
+                    connection.CreateTableIfNotExists<TestDao>();
+
+                    var dao = new TestDao {Id = 1, Thing = "Thing"};
+
+                    connection.Insert(dao);
+                    connection.SingleById<TestDao>(1);
+
+                    dao.Thing = "New Thing";
+
+                    connection.Update(dao, d => d.Id == dao.Id);
+
+                    connection.Delete(dao);
+
+                    connection.DropTable<TestDao>();
+
+                }, Throws.Nothing);
+            }
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -503,7 +503,7 @@ namespace ServiceStack.OrmLite
                 && sqlFilter.TrimStart().StartsWith(SelectStatement, StringComparison.OrdinalIgnoreCase);
 
             if (isFullSelectStatement)
-                return sqlFilter.SqlFmt(filterParams);
+                return sqlFilter.SqlFmt(this, filterParams);
 
             var modelDef = tableType.GetModelDefinition();
             var sql = StringBuilderCache.Allocate();
@@ -512,7 +512,7 @@ namespace ServiceStack.OrmLite
             if (string.IsNullOrEmpty(sqlFilter))
                 return StringBuilderCache.ReturnAndFree(sql);
 
-            sqlFilter = sqlFilter.SqlFmt(filterParams);
+            sqlFilter = sqlFilter.SqlFmt(this, filterParams);
             if (!sqlFilter.StartsWith("ORDER ", StringComparison.OrdinalIgnoreCase)
                 && !sqlFilter.StartsWith("LIMIT ", StringComparison.OrdinalIgnoreCase))
             {
@@ -1184,7 +1184,7 @@ namespace ServiceStack.OrmLite
                 && sqlFilter.Substring(0, deleteStatement.Length).ToUpper().Equals(deleteStatement);
 
             if (isFullDeleteStatement)
-                return sqlFilter.SqlFmt(filterParams);
+                return sqlFilter.SqlFmt(this, filterParams);
 
             var modelDef = tableType.GetModelDefinition();
             sql.Append($"DELETE FROM {GetQuotedTableName(modelDef)}");
@@ -1192,7 +1192,7 @@ namespace ServiceStack.OrmLite
             if (string.IsNullOrEmpty(sqlFilter))
                 return StringBuilderCache.ReturnAndFree(sql);
 
-            sqlFilter = sqlFilter.SqlFmt(filterParams);
+            sqlFilter = sqlFilter.SqlFmt(this, filterParams);
             sql.Append(" WHERE ");
             sql.Append(sqlFilter);
 


### PR DESCRIPTION
My team at the company I work for are in the process of migrating from one DBMS to another. In this situation we can't set the global dialect provider as it causes syntax errors across the DBMSs.

This pull request fixes the issue for us for SQL Server, unless there is something we are doing wrong?

When attempting to use ORMLite extensions against and OrmLiteConnection an ArgumentNullException was thrown when calling to SqlFmt as the global provider was not set.
Using SqlFmt overload that accepts the current dialect provider stops the ArgumentNullException.