### PR TITLE
Addition of a Filter to ORMConfig to enable users access to the Ref Sql Statement

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteConfig.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConfig.cs
@@ -176,6 +176,8 @@ namespace ServiceStack.OrmLite
         public static Action<IDbCommand, object> InsertFilter { get; set; }
         public static Action<IDbCommand, object> UpdateFilter { get; set; }
         public static Action<IUntypedSqlExpression> SqlExpressionSelectFilter { get; set; }
+        public static Func<Type, string, string> SqlSelectRefFilter { get; set; }
+
 
         public static Func<string, string> StringFilter { get; set; }
 

--- a/src/ServiceStack.OrmLite/Support/LoadList.cs
+++ b/src/ServiceStack.OrmLite/Support/LoadList.cs
@@ -54,6 +54,9 @@ namespace ServiceStack.OrmLite.Support
                          $"WHERE {dialectProvider.GetQuotedColumnName(refField)} " +
                          $"IN ({subSql})";
 
+            if (OrmLiteConfig.SqlSelectRefFilter != null)
+                sqlRef = OrmLiteConfig.SqlSelectRefFilter?.Invoke(refModelDef.ModelType, sqlRef);
+
             return sqlRef;
         }
 
@@ -98,6 +101,9 @@ namespace ServiceStack.OrmLite.Support
                          $"WHERE {dialectProvider.GetQuotedColumnName(refModelDef.PrimaryKey)} " +
                          $"IN ({subSqlRef})";
 
+            if (OrmLiteConfig.SqlSelectRefFilter != null)
+                sqlRef = OrmLiteConfig.SqlSelectRefFilter?.Invoke(refModelDef.ModelType, sqlRef);
+
             return sqlRef;
         }
 
@@ -107,6 +113,10 @@ namespace ServiceStack.OrmLite.Support
                          $"FROM {dialectProvider.GetQuotedTableName(refModelDef)} " +
                          $"WHERE {dialectProvider.GetQuotedColumnName(refField)} " +
                          $"IN ({subSql})";
+
+            if (OrmLiteConfig.SqlSelectRefFilter != null)
+                sqlRef = OrmLiteConfig.SqlSelectRefFilter?.Invoke(refModelDef.ModelType, sqlRef);
+
             return sqlRef;
         }
 

--- a/src/ServiceStack.OrmLite/Support/LoadList.cs
+++ b/src/ServiceStack.OrmLite/Support/LoadList.cs
@@ -55,7 +55,7 @@ namespace ServiceStack.OrmLite.Support
                          $"IN ({subSql})";
 
             if (OrmLiteConfig.SqlSelectRefFilter != null)
-                sqlRef = OrmLiteConfig.SqlSelectRefFilter?.Invoke(refModelDef.ModelType, sqlRef);
+                sqlRef = OrmLiteConfig.SqlSelectRefFilter.Invoke(refModelDef.ModelType, sqlRef);
 
             return sqlRef;
         }
@@ -102,7 +102,7 @@ namespace ServiceStack.OrmLite.Support
                          $"IN ({subSqlRef})";
 
             if (OrmLiteConfig.SqlSelectRefFilter != null)
-                sqlRef = OrmLiteConfig.SqlSelectRefFilter?.Invoke(refModelDef.ModelType, sqlRef);
+                sqlRef = OrmLiteConfig.SqlSelectRefFilter.Invoke(refModelDef.ModelType, sqlRef);
 
             return sqlRef;
         }
@@ -115,7 +115,7 @@ namespace ServiceStack.OrmLite.Support
                          $"IN ({subSql})";
 
             if (OrmLiteConfig.SqlSelectRefFilter != null)
-                sqlRef = OrmLiteConfig.SqlSelectRefFilter?.Invoke(refModelDef.ModelType, sqlRef);
+                sqlRef = OrmLiteConfig.SqlSelectRefFilter.Invoke(refModelDef.ModelType, sqlRef);
 
             return sqlRef;
         }

