### PR TITLE
Feature Proposal : interceptors

### DIFF
--- a/src/ServiceStack.OrmLite/Async/WriteExpressionCommandExtensionsAsync.cs
+++ b/src/ServiceStack.OrmLite/Async/WriteExpressionCommandExtensionsAsync.cs
@@ -81,49 +81,47 @@ namespace ServiceStack.OrmLite
             return cmd.ExecNonQueryAsync(token);
         }
 
-        public static Task<int> UpdateOnlyAsync<T>(this IDbCommand cmd,
+        public static async Task<int> UpdateOnlyAsync<T>(this IDbCommand cmd,
             Dictionary<string, object> updateFields,
             Expression<Func<T, bool>> where,
-            Action<IDbCommand> commandFilter = null, 
+            Action<IDbCommand> commandFilter = null,
             CancellationToken token = default(CancellationToken))
         {
             if (updateFields == null)
                 throw new ArgumentNullException(nameof(updateFields));
 
-            OrmLiteConfig.UpdateFilter?.Invoke(cmd, updateFields.FromObjectDictionary<T>());
+            await cmd.OnUpdateAsync(updateFields.FromObjectDictionary<T>()).ConfigureAwait(false);
 
             var q = cmd.GetDialectProvider().SqlExpression<T>();
             q.Where(where);
             q.PrepareUpdateStatement(cmd, updateFields);
             commandFilter?.Invoke(cmd);
 
-            return cmd.ExecNonQueryAsync(token);
+            return await cmd.ExecNonQueryAsync(token).ConfigureAwait(false);
         }
 
-        internal static Task<int> UpdateNonDefaultsAsync<T>(this IDbCommand dbCmd, T item, Expression<Func<T, bool>> obj, CancellationToken token)
+        internal static async Task<int> UpdateNonDefaultsAsync<T>(this IDbCommand dbCmd, T item, Expression<Func<T, bool>> obj, CancellationToken token)
         {
-            OrmLiteConfig.UpdateFilter?.Invoke(dbCmd, item);
-
+            await  dbCmd.OnUpdateAsync(item).ConfigureAwait(false);
             var q = dbCmd.GetDialectProvider().SqlExpression<T>();
             q.Where(obj);
             q.PrepareUpdateStatement(dbCmd, item, excludeDefaults: true);
-            return dbCmd.ExecNonQueryAsync(token);
+            return await dbCmd.ExecNonQueryAsync(token).ConfigureAwait(false);
         }
 
-        internal static Task<int> UpdateAsync<T>(this IDbCommand dbCmd, T item, Expression<Func<T, bool>> expression, Action<IDbCommand> commandFilter, CancellationToken token)
+        internal static async Task<int> UpdateAsync<T>(this IDbCommand dbCmd, T item, Expression<Func<T, bool>> expression, Action<IDbCommand> commandFilter, CancellationToken token)
         {
-            OrmLiteConfig.UpdateFilter?.Invoke(dbCmd, item);
-
+            await dbCmd.OnUpdateAsync(item).ConfigureAwait(false);
             var q = dbCmd.GetDialectProvider().SqlExpression<T>();
             q.Where(expression);
             q.PrepareUpdateStatement(dbCmd, item);
             commandFilter?.Invoke(dbCmd);
-            return dbCmd.ExecNonQueryAsync(token);
+            return await dbCmd.ExecNonQueryAsync(token).ConfigureAwait(false);
         }
 
-        internal static Task<int> UpdateAsync<T>(this IDbCommand dbCmd, object updateOnly, Expression<Func<T, bool>> where, Action<IDbCommand> commandFilter, CancellationToken token)
+        internal static async Task<int> UpdateAsync<T>(this IDbCommand dbCmd, object updateOnly, Expression<Func<T, bool>> where, Action<IDbCommand> commandFilter, CancellationToken token)
         {
-            OrmLiteConfig.UpdateFilter?.Invoke(dbCmd, updateOnly);
+            await dbCmd.OnUpdateAsync(updateOnly).ConfigureAwait(false);
 
             var q = dbCmd.GetDialectProvider().SqlExpression<T>();
             var whereSql = q.Where(where).WhereExpression;
@@ -131,15 +129,14 @@ namespace ServiceStack.OrmLite
             dbCmd.PrepareUpdateAnonSql<T>(dbCmd.GetDialectProvider(), updateOnly, whereSql);
             commandFilter?.Invoke(dbCmd);
 
-            return dbCmd.ExecNonQueryAsync(token);
+            return await dbCmd.ExecNonQueryAsync(token).ConfigureAwait(false);
         }
 
-        internal static Task InsertOnlyAsync<T>(this IDbCommand dbCmd, T obj, string[] onlyFields, CancellationToken token)
+        internal static async Task InsertOnlyAsync<T>(this IDbCommand dbCmd, T obj, string[] onlyFields, CancellationToken token)
         {
-            OrmLiteConfig.InsertFilter?.Invoke(dbCmd, obj);
-
+            await dbCmd.OnInsertAsync(obj).ConfigureAwait(false);
             var sql = dbCmd.GetDialectProvider().ToInsertRowStatement(dbCmd, obj, onlyFields);
-            return dbCmd.ExecuteSqlAsync(sql, token);
+            await dbCmd.ExecuteSqlAsync(sql, token).ConfigureAwait(false);
         }
 
         public static Task<int> InsertOnlyAsync<T>(this IDbCommand dbCmd, Expression<Func<T>> insertFields, CancellationToken token)

--- a/src/ServiceStack.OrmLite/Expressions/WriteExpressionCommandExtensions.cs
+++ b/src/ServiceStack.OrmLite/Expressions/WriteExpressionCommandExtensions.cs
@@ -22,7 +22,7 @@ namespace ServiceStack.OrmLite
 
         internal static void UpdateOnlySql<T>(this IDbCommand dbCmd, T model, SqlExpression<T> onlyFields)
         {
-            OrmLiteConfig.UpdateFilter?.Invoke(dbCmd, model);
+            dbCmd.OnUpdate(model);
 
             var fieldsToUpdate = onlyFields.UpdateFields.Count == 0
                 ? onlyFields.GetAllFields()
@@ -79,7 +79,7 @@ namespace ServiceStack.OrmLite
             if (updateFields == null)
                 throw new ArgumentNullException(nameof(updateFields));
 
-            OrmLiteConfig.UpdateFilter?.Invoke(dbCmd, updateFields.EvalFactoryFn());
+            dbCmd.OnUpdate(updateFields.EvalFactoryFn());
 
             q.CopyParamsTo(dbCmd);
 
@@ -105,7 +105,7 @@ namespace ServiceStack.OrmLite
             if (updateFields == null)
                 throw new ArgumentNullException(nameof(updateFields));
 
-            OrmLiteConfig.UpdateFilter?.Invoke(dbCmd, updateFields.EvalFactoryFn());
+            dbCmd.OnUpdate(updateFields.EvalFactoryFn());
 
             dbCmd.SetParameters(sqlParams);
 
@@ -114,7 +114,7 @@ namespace ServiceStack.OrmLite
 
             return dbCmd;
         }
-        
+
         public static int UpdateAdd<T>(this IDbCommand dbCmd,
             Expression<Func<T>> updateFields,
             SqlExpression<T> q,
@@ -130,7 +130,7 @@ namespace ServiceStack.OrmLite
             if (updateFields == null)
                 throw new ArgumentNullException(nameof(updateFields));
 
-            OrmLiteConfig.UpdateFilter?.Invoke(dbCmd, updateFields.EvalFactoryFn());
+            dbCmd.OnUpdate(updateFields.EvalFactoryFn());
 
             q.CopyParamsTo(dbCmd);
 
@@ -148,7 +148,7 @@ namespace ServiceStack.OrmLite
             if (updateFields == null)
                 throw new ArgumentNullException(nameof(updateFields));
 
-            OrmLiteConfig.UpdateFilter?.Invoke(dbCmd, updateFields.FromObjectDictionary<T>());
+            dbCmd.OnUpdate(updateFields.FromObjectDictionary<T>());
 
             var q = dbCmd.GetDialectProvider().SqlExpression<T>();
             q.Where(where);
@@ -160,7 +160,7 @@ namespace ServiceStack.OrmLite
 
         public static int UpdateNonDefaults<T>(this IDbCommand dbCmd, T item, Expression<Func<T, bool>> where)
         {
-            OrmLiteConfig.UpdateFilter?.Invoke(dbCmd, item);
+            dbCmd.OnUpdate(item);
 
             var q = dbCmd.GetDialectProvider().SqlExpression<T>();
             q.Where(@where);
@@ -170,7 +170,7 @@ namespace ServiceStack.OrmLite
 
         public static int Update<T>(this IDbCommand dbCmd, T item, Expression<Func<T, bool>> expression, Action<IDbCommand> commandFilter = null)
         {
-            OrmLiteConfig.UpdateFilter?.Invoke(dbCmd, item);
+            dbCmd.OnUpdate(item);
 
             var q = dbCmd.GetDialectProvider().SqlExpression<T>();
             q.Where(expression);
@@ -181,7 +181,7 @@ namespace ServiceStack.OrmLite
 
         public static int Update<T>(this IDbCommand dbCmd, object updateOnly, Expression<Func<T, bool>> where = null, Action<IDbCommand> commandFilter = null)
         {
-            OrmLiteConfig.UpdateFilter?.Invoke(dbCmd, updateOnly);
+            dbCmd.OnUpdate(updateOnly);
 
             var q = dbCmd.GetDialectProvider().SqlExpression<T>();
             var whereSql = q.Where(where).WhereExpression;
@@ -225,7 +225,7 @@ namespace ServiceStack.OrmLite
 
         public static long InsertOnly<T>(this IDbCommand dbCmd, T obj, string[] onlyFields, bool selectIdentity)
         {
-            OrmLiteConfig.InsertFilter?.Invoke(dbCmd, obj);
+            dbCmd.OnInsert(obj);
 
             var dialectProvider = dbCmd.GetDialectProvider();
             var sql = dialectProvider.ToInsertRowStatement(dbCmd, obj, onlyFields);
@@ -251,7 +251,7 @@ namespace ServiceStack.OrmLite
             if (insertFields == null)
                 throw new ArgumentNullException(nameof(insertFields));
 
-            OrmLiteConfig.InsertFilter?.Invoke(dbCmd, insertFields.EvalFactoryFn());
+            dbCmd.OnInsert(insertFields.EvalFactoryFn());
 
             var fieldValuesMap = insertFields.AssignedValues();
             dbCmd.GetDialectProvider().PrepareInsertRowStatement<T>(dbCmd, fieldValuesMap);

--- a/src/ServiceStack.OrmLite/Interceptors/IEntityInterceptor.cs
+++ b/src/ServiceStack.OrmLite/Interceptors/IEntityInterceptor.cs
@@ -1,0 +1,41 @@
+﻿using System.Data;
+using System.Threading.Tasks;
+
+namespace ServiceStack.OrmLite.Interceptors
+{
+    /// <summary>
+    ///  Base interceptor
+    /// </summary>
+
+    public interface IEntityInterceptor
+    {
+
+        /// <summary>
+        ///  Interceptor name, should be unique.
+        /// </summary>
+        string Name { get; }
+    }
+
+    /// <summary>
+    ///     Represent a plugin to perform operations for a given entity.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IEntityInterceptor<in T> : IEntityInterceptor
+    {
+        /// <summary>
+        ///     Execute code before create a new entity.
+        /// </summary>
+        /// <param name="dbCmd"></param>
+        /// <param name="entity"></param>
+        /// <returns></returns>
+        Task OnInsertAsync(IDbCommand dbCmd, T entity);
+
+        /// <summary>
+        ///     Execute code before update an entity.
+        /// </summary>
+        /// <param name="dbCmd"></param>
+        /// <param name="entity"></param>
+        /// <returns></returns>
+        Task OnUpdateAsync(IDbCommand dbCmd, T entity);
+    }
+}

--- a/src/ServiceStack.OrmLite/Interceptors/InterceptorOperationsExtensions.cs
+++ b/src/ServiceStack.OrmLite/Interceptors/InterceptorOperationsExtensions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using ServiceStack.OrmLite.Interceptors;
+using ServiceStack.OrmLite.Support;
+
+namespace ServiceStack.OrmLite
+{
+    public static class InterceptorOperationsExtensions
+    {
+        public static async Task OnInsertAsync<T>(this IDbCommand dbCmd, T obj)
+        {
+            OrmLiteConfig.InsertFilter?.Invoke(dbCmd, obj);
+
+            foreach (var candidate in OrmLiteConfig.RegisteredInterceptors.Select(s => s.Value).ToList())
+            {
+                if (candidate is IEntityInterceptor<T> entityInterceptor)
+                {
+                    await entityInterceptor.OnInsertAsync(dbCmd, obj).ConfigureAwait(false);
+                }
+            }
+        }
+
+        public static void OnInsert<T>(this IDbCommand dbCmd, T obj)
+        {
+            AsyncHelper.RunSync(() => OnInsertAsync(dbCmd, obj));
+        }
+
+        public static async Task OnUpdateAsync<T>(this IDbCommand dbCmd, T obj)
+        {
+            OrmLiteConfig.UpdateFilter?.Invoke(dbCmd, obj);
+
+            foreach (var candidate in OrmLiteConfig.RegisteredInterceptors.Select(s => s.Value).ToList())
+            {
+                if (candidate is IEntityInterceptor<T> entityInterceptor)
+                {
+                    await entityInterceptor.OnUpdateAsync(dbCmd, obj).ConfigureAwait(false);
+                }
+            }
+        }
+
+        public static void OnUpdate<T>(this IDbCommand dbCmd, T obj)
+        {
+            AsyncHelper.RunSync(() => OnUpdateAsync(dbCmd, obj));
+        }
+    }
+}

--- a/src/ServiceStack.OrmLite/Legacy/WriteExpressionCommandExtensionsAsyncLegacy.cs
+++ b/src/ServiceStack.OrmLite/Legacy/WriteExpressionCommandExtensionsAsyncLegacy.cs
@@ -50,13 +50,12 @@ namespace ServiceStack.OrmLite.Legacy
             return dbCmd.ExecuteSqlAsync(sql, token);
         }
 
-        internal static Task InsertOnlyAsync<T>(this IDbCommand dbCmd, T obj, SqlExpression<T> onlyFields, CancellationToken token)
+        internal static async Task InsertOnlyAsync<T>(this IDbCommand dbCmd, T obj, SqlExpression<T> onlyFields, CancellationToken token)
         {
-            if (OrmLiteConfig.InsertFilter != null)
-                OrmLiteConfig.InsertFilter(dbCmd, obj);
+            await dbCmd.OnInsertAsync(obj).ConfigureAwait(false);
 
             var sql = dbCmd.GetDialectProvider().ToInsertRowStatement(dbCmd, obj, onlyFields.InsertFields);
-            return dbCmd.ExecuteSqlAsync(sql, token);
+            await dbCmd.ExecuteSqlAsync(sql, token).ConfigureAwait(false);
         }
     }
 }

--- a/src/ServiceStack.OrmLite/Legacy/WriteExpressionCommandExtensionsLegacy.cs
+++ b/src/ServiceStack.OrmLite/Legacy/WriteExpressionCommandExtensionsLegacy.cs
@@ -94,8 +94,7 @@ namespace ServiceStack.OrmLite.Legacy
         [Obsolete(Messages.LegacyApi)]
         public static void InsertOnly<T>(this IDbCommand dbCmd, T obj, SqlExpression<T> onlyFields)
         {
-            if (OrmLiteConfig.InsertFilter != null)
-                OrmLiteConfig.InsertFilter(dbCmd, obj);
+            dbCmd.OnInsert(obj);
 
             var sql = dbCmd.GetDialectProvider().ToInsertRowStatement(dbCmd, obj, onlyFields.InsertFields);
             dbCmd.ExecuteSql(sql);

--- a/src/ServiceStack.OrmLite/OrmLiteConfig.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteConfig.cs
@@ -61,15 +61,6 @@ namespace ServiceStack.OrmLite
                 : DialectProvider;
         }
 
-        public static void AddInterceptor(IEntityInterceptor interceptor)
-        {
-            // avoid duplicate 
-            if (RegisteredInterceptors.Any(p => p.Key == interceptor.Name))
-                return;
-
-            RegisteredInterceptors.TryAdd(interceptor.Name, interceptor);
-        }
-
         public static IOrmLiteExecFilter GetExecFilter(this IOrmLiteDialectProvider dialectProvider)
         {
             return dialectProvider != null
@@ -222,7 +213,21 @@ namespace ServiceStack.OrmLite
         /// <summary>
         ///  Gets a list of currently registered interceptor for this config.
         /// </summary>
-        public static ConcurrentDictionary<string, IEntityInterceptor> RegisteredInterceptors { get; }
+        public static ConcurrentDictionary<string, IEntityInterceptor> RegisteredInterceptors { get; private set; }
             = new ConcurrentDictionary<string, IEntityInterceptor>();
+
+        public static void AddInterceptor(IEntityInterceptor interceptor)
+        {
+            // avoid duplicate 
+            if (RegisteredInterceptors.Any(p => p.Key == interceptor.Name))
+                return;
+
+            RegisteredInterceptors.TryAdd(interceptor.Name, interceptor);
+        }
+
+        public static void RemoveAllInterceptors()
+        {
+            RegisteredInterceptors = new ConcurrentDictionary<string, IEntityInterceptor>();
+        }
     }
 }

--- a/src/ServiceStack.OrmLite/OrmLiteWriteCommandExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteWriteCommandExtensions.cs
@@ -412,7 +412,7 @@ namespace ServiceStack.OrmLite
 
         internal static int Update<T>(this IDbCommand dbCmd, T obj, Action<IDbCommand> commandFilter = null)
         {
-            OrmLiteConfig.UpdateFilter?.Invoke(dbCmd, obj);
+            dbCmd.OnUpdate(obj);
 
             var dialectProvider = dbCmd.GetDialectProvider();
             var hadRowVersion = dialectProvider.PrepareParameterizedUpdateStatement<T>(dbCmd);
@@ -453,8 +453,7 @@ namespace ServiceStack.OrmLite
 
                 foreach (var obj in objs)
                 {
-                    OrmLiteConfig.UpdateFilter?.Invoke(dbCmd, obj);
-
+                    dbCmd.OnUpdate(obj);
                     dialectProvider.SetParameterValues<T>(dbCmd, obj);
 
                     commandFilter?.Invoke(dbCmd);
@@ -677,7 +676,7 @@ namespace ServiceStack.OrmLite
         
         internal static long Insert<T>(this IDbCommand dbCmd, T obj, Action<IDbCommand> commandFilter, bool selectIdentity = false)
         {
-            OrmLiteConfig.InsertFilter?.Invoke(dbCmd, obj);
+            dbCmd.OnInsert(obj);
 
             var dialectProvider = dbCmd.GetDialectProvider();
             dialectProvider.PrepareParameterizedInsertStatement<T>(dbCmd, 
@@ -772,7 +771,7 @@ namespace ServiceStack.OrmLite
 
                 foreach (var obj in objs)
                 {
-                    OrmLiteConfig.InsertFilter?.Invoke(dbCmd, obj);
+                    dbCmd.OnInsert(obj);
                     dialectProvider.SetParameterValues<T>(dbCmd, obj);
 
                     try
@@ -816,7 +815,7 @@ namespace ServiceStack.OrmLite
 
                 foreach (var obj in objs)
                 {
-                    OrmLiteConfig.InsertFilter?.Invoke(dbCmd, obj);
+                    dbCmd.OnInsert(obj);
                     dialectProvider.SetParameterValues<T>(dbCmd, obj);
 
                     try
@@ -908,7 +907,6 @@ namespace ServiceStack.OrmLite
                     var id = modelDef.GetPrimaryKey(row);
                     if (id != defaultIdValue && existingRowsMap.ContainsKey(id))
                     {
-                        OrmLiteConfig.UpdateFilter?.Invoke(dbCmd, row);
                         dbCmd.Update(row);
                     }
                     else
@@ -923,7 +921,6 @@ namespace ServiceStack.OrmLite
                         }
                         else
                         {
-                            OrmLiteConfig.InsertFilter?.Invoke(dbCmd, row);
                             dbCmd.Insert(row, commandFilter: null);
                         }
 

--- a/src/ServiceStack.OrmLite/Support/AsyncHelper.cs
+++ b/src/ServiceStack.OrmLite/Support/AsyncHelper.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ServiceStack.OrmLite.Support
+{
+    internal static class AsyncHelper
+    {
+        private static readonly TaskFactory myTaskFactory = new
+            TaskFactory(CancellationToken.None,
+                TaskCreationOptions.None,
+                TaskContinuationOptions.None,
+                TaskScheduler.Default);
+
+        public static TResult RunSync<TResult>(Func<Task<TResult>> func)
+        {
+            return AsyncHelper.myTaskFactory
+                .StartNew<Task<TResult>>(func)
+                .Unwrap<TResult>()
+                .GetAwaiter()
+                .GetResult();
+        }
+
+        public static void RunSync(Func<Task> func)
+        {
+            AsyncHelper.myTaskFactory
+                .StartNew<Task>(func)
+                .Unwrap()
+                .GetAwaiter()
+                .GetResult();
+        }
+    }
+}

--- a/tests/ServiceStack.OrmLite.Tests/Interceptors/CompleteDomainInterceptor.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Interceptors/CompleteDomainInterceptor.cs
@@ -1,0 +1,22 @@
+﻿using System.Data;
+using System.Threading.Tasks;
+using ServiceStack.OrmLite.Interceptors;
+
+namespace ServiceStack.OrmLite.Tests.Interceptors
+{
+    public class CompleteDomainInterceptor : IEntityInterceptor<EmailAddressesPoco>
+    {
+        public string Name => "CompleteValueInterceptor";
+
+        public Task OnInsertAsync(IDbCommand dbCmd, EmailAddressesPoco entity)
+        {
+            entity.Domain = entity.Email?.Split('@')[1];
+            return Task.CompletedTask;
+        }
+
+        public Task OnUpdateAsync(IDbCommand dbCmd, EmailAddressesPoco entity)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/ServiceStack.OrmLite.Tests/Interceptors/DuplicatedInterceptors.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Interceptors/DuplicatedInterceptors.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ServiceStack.OrmLite.Interceptors;
+
+namespace ServiceStack.OrmLite.Tests.Interceptors
+{
+    public abstract class DuplicatedInterceptors
+    {
+        public class InterceptorCamelCase : IEntityInterceptor<EmailAddressesPoco>
+        {
+            public string Name => "NAME";
+            public Task OnInsertAsync(IDbCommand dbCmd, EmailAddressesPoco entity)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task OnUpdateAsync(IDbCommand dbCmd, EmailAddressesPoco entity)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class Interceptor1 : IEntityInterceptor<EmailAddressesPoco>
+        {
+            public string Name => "name";
+            public Task OnInsertAsync(IDbCommand dbCmd, EmailAddressesPoco entity)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task OnUpdateAsync(IDbCommand dbCmd, EmailAddressesPoco entity)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class Interceptor2 : IEntityInterceptor<EmailAddressesPoco>
+        {
+            public string Name => "name";
+            public Task OnInsertAsync(IDbCommand dbCmd, EmailAddressesPoco entity)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task OnUpdateAsync(IDbCommand dbCmd, EmailAddressesPoco entity)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/tests/ServiceStack.OrmLite.Tests/Interceptors/EmailAddressesPoco.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Interceptors/EmailAddressesPoco.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using ServiceStack.DataAnnotations;
+
+namespace ServiceStack.OrmLite.Tests.Interceptors
+{
+    [Alias("emails")]
+    public partial class EmailAddressesPoco
+    {
+        public int Id { get; set; }
+
+        public string Email { get; set; }
+
+        public string Domain { get; set; }
+    }
+}

--- a/tests/ServiceStack.OrmLite.Tests/Interceptors/FailInterceptor.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Interceptors/FailInterceptor.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ServiceStack.OrmLite.Interceptors;
+
+namespace ServiceStack.OrmLite.Tests.Interceptors
+{
+    public class FailInterceptor : IEntityInterceptor<EmailAddressesPoco>
+    {
+        public string Name => "Fail";
+
+        public Task OnInsertAsync(IDbCommand dbCmd, EmailAddressesPoco entity)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task OnUpdateAsync(IDbCommand dbCmd, EmailAddressesPoco entity)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/ServiceStack.OrmLite.Tests/Interceptors/InterceptorsTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Interceptors/InterceptorsTests.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using ServiceStack.DataAnnotations;
+using ServiceStack.OrmLite.Tests.Async;
+using ServiceStack.OrmLite.Tests.Interceptors;
+
+namespace ServiceStack.OrmLite.Tests
+{
+    [TestFixtureOrmLite]
+    public class InterceptorsTests : OrmLiteProvidersTestBase
+    {
+        public InterceptorsTests(DialectContext context) : base(context)
+        {
+        }
+
+        [Test]
+        public async Task Can_Insert_Calling_Interceptor()
+        {
+            OrmLiteConfig.RemoveAllInterceptors();
+
+            using (var db = OpenDbConnection())
+            {
+                OrmLiteConfig.AddInterceptor(new TrimInterceptor());
+
+                db.DropAndCreateTable<EmailAddressesPoco>();
+                await db.InsertAsync(new EmailAddressesPoco
+                {
+                    Email = "test@servicestack.com       "
+                });
+
+                var inserted = (await db.SelectAsync<EmailAddressesPoco>()).FirstOrDefault();
+
+                Assert.NotNull(inserted);
+                Assert.AreEqual("test@servicestack.com", inserted.Email);
+            }
+        }
+
+        [Test]
+        public async Task Can_Use_Multiple_Interceptors()
+        {
+            OrmLiteConfig.RemoveAllInterceptors();
+
+            using (var db = OpenDbConnection())
+            {
+                OrmLiteConfig.AddInterceptor(new TrimInterceptor());
+                OrmLiteConfig.AddInterceptor(new CompleteDomainInterceptor());
+
+                db.DropAndCreateTable<EmailAddressesPoco>();
+                await db.InsertAsync(new EmailAddressesPoco
+                {
+                    Email = "test@servicestack.com       "
+                });
+
+                var inserted = (await db.SelectAsync<EmailAddressesPoco>()).FirstOrDefault();
+
+                Assert.NotNull(inserted);
+                Assert.AreEqual("test@servicestack.com", inserted.Email);
+                Assert.AreEqual("servicestack.com", inserted.Domain);
+            }
+        }
+
+        [Test]
+        public void Interceptors_Are_Throwing_Exceptions_For_Insert()
+        {
+            OrmLiteConfig.RemoveAllInterceptors();
+
+            using (var db = OpenDbConnection())
+            {
+                OrmLiteConfig.AddInterceptor(new FailInterceptor());
+
+                db.DropAndCreateTable<EmailAddressesPoco>();
+
+                Assert.ThrowsAsync<NotImplementedException>(async () =>
+                    await db.InsertAsync(new EmailAddressesPoco
+                    {
+                        Email = "test@servicestack.com"
+                    }));
+            }
+        }
+
+        [Test]
+        public async Task Can_Update_Calling_Interceptor()
+        {
+            OrmLiteConfig.RemoveAllInterceptors();
+
+            using (var db = OpenDbConnection())
+            {
+                OrmLiteConfig.AddInterceptor(new TrimInterceptor());
+
+                db.DropAndCreateTable<EmailAddressesPoco>();
+
+                await db.InsertAsync(new EmailAddressesPoco
+                {
+                    Email = "oldemail@servicestack.com"
+                });
+
+                await db.UpdateAsync(new EmailAddressesPoco
+                {
+                    Email = "test@servicestack.com       "
+                });
+
+                var inserted = (await db.SelectAsync<EmailAddressesPoco>()).FirstOrDefault();
+
+                Assert.NotNull(inserted);
+                Assert.AreEqual("test@servicestack.com", inserted.Email);
+            }
+        }
+
+        [Test]
+        public void Duplicated_Interceptors_Are_Ignored()
+        {
+            OrmLiteConfig.RemoveAllInterceptors();
+
+            var interceptor = new DuplicatedInterceptors.Interceptor1();
+            var duplicated = new DuplicatedInterceptors.Interceptor2();
+
+            OrmLiteConfig.AddInterceptor(interceptor);
+            OrmLiteConfig.AddInterceptor(duplicated);
+
+            // the second one should be ignored as the name is the same
+            Assert.AreEqual(interceptor.Name, duplicated.Name);
+            Assert.AreEqual(1, OrmLiteConfig.RegisteredInterceptors.Count);
+        }
+
+        [Test]
+        public void Interceptor_Name_Is_Case_Sensitive()
+        {
+            OrmLiteConfig.RemoveAllInterceptors();
+
+            var interceptor = new DuplicatedInterceptors.Interceptor1();
+            var duplicated = new DuplicatedInterceptors.InterceptorCamelCase();
+
+            OrmLiteConfig.AddInterceptor(interceptor);
+            OrmLiteConfig.AddInterceptor(duplicated);
+
+            // the second one should be ignored as the name is the same
+            Assert.AreEqual(interceptor.Name.ToLower(), duplicated.Name.ToLower());
+            Assert.True(interceptor.Name != duplicated.Name);
+            Assert.AreEqual(2, OrmLiteConfig.RegisteredInterceptors.Count);
+        }
+
+        [Test]
+        public async Task Filters_And_Interceptors_Are_Compatible()
+        {
+            OrmLiteConfig.RemoveAllInterceptors();
+
+            using (var db = OpenDbConnection())
+            {
+                OrmLiteConfig.AddInterceptor(new TrimInterceptor());
+                OrmLiteConfig.InsertFilter = (command, o) =>
+                {
+                    if (o is EmailAddressesPoco entity)
+                    {
+                        entity.Domain = "ormlite.com";
+                    }
+                };
+
+                db.DropAndCreateTable<EmailAddressesPoco>();
+                await db.InsertAsync(new EmailAddressesPoco
+                {
+                    Email = "test@servicestack.com       "
+                });
+
+                var inserted = (await db.SelectAsync<EmailAddressesPoco>()).FirstOrDefault();
+                Assert.NotNull(inserted);
+                Assert.AreEqual("test@servicestack.com", inserted.Email);
+                Assert.AreEqual("ormlite.com", inserted.Domain);
+            }
+        }
+    }
+}

--- a/tests/ServiceStack.OrmLite.Tests/Interceptors/TrimInterceptor.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Interceptors/TrimInterceptor.cs
@@ -1,0 +1,23 @@
+﻿using System.Data;
+using System.Threading.Tasks;
+using ServiceStack.OrmLite.Interceptors;
+
+namespace ServiceStack.OrmLite.Tests.Interceptors
+{
+    public class TrimInterceptor : IEntityInterceptor<EmailAddressesPoco>
+    {
+        public string Name => "InterceptedPocoEntity";
+
+        public Task OnInsertAsync(IDbCommand dbCmd, EmailAddressesPoco entity)
+        {
+            entity.Email = entity.Email.Trim();
+            return Task.CompletedTask;
+        }
+
+        public Task OnUpdateAsync(IDbCommand dbCmd, EmailAddressesPoco entity)
+        {
+            entity.Email = entity.Email.Trim();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
+++ b/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
@@ -30,4 +30,7 @@
       <Link>TestConfig.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Interceptors\" />
+  </ItemGroup>
 </Project>

--- a/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
+++ b/tests/ServiceStack.OrmLite.Tests/ServiceStack.OrmLite.Tests.csproj
@@ -30,7 +30,4 @@
       <Link>TestConfig.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Interceptors\" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Motivations to Implement this feature.

OrmLite Insert, Update Filters are well, however they can lead into few limitations.
 - Large switch statements to check if the entity is the desired to process.
 - Put all the logic in a single place, could lead in a very large and unreadable code.
 - There is no flexibility to add behaviour as a new functionality need to merged with the current delegated or it will be erased.

### Proposal
Interceptors.
They are basically classes that implement ```C# IEntityInterceptor ``` interface.

```C#
/// <summary>
    ///     Represent a plugin to perform operations for a given entity.
    /// </summary>
    /// <typeparam name="T"></typeparam>
    public interface IEntityInterceptor<in T> : IEntityInterceptor
    {
        /// <summary>
        ///     Execute code before create a new entity.
        /// </summary>
        /// <param name="dbCmd"></param>
        /// <param name="entity"></param>
        /// <returns></returns>
        Task OnInsertAsync(IDbCommand dbCmd, T entity);

        /// <summary>
        ///     Execute code before update an entity.
        /// </summary>
        /// <param name="dbCmd"></param>
        /// <param name="entity"></param>
        /// <returns></returns>
        Task OnUpdateAsync(IDbCommand dbCmd, T entity);
    }
```

This will be executed for each Insert, Update call for an entity.
**Benefits using this approach.**
 - Fully Async Code for Interception
 - 100% Compatible with Async, 0 breaking change.
 - Multiple classes with different responsibilities (+ Readability  +Separation of Concerns)
 - Flexibility to assign more behaviour without break any existing code.
 - More testable code that change entities through interception.

At code level 
 - Filters more controlled in a single place if in the future more operations needs to be performed. 


Code implemented and unit tests added.

Usage: 
``` C#
[Alias("client")]
public class Client 
{
      public string Email { get; set; }

      public string Domain { get; set; }
}

public class  : IEntityInterceptor<EmailAddressesPoco>
        {
            public string Name => "InterceptorName";

            public Task OnInsertAsync(IDbCommand dbCmd, Client entity)
            {
                 return Task.Completed.
            }

            public Task OnUpdateAsync(IDbCommand dbCmd, Client entity)
            {
                 entity.Domain = entity.Email.Split('@')[1];
                 return Task.Completed;
            }
        }
```

Registration is straight forward
``` C#
    OrmLiteConfig.AddInterceptor(new NewInterceptor());
```

Feature proposal:
- Support Interceptors for base/abstract classes for common usage cases like Auditable classes.
- Allow run interceptions in parallel with a configuration.
- New overload with the connection in Interceptors, that way the user can perform operations from an Interceptor for related entities or recursive loops.
