### PR TITLE
Fix RowCount not working with SelectFilters.

### DIFF
--- a/src/ServiceStack.OrmLite/Async/ReadExpressionCommandExtensionsAsync.cs
+++ b/src/ServiceStack.OrmLite/Async/ReadExpressionCommandExtensionsAsync.cs
@@ -163,7 +163,7 @@ namespace ServiceStack.OrmLite
         internal static Task<long> RowCountAsync<T>(this IDbCommand dbCmd, SqlExpression<T> expression, CancellationToken token)
         {
             var countExpr = expression.Clone().OrderBy();
-            return dbCmd.ScalarAsync<long>(dbCmd.GetDialectProvider().ToRowCountStatement(countExpr.ToSelectStatement()), expression.Params, token);
+            return dbCmd.ScalarAsync<long>(dbCmd.GetDialectProvider().ToRowCountStatement(countExpr.ToSelectStatement()), countExpr.Params, token);
         }
 
         internal static Task<long> RowCountAsync(this IDbCommand dbCmd, string sql, object anonType, CancellationToken token)

--- a/src/ServiceStack.OrmLite/Expressions/ReadExpressionCommandExtensions.cs
+++ b/src/ServiceStack.OrmLite/Expressions/ReadExpressionCommandExtensions.cs
@@ -198,7 +198,7 @@ namespace ServiceStack.OrmLite
         {
             //ORDER BY throws when used in subselects in SQL Server. Removing OrderBy() clause since it doesn't impact results
             var countExpr = expression.Clone().OrderBy(); 
-            return dbCmd.Scalar<long>(dbCmd.GetDialectProvider().ToRowCountStatement(countExpr.ToSelectStatement()), expression.Params);
+            return dbCmd.Scalar<long>(dbCmd.GetDialectProvider().ToRowCountStatement(countExpr.ToSelectStatement()), countExpr.Params);
         }
 
         internal static long RowCount(this IDbCommand dbCmd, string sql, object anonType)


### PR DESCRIPTION
`countExpr` is a clone of `expression` so it did not gain any new parameters added by `.ToSelectStatement()`, which was causing an exception when being executed.