### PR TITLE
Feature/rowversion: make RowVersion logic cater for ulong and byte[] properties

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServer/Converters/SqlServerSpecialConverters.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/Converters/SqlServerSpecialConverters.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Data;
 using ServiceStack.OrmLite.Converters;
 
 namespace ServiceStack.OrmLite.SqlServer.Converters
@@ -16,8 +15,11 @@ namespace ServiceStack.OrmLite.SqlServer.Converters
             var bytes = value as byte[];
             if (bytes != null)
             {
-                var ulongValue = OrmLiteUtils.ConvertToULong(bytes);
-                return ulongValue;
+	            if (fieldType == typeof(byte[])) return bytes;
+				if (fieldType == typeof(ulong)) return OrmLiteUtils.ConvertToULong(bytes);
+
+                // an SQL row version has to be declared as either byte[] OR ulong... 
+				throw new Exception("SQL Rowversion property must be declared as either byte[] or ulong");
             }
             return null;
         }

--- a/src/ServiceStack.OrmLite.SqlServer/Converters/SqlServerSpecialConverters.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/Converters/SqlServerSpecialConverters.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using ServiceStack.OrmLite.Converters;
+﻿using ServiceStack.OrmLite.Converters;
 
 namespace ServiceStack.OrmLite.SqlServer.Converters
 {
@@ -9,35 +8,5 @@ namespace ServiceStack.OrmLite.SqlServer.Converters
         {
             get { return "rowversion"; }
         }
-
-        public override object FromDbValue(Type fieldType, object value)
-        {
-            var bytes = value as byte[];
-            if (bytes != null)
-            {
-	            if (fieldType == typeof(byte[])) return bytes;
-				if (fieldType == typeof(ulong)) return OrmLiteUtils.ConvertToULong(bytes);
-
-                // an SQL row version has to be declared as either byte[] OR ulong... 
-				throw new Exception("SQL Rowversion property must be declared as either byte[] or ulong");
-            }
-            return null;
-        }
-
-  //      public override object FromDbRowVersion(Type fieldType, object value)
-  //      {
-  //          var bytes = value as byte[];
-	 //       if (bytes != null)
-	 //       {
-		//        if (fieldType == typeof(byte[])) return bytes;
-		//        if (fieldType == typeof(ulong)) return OrmLiteUtils.ConvertToULong(bytes);
-
-		//        // an SQL row version has to be declared as either byte[] OR ulong... 
-		//        throw new Exception("SQL Rowversion property must be declared as either byte[] or ulong");
-	 //       }
-		//	//var ulongValue = OrmLiteUtils.ConvertToULong(bytes);
-		//	//return ulongValue;
-		//	throw new Exception("Rowversion could not be parsed as byte array");
-		//}
     }
 }

--- a/src/ServiceStack.OrmLite.SqlServer/Converters/SqlServerSpecialConverters.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/Converters/SqlServerSpecialConverters.cs
@@ -24,11 +24,20 @@ namespace ServiceStack.OrmLite.SqlServer.Converters
             return null;
         }
 
-        public override ulong FromDbRowVersion(object value)
-        {
-            var bytes = value as byte[];
-            var ulongValue = OrmLiteUtils.ConvertToULong(bytes);
-            return ulongValue;
-        }
+  //      public override object FromDbRowVersion(Type fieldType, object value)
+  //      {
+  //          var bytes = value as byte[];
+	 //       if (bytes != null)
+	 //       {
+		//        if (fieldType == typeof(byte[])) return bytes;
+		//        if (fieldType == typeof(ulong)) return OrmLiteUtils.ConvertToULong(bytes);
+
+		//        // an SQL row version has to be declared as either byte[] OR ulong... 
+		//        throw new Exception("SQL Rowversion property must be declared as either byte[] or ulong");
+	 //       }
+		//	//var ulongValue = OrmLiteUtils.ConvertToULong(bytes);
+		//	//return ulongValue;
+		//	throw new Exception("Rowversion could not be parsed as byte array");
+		//}
     }
 }