--- a/src/ServiceStack.OrmLite/Support/LoadList.cs
+++ b/src/ServiceStack.OrmLite/Support/LoadList.cs
@@ -55,7 +55,7 @@ namespace ServiceStack.OrmLite.Support
                          $"IN ({subSql})";
 
             if (OrmLiteConfig.SqlSelectRefFilter != null)
-                sqlRef = OrmLiteConfig.SqlSelectRefFilter.Invoke(refModelDef.ModelType, sqlRef);
+                sqlRef = OrmLiteConfig.SqlSelectRefFilter(refModelDef.ModelType, sqlRef);
 
             return sqlRef;
         }
@@ -102,7 +102,7 @@ namespace ServiceStack.OrmLite.Support
                          $"IN ({subSqlRef})";
 
             if (OrmLiteConfig.SqlSelectRefFilter != null)
-                sqlRef = OrmLiteConfig.SqlSelectRefFilter.Invoke(refModelDef.ModelType, sqlRef);
+                sqlRef = OrmLiteConfig.SqlSelectRefFilter(refModelDef.ModelType, sqlRef);
 
             return sqlRef;
         }
@@ -115,7 +115,7 @@ namespace ServiceStack.OrmLite.Support
                          $"IN ({subSql})";
 
             if (OrmLiteConfig.SqlSelectRefFilter != null)
-                sqlRef = OrmLiteConfig.SqlSelectRefFilter.Invoke(refModelDef.ModelType, sqlRef);
+                sqlRef = OrmLiteConfig.SqlSelectRefFilter(refModelDef.ModelType, sqlRef);
 
             return sqlRef;
         }

--- a/src/ServiceStack.OrmLite/Support/LoadReferences.cs
+++ b/src/ServiceStack.OrmLite/Support/LoadReferences.cs
@@ -38,6 +38,9 @@ namespace ServiceStack.OrmLite.Support
             var sqlFilter = dialectProvider.GetQuotedColumnName(refField.FieldName) + "={0}";
             var sql = dialectProvider.ToSelectStatement(refType, sqlFilter, pkValue);
 
+            if (OrmLiteConfig.SqlSelectRefFilter != null)
+                sql = OrmLiteConfig.SqlSelectRefFilter?.Invoke(refType, sql);
+
             return sql;
         }
 
@@ -45,6 +48,10 @@ namespace ServiceStack.OrmLite.Support
         {
             var sqlFilter = dialectProvider.GetQuotedColumnName(refField.FieldName) + "={0}";
             var sql = dialectProvider.ToSelectStatement(refType, sqlFilter, pkValue);
+
+            if (OrmLiteConfig.SqlSelectRefFilter != null)
+                sql = OrmLiteConfig.SqlSelectRefFilter?.Invoke(refType, sql);
+
             return sql;
         }
 
@@ -57,6 +64,10 @@ namespace ServiceStack.OrmLite.Support
 
             var sqlFilter = dialectProvider.GetQuotedColumnName(refModelDef.PrimaryKey.FieldName) + "={0}";
             var sql = dialectProvider.ToSelectStatement(refType, sqlFilter, refPkValue);
+
+            if (OrmLiteConfig.SqlSelectRefFilter != null)
+                sql = OrmLiteConfig.SqlSelectRefFilter?.Invoke(refType, sql);
+
             return sql;
         }
     }

--- a/src/ServiceStack.OrmLite/Support/LoadReferences.cs
+++ b/src/ServiceStack.OrmLite/Support/LoadReferences.cs
@@ -39,7 +39,7 @@ namespace ServiceStack.OrmLite.Support
             var sql = dialectProvider.ToSelectStatement(refType, sqlFilter, pkValue);
 
             if (OrmLiteConfig.SqlSelectRefFilter != null)
-                sql = OrmLiteConfig.SqlSelectRefFilter?.Invoke(refType, sql);
+                sql = OrmLiteConfig.SqlSelectRefFilter.Invoke(refType, sql);
 
             return sql;
         }
