### PR TITLE
Clean PR: Create parameter with DBNull.Value for null values in OrmLiteReadCommand

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteReadCommandExtensions.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteReadCommandExtensions.cs
@@ -1052,6 +1052,10 @@ namespace ServiceStack.OrmLite
                 p.Value = value;
                 dialectProvider.InitDbParam(p, value.GetType());
             }
+            else
+            {
+                p.Value = DBNull.Value;
+            }
 
             if (dbType != null)
                 p.DbType = dbType.Value;

--- a/tests/ServiceStack.OrmLite.Tests/SelectParamTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/SelectParamTests.cs
@@ -35,5 +35,20 @@ namespace ServiceStack.OrmLite.Tests
                 Assert.That(db.SqlList<Person>("SELECT * FROM Person WHERE Age = @age", new[] { db.CreateParam("age", 27) }).Count, Is.EqualTo(4));
             }
         }
+
+        [Test]
+        public void Can_Select_with_Null_param()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<Person>();
+                db.InsertAll(Person.Rockstars);
+
+                var dbCmd = db.CreateCommand();//demo code, just for dbCmd.CreateParam
+
+                // for sqlite that works with paramter with DBNull.Value and usual null.
+                Assert.That(db.Select<Person>("FirstName = @firstname", new List<System.Data.IDbDataParameter> { dbCmd.CreateParam("firstname", null) }).Count, Is.EqualTo(0));
+            }
+        }
     }
 }


### PR DESCRIPTION
Hi!
I cleaned my fork and created the new PR with only the commits containing the changes.