### PR TITLE
SelectOnly support for retrieving only the necessary fields in a POCO.

### DIFF
--- a/src/ServiceStack.OrmLite/ModelDefinition.cs
+++ b/src/ServiceStack.OrmLite/ModelDefinition.cs
@@ -192,7 +192,7 @@ namespace ServiceStack.OrmLite
     {
         private static ModelDefinition definition;
         public static ModelDefinition Definition => definition ?? (definition = typeof(T).GetModelDefinition());
-
+        public static ModelDefinition DynamicDefinition(List<string> fieldNames) => typeof(T).GetModelDefinition(fieldNames);
         private static string primaryKeyName;
         public static string PrimaryKeyName => primaryKeyName ?? (primaryKeyName = Definition.PrimaryKey.FieldName);
     }

--- a/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConfigExtensions.cs
@@ -38,9 +38,9 @@ namespace ServiceStack.OrmLite
             typeModelDefinitionMap = new Dictionary<Type, ModelDefinition>();
         }
 
-        internal static ModelDefinition GetModelDefinition(this Type modelType)
+        internal static ModelDefinition GetModelDefinition(this Type modelType, List<string> fieldNames = null)
         {
-            if (typeModelDefinitionMap.TryGetValue(modelType, out var modelDef))
+            if (typeModelDefinitionMap.TryGetValue(modelType, out var modelDef) && fieldNames == null)
                 return modelDef;
 
             if (modelType.IsValueType || modelType == typeof(string))
@@ -74,7 +74,10 @@ namespace ServiceStack.OrmLite
 
             var objProperties = modelType.GetProperties(
                 BindingFlags.Public | BindingFlags.Instance).ToList();
-
+            if (fieldNames != null)
+            {
+                objProperties = objProperties.Where(x => fieldNames.Contains(x.Name)).ToList();
+            }
             var hasPkAttr = objProperties.Any(p => p.HasAttribute<PrimaryKeyAttribute>());
 
             var hasIdField = CheckForIdField(objProperties);

--- a/src/ServiceStack.OrmLite/OrmLiteReadApi.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadApi.cs
@@ -76,6 +76,11 @@ namespace ServiceStack.OrmLite
             return dbConn.Exec(dbCmd => dbCmd.Select<TModel>(fromTableType));
         }
 
+        public static List<TModel> SelectOnly<TModel>(this IDbConnection dbConn, Type fromTableType, Expression<Func<TModel, object>> onlyFields = null)
+        {
+            return dbConn.Exec(dbCmd => dbCmd.SelectOnly<TModel>(fromTableType, onlyFields));
+        }
+
         /// <summary>
         /// Returns results from using a single name, value filter. E.g:
         /// <para>db.Where&lt;Person&gt;("Age", 27)</para>


### PR DESCRIPTION
ModelDefinition will not be cached if the field names are provided.