--- a/src/ServiceStack.OrmLite.SqlServerTests/RowVersionTests.cs
+++ b/src/ServiceStack.OrmLite.SqlServerTests/RowVersionTests.cs
@@ -1,0 +1,253 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using ServiceStack.Data;
+using ServiceStack.DataAnnotations;
+using ServiceStack.OrmLite.Dapper;
+
+namespace ServiceStack.OrmLite.SqlServerTests
+{
+	[TestFixture]
+	public class RowVersionTests : OrmLiteTestBase
+	{
+		public class ByteChildTbl
+		{
+			[PrimaryKey]
+			public Guid Id { get; set; }
+
+			[References(typeof(ByteTbl))]
+			public Guid ParentId { get; set; }
+
+			[RowVersion]
+			public byte[] RowVersion { get; set; }
+
+			
+		}
+
+		public class ByteTbl
+		{
+			[PrimaryKey]
+			public Guid Id { get; set; }
+
+			public string Text { get; set; }
+
+			[RowVersion]
+			public byte[] RowVersion { get; set; }
+
+			[Reference]
+			public List<ByteChildTbl> Children { get; set; } = new List<ByteChildTbl>();
+		}
+
+		public class UlongChildTbl
+		{
+			[PrimaryKey]
+			public Guid Id { get; set; }
+
+			[References(typeof(UlongTbl))]
+			public Guid ParentId { get; set; }
+
+			[RowVersion]
+			public ulong RowVersion { get; set; }
+		}
+
+		public class UlongTbl
+		{
+			[PrimaryKey]
+			public Guid Id { get; set; }
+
+			public string Text { get; set; }
+
+			// Use of ulong makes embedded Dapper functionality unavailable
+			[RowVersion]
+			public ulong RowVersion { get; set; }
+
+			[Reference]
+			public List<UlongChildTbl> Children { get; set; } = new List<UlongChildTbl>();
+		}
+
+		[Test]
+		public void Read_and_write_to_tables_with_rowversions()
+		{
+			using (var db = OpenDbConnection())
+			{
+				// Show that we can drop and create tables with rowversions of both .NET types and both get created as ROWVERSION in MSSQL
+				db.DropTable<ByteChildTbl>();
+				db.DropTable<ByteTbl>();
+				db.DropTable<UlongChildTbl>();
+				db.DropTable<UlongTbl>();
+				db.CreateTable<ByteTbl>();
+				db.CreateTable<ByteChildTbl>();
+				db.CreateTable<UlongTbl>();
+				db.CreateTable<UlongChildTbl>();
+				
+
+
+
+				{
+					// Confirm off new Ormlite CRUD functionality with byte[] rowversion
+
+					var byteId = Guid.NewGuid();
+					db.Insert(new ByteTbl() { Id = byteId });
+
+					var getByteRecord = db.SingleById<ByteTbl>(byteId);
+					getByteRecord.Text += " Updated";
+					db.Update(getByteRecord); //success!
+
+					getByteRecord.Text += "Attempting to update stale record";
+
+					//Can't update stale record
+					Assert.Throws<OptimisticConcurrencyException>(() => db.Update(getByteRecord));
+
+					//Can update latest version
+					var updatedRow = db.SingleById<ByteTbl>(byteId); // fresh version
+					updatedRow.Text += "Update Success!";
+					db.Update(updatedRow);
+
+					updatedRow = db.SingleById<ByteTbl>(byteId);
+					db.Delete(updatedRow); // can delete fresh version
+				}
+
+
+				{
+					// confirm original Ormlite CRUD functionality based on ulong rowversion
+
+					var ulongId = Guid.NewGuid();
+					db.Insert(new UlongTbl { Id = ulongId });
+
+					var getUlongRecord = db.SingleById<UlongTbl>(ulongId);
+					getUlongRecord.Text += " Updated";
+					db.Update(getUlongRecord); //success!
+
+					getUlongRecord.Text += "Attempting to update stale record";
+
+					//Can't update stale record
+					Assert.Throws<OptimisticConcurrencyException>(() => db.Update(getUlongRecord));
+
+					// Can update latest version
+					var updatedUlongRow = db.SingleById<UlongTbl>(ulongId); // fresh version
+					updatedUlongRow.Text += "Update Success!";
+					db.Update(updatedUlongRow);
+
+					updatedUlongRow = db.SingleById<UlongTbl>(ulongId);
+					db.Delete(updatedUlongRow); // can delete fresh version
+				}
+
+
+				{
+					// Confirm that original ulong rowversion unfortunately fails with Dapper custom sql queries
+
+					var ulongId = Guid.NewGuid();
+					db.Insert(new UlongTbl { Id = ulongId });
+
+					// As a further example, using Dapper but without rowversion column WILL work (but rowversion will NOT be set of course)
+					var thisDapperQryWorks = db.Query<UlongTbl>("select Id, Text from [UlongTbl]").ToList();
+					Assert.True(thisDapperQryWorks.Count == 1);
+
+					// But any time RowVersion as ulong is include... no joy.. the map from db rowversion to ulong in dapper fails
+					Assert.Throws<System.Data.DataException>(() => db.Query<UlongTbl>("select  Id, Text, Rowversion from [UlongTbl]"));
+				}
+
+
+				{
+					// Now test out use of new byte[] rowversion with Dapper custom sql queries
+
+					var byteId = Guid.NewGuid();
+					db.Insert(new ByteTbl { Id = byteId });
+
+					// As a further example, using Dapper but without rowversion column WILL work, BUT the rowversion WONT BE SET (of course)
+					var thisDapperQryWorks = db.Query<ByteTbl>("select Id, Text from [ByteTbl]").ToList();
+					Assert.True(thisDapperQryWorks.Count == 1);
+					Assert.True(thisDapperQryWorks.First().RowVersion == default(byte[]));
+
+					// But any time RowVersion as ulong is include... no joy.. the map from db rowversion to ulong in dapper fails
+					var thisDapperQryWithRowVersionAlsoWorks = db.Query<ByteTbl>("select  Id, Text, Rowversion from [ByteTbl]").ToList();
+					Assert.True(thisDapperQryWithRowVersionAlsoWorks.Count == 1);
+					Assert.True(thisDapperQryWithRowVersionAlsoWorks.First().RowVersion != default(byte[]));
+				}
+
+
+				{
+					// test original ulong version with child operations
+					var ulongId1 = Guid.NewGuid();
+					db.Insert(new UlongTbl
+					{
+						Id = ulongId1,
+						Children = new List<UlongChildTbl>()
+						{
+							new UlongChildTbl { Id = Guid.NewGuid() },
+							new UlongChildTbl { Id = Guid.NewGuid() }
+						}
+					});
+					db.LoadSelect<UlongTbl>(x => x.Id == ulongId1);
+
+					var ulongId2 = Guid.NewGuid();
+					db.Save(new UlongTbl
+					{
+						Id = ulongId2,
+						Children = new List<UlongChildTbl>()
+						{
+							new UlongChildTbl {Id = Guid.NewGuid()},
+							new UlongChildTbl {Id = Guid.NewGuid()}
+						}
+					});
+					db.LoadSelect<UlongTbl>(x => x.Id == ulongId2);
+
+					// COnfirm multip select logic works
+					var q = db.From<UlongTbl>()
+							.Join<UlongTbl, UlongChildTbl>()
+						;
+					var results = db.SelectMulti<UlongTbl, UlongChildTbl>(q);
+					foreach (var tuple in results)
+					{
+						UlongTbl parent = tuple.Item1;
+						UlongChildTbl child = tuple.Item2;
+					}
+				}
+
+				{
+					// test byte[] version with child operations
+					var byteid1 = Guid.NewGuid();
+					db.Insert(new ByteTbl
+					{
+						Id = byteid1,
+						Children = new List<ByteChildTbl>()
+						{
+							new ByteChildTbl() { Id = Guid.NewGuid() },
+							new ByteChildTbl { Id = Guid.NewGuid() }
+						}
+					});
+					var result = db.LoadSelect<ByteTbl>(x => x.Id == byteid1);
+
+					var byteid2 = Guid.NewGuid();
+					db.Save(new ByteTbl
+					{
+						Id = byteid2,
+						Children = new List<ByteChildTbl>()
+						{
+							new ByteChildTbl {Id = Guid.NewGuid()},
+							new ByteChildTbl {Id = Guid.NewGuid()}
+						}
+					});
+					db.LoadSelect<ByteTbl>(x => x.Id == byteid2);
+
+					// COnfirm multip select logic works
+					var q = db.From<ByteTbl>()
+							.Join<ByteTbl, ByteChildTbl>()
+						;
+					var results = db.SelectMulti<ByteTbl, ByteChildTbl>(q);
+					foreach (var tuple in results)
+					{
+						ByteTbl parent = tuple.Item1;
+						ByteChildTbl child = tuple.Item2;
+					}
+				}
+
+				//Console.WriteLine("hit a key to end test");
+				//Console.ReadLine();
+
+
+			}
+		}
+	}
+}

