### PR TITLE
[WIP - Do not merge] Solving some inconsistencies regarding tables naming convention

### DIFF
--- a/src/ServiceStack.OrmLite/Expressions/SqlExpression.Join.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpression.Join.cs
@@ -183,7 +183,7 @@ namespace ServiceStack.OrmLite
             if (refField == null) 
             {
                 if(!isCrossJoin)
-                    throw new ArgumentException($"Could not infer relationship between {sourceDef.ModelName} and {targetDef.ModelName}");
+                    throw new ArgumentException($"Could not infer relationship between {DialectProvider.GetTableName(sourceDef)} and {DialectProvider.GetTableName(targetDef.ModelName)}");
 
                 return string.Empty;
             }
@@ -315,7 +315,7 @@ namespace ServiceStack.OrmLite
                                     }
                                     else
                                     {
-                                        sbSelect.Append(DialectProvider.GetRowVersionSelectColumn(fieldDef, DialectProvider.GetTableName(tableDef.ModelName)));
+                                        sbSelect.Append(DialectProvider.GetRowVersionSelectColumn(fieldDef, DialectProvider.GetTableName(tableDef)));
                                     }
                                 }
                                 else

--- a/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
@@ -2011,7 +2011,7 @@ namespace ServiceStack.OrmLite
         {
             var paramModelDef = p.Type.GetModelDefinition();
             if (paramModelDef != null)
-                return new SelectList(DialectProvider.GetColumnNames(paramModelDef, paramModelDef.ModelName));
+                return new SelectList(DialectProvider.GetColumnNames(paramModelDef, DialectProvider.GetTableName(paramModelDef)));
 
             return p.Name;
         }
@@ -2426,11 +2426,14 @@ namespace ServiceStack.OrmLite
         {
             OnlyFields = null;
             selectDistinct = distinct;
-            
+
             selectExpression = $"SELECT {(selectDistinct ? "DISTINCT " : "")}" +
-               (string.IsNullOrEmpty(fields) 
-                    ? DialectProvider.GetColumnNames(modelDef, PrefixFieldWithTableName ? TableAlias ?? ModelDef.ModelName : null).ToSelectString() 
-                    : fields);
+                               (string.IsNullOrEmpty(fields)
+                                   ? DialectProvider.GetColumnNames(modelDef,
+                                       PrefixFieldWithTableName
+                                           ? TableAlias ?? DialectProvider.NamingStrategy.GetTableName(ModelDef)
+                                           : null).ToSelectString()
+                                   : fields);
         }
 
         public IList<string> GetAllFields()

