### PR TITLE
Fix bug can't insert data with sequence

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
@@ -850,10 +850,13 @@ namespace ServiceStack.OrmLite.Oracle
                 }
                 return retObj;
             }
-            
+            //Get current CommandText
+            var lastSql = dbCmd.CommandText;
             dbCmd.CommandText = $"SELECT {Quote(sequence)}.NEXTVAL FROM dual";
             long result = (long)dbCmd.LongScalar();
             LastInsertId = result;
+            //Set CommandText back
+            dbCmd.CommandText = lastSql;
             return result;
         }
 


### PR DESCRIPTION
I have stackoverflow here:
https://stackoverflow.com/questions/56392375/servicestack-ormlite-oracle-cant-insert-object-with-sequence-attribute

After debug I see a bug when execute function GetNextValue(IDbCommand dbCmd, string sequence, object value), CommandText of IDbCommand has change from "insert into..." to "select seq.nextval.."