--- a/src/ServiceStack.OrmLite/Async/OrmLiteWriteCommandExtensionsAsync.cs
+++ b/src/ServiceStack.OrmLite/Async/OrmLiteWriteCommandExtensionsAsync.cs
@@ -523,11 +523,11 @@ namespace ServiceStack.OrmLite
             return dbCommand.ExecuteSqlAsync(sql, token);
         }
 
-        internal static Task<ulong> GetRowVersionAsync(this IDbCommand dbCmd, ModelDefinition modelDef, object id, CancellationToken token)
+        internal static Task<object> GetRowVersionAsync(this IDbCommand dbCmd, ModelDefinition modelDef, object id, CancellationToken token)
         {
             var sql = dbCmd.RowVersionSql(modelDef, id);
-            return dbCmd.ScalarAsync<ulong>(sql, token)
-                .Success(x => dbCmd.GetDialectProvider().FromDbRowVersion(x));
+            return dbCmd.ScalarAsync<object>(sql, token)
+                .Success(x => dbCmd.GetDialectProvider().FromDbRowVersion(modelDef.RowVersion.FieldType, x));
         }
     }
 }

--- a/src/ServiceStack.OrmLite/Converters/SpecialConverters.cs
+++ b/src/ServiceStack.OrmLite/Converters/SpecialConverters.cs
@@ -67,14 +67,6 @@ namespace ServiceStack.OrmLite.Converters
     {
         public override string ColumnDefinition => "BIGINT";
 
-        public virtual object FromDbRowVersion(Type fieldType, object value)
-        {
-            //return (ulong)this.ConvertNumber(typeof(ulong), value);
-
-	        return this.FromDbValue(fieldType, value);
-        }
-
-
         public override object FromDbValue(Type fieldType, object value)
         {
 	        var bytes = value as byte[];
@@ -84,7 +76,7 @@ namespace ServiceStack.OrmLite.Converters
 		        if (fieldType == typeof(ulong)) return OrmLiteUtils.ConvertToULong(bytes);
 
 		        // an SQL row version has to be declared as either byte[] OR ulong... 
-		        throw new Exception("SQL Rowversion property must be declared as either byte[] or ulong");
+		        throw new Exception("Rowversion property must be declared as either byte[] or ulong");
 	        }
 	        return null;
         }

