### PR TITLE
Added 3 JSON Sql methods to the SQLServer 2016 Dialect Provider

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServer.Converters/ServiceStack.OrmLite.SqlServer.Converters.csproj
+++ b/src/ServiceStack.OrmLite.SqlServer.Converters/ServiceStack.OrmLite.SqlServer.Converters.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="Microsoft.SqlServer.Types" Version="11.0.2" />
+    <PackageReference Include="Microsoft.SqlServer.Types" Version="14.0.314.76" />
     <ProjectReference Include="..\ServiceStack.OrmLite\ServiceStack.OrmLite.csproj" />
     <ProjectReference Include="..\ServiceStack.OrmLite.SqlServer\ServiceStack.OrmLite.SqlServer.csproj" />
     <Reference Include="..\..\lib\net45\ServiceStack.Text.dll" />

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServer2016Expression.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServer2016Expression.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq.Expressions;
+using System.Text;
+using ServiceStack.OrmLite;
+using ServiceStack.OrmLite.SqlServer.Converters;
+using ServiceStack.Text;
+
+namespace ServiceStack.OrmLite.SqlServer
+{
+    public class SqlServer2016Expression<T> : SqlServerExpression<T>
+    {
+        public SqlServer2016Expression(IOrmLiteDialectProvider dialectProvider)
+            : base(dialectProvider) {}
+
+        protected override object VisitSqlMethodCall(MethodCallExpression m)
+        {
+            List<object> args = VisitInSqlExpressionList(m.Arguments);
+            object quotedColName = args[0];
+            args.RemoveAt(0);
+
+            string statement;
+
+            switch (m.Method.Name)
+            {
+                case nameof(Sql.In):
+                    statement = ConvertInExpressionToSql(m, quotedColName);
+                    break;
+                case nameof(Sql.Desc):
+                    statement = $"{quotedColName} DESC";
+                    break;
+                case nameof(Sql.As):
+                    statement = $"{quotedColName} AS {DialectProvider.GetQuotedColumnName(RemoveQuoteFromAlias(args[0].ToString()))}";
+                    break;
+                case nameof(Sql.Sum):
+                case nameof(Sql.Count):
+                case nameof(Sql.Min):
+                case nameof(Sql.Max):
+                case nameof(Sql.Avg):
+                    statement = $"{m.Method.Name}({quotedColName}{(args.Count == 1 ? $",{args[0]}" : "")})";
+                    break;
+                case nameof(Sql.CountDistinct):
+                    statement = $"COUNT(DISTINCT {quotedColName})";
+                    break;
+                case nameof(Sql.AllFields):
+                    var argDef = m.Arguments[0].Type.GetModelMetadata();
+                    statement = DialectProvider.GetQuotedTableName(argDef) + ".*";
+                    break;
+                case nameof(Sql.JoinAlias):
+                    statement = args[0] + "." + quotedColName.ToString().LastRightPart('.');
+                    break;
+                case nameof(Sql.Custom):
+                    statement = quotedColName.ToString();
+                    break;
+                case nameof(Sql2016.IsJson):
+                    statement = $"ISJSON({quotedColName})";
+                    break;
+                case nameof(Sql2016.JsonValue):
+                    statement = $"JSON_VALUE({quotedColName}, '{args[0]}')";
+                    break;
+                case nameof(Sql2016.JsonQuery):
+                    statement = $"JSON_QUERY({quotedColName}";
+                    if (DialectProvider is SqlServer2017OrmLiteDialectProvider && args.Count > 0)
+                    {
+                        statement += $", '{args[0]}'";
+                    }
+                    statement += ")";
+                    break;
+                default:
+                    throw new NotSupportedException();
+            }
+
+            return new PartialSqlString(statement);
+        }
+    }
+}
+
+namespace ServiceStack.OrmLite
+{
+    public static class Sql2016
+    {
+        /// <summary>Tests whether a string contains valid JSON.</summary>
+        /// <param name="expression">The string to test.</param>
+        /// <returns>Returns True if the string contains valid JSON; otherwise, returns False. Returns null if expression is null.</returns>
+        /// <remarks>ISJSON does not check the uniqueness of keys at the same level.</remarks>
+        /// <see cref="https://docs.microsoft.com/en-us/sql/t-sql/functions/isjson-transact-sql"/>
+        public static bool? IsJson(string expression) => null;
+
+        /// <summary>Extracts a scalar value from a JSON string.</summary>
+        /// <param name="expression">
+        /// An expression. Typically the name of a variable or a column that contains JSON text.<br/><br/>
+        /// If <b>JSON_VALUE</b> finds JSON that is not valid in expression before it finds the value identified by <i>path</i>, the function returns an error. If <b>JSON_VALUE</b> doesn't find the value identified by <i>path</i>, it scans the entire text and returns an error if it finds JSON that is not valid anywhere in <i>expression</i>.
+        /// </param>
+        /// <param name="path">
+        /// A JSON path that specifies the property to extract. For more info, see <see cref="https://docs.microsoft.com/en-us/sql/relational-databases/json/json-path-expressions-sql-server">JSON Path Expressions (SQL Server)</see>.<br/><br/>
+        /// In SQL Server 2017 and in Azure SQL Database, you can provide a variable as the value of <i>path</i>.<br/><br/> 
+        /// If the format of path isn't valid, <b>JSON_VALUE</b> returns an error.<br/><br/>
+        /// </param>
+        /// <returns>
+        /// Returns a single text value of type nvarchar(4000). The collation of the returned value is the same as the collation of the input expression.
+        /// If the value is greater than 4000 characters: <br/><br/>
+        /// <ul>
+        /// <li>In lax mode, <b>JSON_VALUE</b> returns null.</li>
+        /// <li>In strict mode, <b>JSON_VALUE</b> returns an error.</li>
+        /// </ul>
+        /// <br/>
+        /// If you have to return scalar values greater than 4000 characters, use <b>OPENJSON</b> instead of <b>JSON_VALUE</b>. For more info, see <see cref="https://docs.microsoft.com/en-us/sql/t-sql/functions/openjson-transact-sql">OPENJSON (Transact-SQL)</see>.
+        /// </returns>
+        /// <see cref="https://docs.microsoft.com/en-us/sql/t-sql/functions/json-value-transact-sql"/>
+        public static T JsonValue<T>(string expression, string path) => default(T);
+
+        /// <summary>Extracts a scalar value from a JSON string.</summary>
+        /// <param name="expression">
+        /// An expression. Typically the name of a variable or a column that contains JSON text.<br/><br/>
+        /// If <b>JSON_VALUE</b> finds JSON that is not valid in expression before it finds the value identified by <i>path</i>, the function returns an error. If <b>JSON_VALUE</b> doesn't find the value identified by <i>path</i>, it scans the entire text and returns an error if it finds JSON that is not valid anywhere in <i>expression</i>.
+        /// </param>
+        /// <param name="path">
+        /// A JSON path that specifies the property to extract. For more info, see <see cref="https://docs.microsoft.com/en-us/sql/relational-databases/json/json-path-expressions-sql-server">JSON Path Expressions (SQL Server)</see>.<br/><br/>
+        /// In SQL Server 2017 and in Azure SQL Database, you can provide a variable as the value of <i>path</i>.<br/><br/> 
+        /// If the format of path isn't valid, <b>JSON_VALUE</b> returns an error.<br/><br/>
+        /// </param>
+        /// <returns>
+        /// Returns a single text value of type nvarchar(4000). The collation of the returned value is the same as the collation of the input expression.
+        /// If the value is greater than 4000 characters: <br/><br/>
+        /// <ul>
+        /// <li>In lax mode, <b>JSON_VALUE</b> returns null.</li>
+        /// <li>In strict mode, <b>JSON_VALUE</b> returns an error.</li>
+        /// </ul>
+        /// <br/>
+        /// If you have to return scalar values greater than 4000 characters, use <b>OPENJSON</b> instead of <b>JSON_VALUE</b>. For more info, see <see cref="https://docs.microsoft.com/en-us/sql/t-sql/functions/openjson-transact-sql">OPENJSON (Transact-SQL)</see>.
+        /// </returns>
+        /// <see cref="https://docs.microsoft.com/en-us/sql/t-sql/functions/json-value-transact-sql"/>
+        public static string JsonValue(string expression, string path) => 
+            $"JSON_VALUE({expression}, '{path}')";
+
+        /// <summary>
+        /// Extracts an object or an array from a JSON string.<br/><br/>
+        /// To extract a scalar value from a JSON string instead of an object or an array, see <see cref="https://docs.microsoft.com/en-us/sql/t-sql/functions/json-value-transact-sql">JSON_VALUE(Transact-SQL)</see>. 
+        /// For info about the differences between <b>JSON_VALUE</b> and <b>JSON_QUERY</b>, see <see cref="https://docs.microsoft.com/en-us/sql/relational-databases/json/validate-query-and-change-json-data-with-built-in-functions-sql-server#JSONCompare">Compare JSON_VALUE and JSON_QUERY</see>.
+        /// </summary>
+        /// <typeparam name="T">Type of objects returned</typeparam>
+        /// <param name="expression">
+        /// An expression. Typically the name of a variable or a column that contains JSON text.<br/><br/>
+        /// If <b>JSON_QUERY</b> finds JSON that is not valid in <i>expression</i> before it finds the value identified by <i>path</i>, the function returns an error. If <b>JSON_QUERY</b> doesn't find the value identified by <i>path</i>, it scans the entire text and returns an error if it finds JSON that is not valid anywhere in <i>expression</i>.
+        /// </param>
+        /// <param name="path">
+        /// A JSON path that specifies the object or the array to extract.<br/><br/>
+        /// In SQL Server 2017 and in Azure SQL Database, you can provide a variable as the value of <i>path</i>.<br/><br/>
+        /// The JSON path can specify lax or strict mode for parsing.If you don't specify the parsing mode, lax mode is the default. For more info, see <see cref="https://docs.microsoft.com/en-us/sql/relational-databases/json/json-path-expressions-sql-server">JSON Path Expressions (SQL Server)</see>.<br/><br/>
+        /// The default value for path is '$'. As a result, if you don't provide a value for path, <b>JSON_QUERY</b> returns the input <i>expression</i>.<br/><br/>
+        /// If the format of <i>path</i> isn't valid, <b>JSON_QUERY</b> returns an error.
+        /// </param>
+        /// <returns>
+        /// Returns a JSON fragment of type T. The collation of the returned value is the same as the collation of the input expression.<br/><br/>
+        /// If the value is not an object or an array:
+        /// <ul>
+        /// <li>In lax mode, <b>JSON_QUERY</b> returns null.</li>
+        /// <li>In strict mode, <b>JSON_QUERY</b> returns an error.</li>
+        /// </ul>
+        /// </returns>
+        public static T JsonQuery<T>(string expression, string path = null) => default(T);
+
+        /// <summary>
+        /// Extracts an object or an array from a JSON string.<br/><br/>
+        /// To extract a scalar value from a JSON string instead of an object or an array, see <see cref="https://docs.microsoft.com/en-us/sql/t-sql/functions/json-value-transact-sql">JSON_VALUE(Transact-SQL)</see>. 
+        /// For info about the differences between <b>JSON_VALUE</b> and <b>JSON_QUERY</b>, see <see cref="https://docs.microsoft.com/en-us/sql/relational-databases/json/validate-query-and-change-json-data-with-built-in-functions-sql-server#JSONCompare">Compare JSON_VALUE and JSON_QUERY</see>.
+        /// </summary>
+        /// <typeparam name="T">Type of objects returned</typeparam>
+        /// <param name="expression">
+        /// An expression. Typically the name of a variable or a column that contains JSON text.<br/><br/>
+        /// If <b>JSON_QUERY</b> finds JSON that is not valid in <i>expression</i> before it finds the value identified by <i>path</i>, the function returns an error. If <b>JSON_QUERY</b> doesn't find the value identified by <i>path</i>, it scans the entire text and returns an error if it finds JSON that is not valid anywhere in <i>expression</i>.
+        /// </param>
+        /// <param name="path">
+        /// A JSON path that specifies the object or the array to extract.<br/><br/>
+        /// In SQL Server 2017 and in Azure SQL Database, you can provide a variable as the value of <i>path</i>.<br/><br/>
+        /// The JSON path can specify lax or strict mode for parsing.If you don't specify the parsing mode, lax mode is the default. For more info, see <see cref="https://docs.microsoft.com/en-us/sql/relational-databases/json/json-path-expressions-sql-server">JSON Path Expressions (SQL Server)</see>.<br/><br/>
+        /// The default value for path is '$'. As a result, if you don't provide a value for path, <b>JSON_QUERY</b> returns the input <i>expression</i>.<br/><br/>
+        /// If the format of <i>path</i> isn't valid, <b>JSON_QUERY</b> returns an error.
+        /// </param>
+        /// <returns>
+        /// Returns a JSON fragment of type T. The collation of the returned value is the same as the collation of the input expression.<br/><br/>
+        /// If the value is not an object or an array:
+        /// <ul>
+        /// <li>In lax mode, <b>JSON_QUERY</b> returns null.</li>
+        /// <li>In strict mode, <b>JSON_QUERY</b> returns an error.</li>
+        /// </ul>
+        /// </returns>
+        public static string JsonQuery(string expression, string path = null) =>
+            (path.Contains("$")) 
+                ? $"JSON_QUERY({expression}, '{path}')"
+                : $"JSON_QUERY({expression})";
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServer2016OrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServer2016OrmLiteDialectProvider.cs
@@ -8,5 +8,7 @@ namespace ServiceStack.OrmLite.SqlServer
     public class SqlServer2016OrmLiteDialectProvider : SqlServer2014OrmLiteDialectProvider
     {
         public new static SqlServer2016OrmLiteDialectProvider Instance = new SqlServer2016OrmLiteDialectProvider();
+
+        public override SqlExpression<T> SqlExpression<T>() => new SqlServer2016Expression<T>(this);
     }
 }

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServer2017OrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServer2017OrmLiteDialectProvider.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Data;
+using System.Text;
+using ServiceStack.Text;
+
+namespace ServiceStack.OrmLite.SqlServer
+{
+    public class SqlServer2017OrmLiteDialectProvider : SqlServer2016OrmLiteDialectProvider
+    {
+        public new static SqlServer2017OrmLiteDialectProvider Instance = new SqlServer2017OrmLiteDialectProvider();
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerDialect.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerDialect.cs
@@ -21,4 +21,9 @@ namespace ServiceStack.OrmLite
     {
         public static IOrmLiteDialectProvider Provider => SqlServer2016OrmLiteDialectProvider.Instance;
     }
+
+    public static class SqlServer2017Dialect
+    {
+        public static IOrmLiteDialectProvider Provider => SqlServer2017OrmLiteDialectProvider.Instance;
+    }
 }

--- a/src/ServiceStack.OrmLite.SqlServerTests/Expressions/JsonExpressionsTest.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/Expressions/JsonExpressionsTest.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Data;
+using System.Linq;
+using NUnit.Framework;
+
+namespace ServiceStack.OrmLite.SqlServerTests.Expressions
+{
+    public class JsonExpressionsTest : ExpressionsTestBase
+    {
+        [Test]
+        public void Can_select_json_scalar_value()
+        {
+            OrmLiteConfig.DialectProvider = SqlServer2016Dialect.Provider;
+
+            OpenDbConnection().CreateTableIfNotExists<TestType>();
+            OpenDbConnection().DeleteAll<TestType>();
+
+            var obj = new { Address = new Address { Line1 = "1234 Main Street", Line2 = "Apt. 404", City = "Las Vegas", State = "NV" } };
+            var stringValue = obj.ToJson(); //"{ \"Address\": { \"Line1\": \"1234 Main Street\", \"Line2\": \"Apt. 404\", \"City\": \"Las Vegas\", \"State\": \"NV\" } }"
+
+            OpenDbConnection().Insert(new TestType() { StringColumn = stringValue });
+
+            var actual = OpenDbConnection().Select<TestType>(q => 
+                Sql2016.JsonValue(q.StringColumn, "$.address.state") == "NV");
+
+            Assert.AreEqual(obj.Address.State, actual);
+        }
+
+        [Test]
+        public void Can_select_json_object_value()
+        {
+            OrmLiteConfig.DialectProvider = SqlServer2016Dialect.Provider;
+
+            OpenDbConnection().CreateTableIfNotExists<TestType>();
+            OpenDbConnection().DeleteAll<TestType>();
+
+            var expected = new Address { Line1 = "1234 Main Street", Line2 = "Apt. 404", City = "Las Vegas", State = "NV" };
+            var obj = new { Address = expected };
+            var stringValue = obj.ToJson(); //"{ \"Address\": { \"Line1\": \"1234 Main Street\", \"Line2\": \"Apt. 404\", \"City\": \"Las Vegas\", \"State\": \"NV\" } }"
+
+            OpenDbConnection().Insert(new TestType() { StringColumn = stringValue });
+
+            var address = OpenDbConnection().From<TestType>().Select(q =>
+                Sql2016.JsonQuery<Address>(q.StringColumn, "$.address")).ConvertTo<Address>();
+
+            Assert.AreEqual(obj.Address, address);
+        }
+
+        internal class Address
+        {
+            public string Line1 { get; set; }
+            public string Line2 { get; set; }
+            public string City { get; set; }
+            public string State { get; set; }
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
+++ b/src/ServiceStack.OrmLite.SqlServerTests/ServiceStack.OrmLite.SqlServerTests.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NUnit" Version="3.7.1" />
     <Reference Include="..\..\lib\pcl\ServiceStack.Interfaces.dll" />
   </ItemGroup>
 
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="Microsoft.SqlServer.Types" Version="11.0.2" />
+    <PackageReference Include="Microsoft.SqlServer.Types" Version="14.0.314.76" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Threading" />


### PR DESCRIPTION
Added a few of the JSON SQL methods to the SqlServer 2016 Dialect Provider so developers can parse and query JSON objects and arrays directly from SQL Server. This should be helpful for developers who dump raw JSON into a single string field (NVARCHAR) and still need the ability to query this data. 

For example, if a developer stores an entire address as JSON into a single field and need to only query those where State = "NY", this should make it easier and much more efficient.

Note that my NUnit test adapter has been malfunctioning and I wasn't able to execute the tests, so you may find a few errors. Sorry ;-(.