### PR TITLE
Cancel Odp.Net's trace option setting from "OracleOrmLiteDialectProvider.cs"

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleOrmLiteDialectProvider.cs
@@ -93,7 +93,7 @@ namespace ServiceStack.OrmLite.Oracle
             //OracleConfiguration.DisableOOB = true;
             //OracleConfiguration.OnsMode = OnsConfigMode.Unspecified;
             OracleConfiguration.TraceOption = 1;
-            OracleConfiguration.TraceLevel = 7;
+            //OracleConfiguration.TraceLevel = 7;
             //OracleConfiguration.TcpNoDelay = true;
             OracleConfiguration.TraceFileLocation = "c:\\temp\\ora";
 #endif


### PR DESCRIPTION
remove `OracleConfiguration.TraceLevel=7` from `OracleOrmLiteDialectProvider.cs`

I don't think this option is suitable for all situations and will cause potential additional risks (this is also the motivation for modification after the problems I encountered in the actual project)

This option generates a large number of logs in the netcore environment, resulting in insufficient server disk space. As shown：
![image](https://user-images.githubusercontent.com/6604230/72127145-accfa380-33a9-11ea-894a-86202c459e35.png)

PS:
For scenarios that are really needed, users should decide for themselves or at least allow external configuration (such as providing options in OrmliteConfig)