### PR TITLE
fix OrmLiteReadCommandExtensions. SetParameters value is an array type, the genus SetParamValue propType parameter error.

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteReadCommandExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadCommandExtensions.cs
@@ -173,7 +173,7 @@ namespace ServiceStack.OrmLite
                         p.Direction = ParameterDirection.Input;
                         dialectProvider.InitDbParam(p, item.GetType());
 
-                        dialectProvider.SetParamValue(p, item, propType);
+                        dialectProvider.SetParamValue(p, item, item.GetType());
 
                         dbCmd.Parameters.Add(p);
                     }
@@ -238,7 +238,7 @@ namespace ServiceStack.OrmLite
                         p.Direction = ParameterDirection.Input;
                         dialectProvider.InitDbParam(p, item.GetType());
 
-                        dialectProvider.SetParamValue(p, item, propType);
+                        dialectProvider.SetParamValue(p, item, item.GetType());
 
                         dbCmd.Parameters.Add(p);
                     }


### PR DESCRIPTION
Assuming that the anonType parameter is SqlInValues, SetParamValue will pass that the propType type will cause invoke ReferenceTypeConverter.FromDbValue to cause performance problems.