--- a/src/ServiceStack.OrmLite/Converters/SpecialConverters.cs
+++ b/src/ServiceStack.OrmLite/Converters/SpecialConverters.cs
@@ -67,16 +67,26 @@ namespace ServiceStack.OrmLite.Converters
     {
         public override string ColumnDefinition => "BIGINT";
 
-        public virtual ulong FromDbRowVersion(object value)
+        public virtual object FromDbRowVersion(Type fieldType, object value)
         {
-            return (ulong)this.ConvertNumber(typeof(ulong), value);
+            //return (ulong)this.ConvertNumber(typeof(ulong), value);
+
+	        return this.FromDbValue(fieldType, value);
         }
+
 
         public override object FromDbValue(Type fieldType, object value)
         {
-            return value != null
-                ? this.ConvertNumber(typeof(ulong), value)
-                : null;
+	        var bytes = value as byte[];
+	        if (bytes != null)
+	        {
+		        if (fieldType == typeof(byte[])) return bytes;
+		        if (fieldType == typeof(ulong)) return OrmLiteUtils.ConvertToULong(bytes);
+
+		        // an SQL row version has to be declared as either byte[] OR ulong... 
+		        throw new Exception("SQL Rowversion property must be declared as either byte[] or ulong");
+	        }
+	        return null;
         }
     }
 