--- a/src/ServiceStack.OrmLite/FieldDefinition.cs
+++ b/src/ServiceStack.OrmLite/FieldDefinition.cs
@@ -192,12 +192,12 @@ namespace ServiceStack.OrmLite
             if (ForeignKeyName.IsNullOrEmpty())
             {
                 var modelName = modelDef.IsInSchema
-                    ? modelDef.Schema + "_" + NamingStrategy.GetTableName(modelDef.ModelName)
-                    : NamingStrategy.GetTableName(modelDef.ModelName);
+                    ? modelDef.Schema + "_" + NamingStrategy.GetTableName(modelDef)
+                    : NamingStrategy.GetTableName(modelDef);
 
                 var refModelName = refModelDef.IsInSchema
-                    ? refModelDef.Schema + "_" + NamingStrategy.GetTableName(refModelDef.ModelName)
-                    : NamingStrategy.GetTableName(refModelDef.ModelName);
+                    ? refModelDef.Schema + "_" + NamingStrategy.GetTableName(refModelDef)
+                    : NamingStrategy.GetTableName(refModelDef);
 
                 var fkName = $"FK_{modelName}_{refModelName}_{fieldDef.FieldName}";
                 return NamingStrategy.ApplyNameRestrictions(fkName);

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -353,7 +353,7 @@ namespace ServiceStack.OrmLite
 
         public virtual string GetTableName(ModelDefinition modelDef)
         {
-            return GetTableName(modelDef.ModelName, modelDef.Schema);
+            return GetTableName(NamingStrategy.GetTableName(modelDef), modelDef.Schema);
         }
 
         public virtual string GetTableName(string table, string schema = null)
@@ -365,7 +365,7 @@ namespace ServiceStack.OrmLite
 
         public virtual string GetQuotedTableName(ModelDefinition modelDef)
         {
-            return GetQuotedTableName(modelDef.ModelName, modelDef.Schema);
+            return GetQuotedTableName(NamingStrategy.GetTableName(modelDef), modelDef.Schema);
         }
 
         public virtual string GetQuotedTableName(string tableName, string schema = null)
@@ -1396,7 +1396,7 @@ namespace ServiceStack.OrmLite
 
         protected virtual string GetCompositeIndexName(CompositeIndexAttribute compositeIndex, ModelDefinition modelDef)
         {
-            return compositeIndex.Name ?? GetIndexName(compositeIndex.Unique, modelDef.ModelName.SafeVarName(),
+            return compositeIndex.Name ?? GetIndexName(compositeIndex.Unique, NamingStrategy.GetTableName(modelDef).SafeVarName(),
                 string.Join("_", compositeIndex.FieldNames.Map(x => x.LeftPart(' ')).ToArray()));
         }
 
@@ -1510,7 +1510,7 @@ namespace ServiceStack.OrmLite
             var referenceFieldName = referenceMD.GetFieldDefinition(foreignField).FieldName;
 
             string name = GetQuotedName(foreignKeyName.IsNullOrEmpty() ?
-                "fk_" + sourceMD.ModelName + "_" + fieldName + "_" + referenceFieldName :
+                "fk_" + NamingStrategy.GetTableName(sourceMD) + "_" + fieldName + "_" + referenceFieldName :
                 foreignKeyName);
 
             return $"ALTER TABLE {GetQuotedTableName(sourceMD)} " +
@@ -1527,7 +1527,7 @@ namespace ServiceStack.OrmLite
             var fieldName = sourceDef.GetFieldDefinition(field).FieldName;
 
             string name = GetQuotedName(indexName.IsNullOrEmpty() ?
-                (unique ? "uidx" : "idx") + "_" + sourceDef.ModelName + "_" + fieldName :
+                (unique ? "uidx" : "idx") + "_" + NamingStrategy.GetTableName(sourceDef) + "_" + fieldName :
                 indexName);
 
             string command = $"CREATE {(unique ? "UNIQUE" : "")} " +

--- a/src/ServiceStack.OrmLite/OrmLiteSchemaModifyApi.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteSchemaModifyApi.cs
@@ -118,7 +118,7 @@ namespace ServiceStack.OrmLite
             var provider = dbConn.GetDialectProvider();
             var modelDef = ModelDefinition<T>.Definition;
             var command = string.Format(provider.GetDropForeignKeyConstraints(modelDef),
-                provider.GetQuotedTableName(modelDef.ModelName),
+                provider.GetQuotedTableName(modelDef),
                 provider.GetQuotedName(foreignKeyName));
 
             dbConn.ExecuteSql(command);
@@ -136,7 +136,7 @@ namespace ServiceStack.OrmLite
         public static void DropIndex<T>(this IDbConnection dbConn, string indexName)
         {
             var provider = dbConn.GetDialectProvider();
-            var command = $"ALTER TABLE {provider.GetQuotedTableName(ModelDefinition<T>.Definition.ModelName)} " +
+            var command = $"ALTER TABLE {provider.GetQuotedTableName(ModelDefinition<T>.Definition)} " +
                           $"DROP INDEX  {provider.GetQuotedName(indexName)};";
             dbConn.ExecuteSql(command);
         }


### PR DESCRIPTION
It seems the code is mixing the use of ModelDef.ModelName and the value defined by INamingStrategy/IOrmLiteDialectProvider.GetTableName to get the name of a table.
Most of the time, the convention defined by the naming strategy is ignored under the assumption that INamingStrategy.GetTableName(ModelDef) is always equal to ModelDef.ModelName.

As a matter of example, let say I define a table through the following class
```
class Relation<A,B> 
{
// ....
}
```
with a naming strategy ensuring that this kind of class will get the name "AtoB". 
Depending on whether NamingStrategy.GetTable(modelDef) or ModelDef.ModelName is called in the code, I may end up with either "AtoB" or "Relation`2".

The changes I have performed in this PR are just a sketch because the whole structure of the API (mixing calls with either a ModelDefinition or a string as parameter) does not make it easy to normalize.

What should be the best approach here to fix this issue ?