@@ -50,7 +50,7 @@ namespace ServiceStack.OrmLite.Support
             var sql = dialectProvider.ToSelectStatement(refType, sqlFilter, pkValue);
 
             if (OrmLiteConfig.SqlSelectRefFilter != null)
-                sql = OrmLiteConfig.SqlSelectRefFilter?.Invoke(refType, sql);
+                sql = OrmLiteConfig.SqlSelectRefFilter.Invoke(refType, sql);
 
             return sql;
         }
@@ -66,7 +66,7 @@ namespace ServiceStack.OrmLite.Support
             var sql = dialectProvider.ToSelectStatement(refType, sqlFilter, refPkValue);
 
             if (OrmLiteConfig.SqlSelectRefFilter != null)
-                sql = OrmLiteConfig.SqlSelectRefFilter?.Invoke(refType, sql);
+                sql = OrmLiteConfig.SqlSelectRefFilter.Invoke(refType, sql);
 
             return sql;
         }

--- a/src/ServiceStack.OrmLite/Support/LoadReferences.cs
+++ b/src/ServiceStack.OrmLite/Support/LoadReferences.cs
@@ -39,7 +39,7 @@ namespace ServiceStack.OrmLite.Support
             var sql = dialectProvider.ToSelectStatement(refType, sqlFilter, pkValue);
 
             if (OrmLiteConfig.SqlSelectRefFilter != null)
-                sql = OrmLiteConfig.SqlSelectRefFilter.Invoke(refType, sql);
+                sql = OrmLiteConfig.SqlSelectRefFilter(refType, sql);
 
             return sql;
         }
@@ -50,7 +50,7 @@ namespace ServiceStack.OrmLite.Support
             var sql = dialectProvider.ToSelectStatement(refType, sqlFilter, pkValue);
 
             if (OrmLiteConfig.SqlSelectRefFilter != null)
-                sql = OrmLiteConfig.SqlSelectRefFilter.Invoke(refType, sql);
+                sql = OrmLiteConfig.SqlSelectRefFilter(refType, sql);
 
             return sql;
         }
@@ -66,7 +66,7 @@ namespace ServiceStack.OrmLite.Support
             var sql = dialectProvider.ToSelectStatement(refType, sqlFilter, refPkValue);
 
             if (OrmLiteConfig.SqlSelectRefFilter != null)
-                sql = OrmLiteConfig.SqlSelectRefFilter.Invoke(refType, sql);
+                sql = OrmLiteConfig.SqlSelectRefFilter(refType, sql);
 
             return sql;
         }


### PR DESCRIPTION
The primary use case the the enablement of developers to manipulate the Sql queries for loading references (seen a couple of questions online around it) one reference is :
https://forums.servicestack.net/t/code-to-traverse-all-object-graph-and-remove-issoftdeleted/5709


The current closest method is **OrmLiteConfig.SqlExpressionSelectFilter** in which you could filter out records that have been soft deleted for example

```
OrmLiteConfig.SqlExpressionSelectFilter = expression =>
{
    if (expression.ModelDef.ModelType.HasInterface(typeof(IAuditedEntity)))
    {
        expression.Where<IAuditedEntity>(e => e.IsDeleted == false || e.IsDeleted == null);
    }
};
```

this however unfortunately doesnt work the same for loading references, which only runs the above code for the SelectExpression component (missing the crucial outer query)

I have added an additional filter function **OrmLiteConfig.SqlSelectRefFilter** this gives users access to the Type of the ReferenceModel and the generated sql statement just before it goes into functions to be excecuted.

this should give the user sufficient details to process the statements. eg

```
OrmLiteConfig.SqlSelectRefFilter = (type, sql) =>
{
    var meta = type.GetModelMetadata();
    if (type.HasInterface(typeof(IAuditedEntity)))
    {
        sql += $" AND ({meta.Alias}.IsDeleted = 0 || {meta.Alias}.IsDeleted IS NULL)";
    }

    return sql;
};
```

using this function we can successfully manipulate the query and filter out on the database soft deletes which is much more effective than a results filter, or manual processing.