--- a/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite/IOrmLiteDialectProvider.cs
@@ -161,7 +161,8 @@ namespace ServiceStack.OrmLite
 
         void DropColumn(IDbConnection db, Type modelType, string columnName);
 
-        ulong FromDbRowVersion(object value);
+        object FromDbRowVersion(Type fieldType,  object value);
+
         SelectItem GetRowVersionColumnName(FieldDefinition field, string tablePrefix = null);
 
         string GetColumnNames(ModelDefinition modelDef);

--- a/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
@@ -95,7 +95,7 @@ namespace ServiceStack.OrmLite
                     || propertyInfo.HasAttributeNamed(typeof(PrimaryKeyAttribute).Name);
 
                 var isRowVersion = propertyInfo.Name == ModelDefinition.RowVersionName
-                    && propertyInfo.PropertyType == typeof(ulong);
+                    && (propertyInfo.PropertyType == typeof(ulong) || propertyInfo.PropertyType == typeof(byte[]));
 
                 var isNullableType = propertyInfo.PropertyType.IsNullableType();
 

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -252,12 +252,12 @@ namespace ServiceStack.OrmLite
             return converter == null || converter is NativeValueOrmLiteConverter;
         }
 
-        public virtual object FromDbRowVersion(Type fieldType, object value)
-        {
-            return RowVersionConverter.FromDbRowVersion(fieldType, value);
-        }
+		public virtual object FromDbRowVersion(Type fieldType, object value)
+		{
+			return RowVersionConverter.FromDbValue(fieldType, value);
+		}
 
-        public IOrmLiteConverter GetConverterBestMatch(Type type)
+		public IOrmLiteConverter GetConverterBestMatch(Type type)
         {
             var converter = GetConverter(type);
             if (converter != null)

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -252,9 +252,9 @@ namespace ServiceStack.OrmLite
             return converter == null || converter is NativeValueOrmLiteConverter;
         }
 
-        public virtual ulong FromDbRowVersion(object value)
+        public virtual object FromDbRowVersion(Type fieldType, object value)
         {
-            return RowVersionConverter.FromDbRowVersion(value);
+            return RowVersionConverter.FromDbRowVersion(fieldType, value);
         }
 
         public IOrmLiteConverter GetConverterBestMatch(Type type)

--- a/src/ServiceStack.OrmLite/OrmLiteWriteCommandExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteWriteCommandExtensions.cs
@@ -939,10 +939,10 @@ namespace ServiceStack.OrmLite
             dbCmd.ExecuteNonQuery();
         }
 
-        internal static ulong GetRowVersion(this IDbCommand dbCmd, ModelDefinition modelDef, object id)
+        internal static object GetRowVersion(this IDbCommand dbCmd, ModelDefinition modelDef, object id)
         {
             var sql = RowVersionSql(dbCmd, modelDef, id);
-            return dbCmd.GetDialectProvider().FromDbRowVersion(dbCmd.Scalar<object>(sql));
+            return dbCmd.GetDialectProvider().FromDbRowVersion(modelDef.RowVersion.FieldType, dbCmd.Scalar<object>(sql));
         }
 
         internal static string RowVersionSql(this IDbCommand dbCmd, ModelDefinition modelDef, object id)


### PR DESCRIPTION
Follow up to https://forums.servicestack.net/t/cant-use-ormlite-rowversion-and-dapper-custom-sql-in-same-project/4947/4 in which I proposed allowing byte[] properties as RowVersion trackers so that the Dapper functionality embedded in ServiceStack can be used with records containing RowVersions (ulong is inconsistent with Dapper mapping and so crashes when using the two in combination).

All tests implemented for this new functionality are in the RowVersionTests.cs file.

Broadly speaking, the RowVersionConverter has become aware of the tracking field type within the FromDbValue method so that it can decide whether to force a parse to ulong or byte[] , and the FromDbRowVersion method was subsequently made redundant and removed.

The solution builds, BUT i do not have access to the db types other than MS SQL nor could I run those test cases for those other db types - if you can run those tests and let me know if there are any issues, that would be great.