### PR TITLE
Include appropriate files in ServiceStack.ormLite.SqlServer.Data.Core

### DIFF
--- a/src/ServiceStack.OrmLite.SqlServer.Data/ServiceStack.OrmLite.SqlServer.Data.Core.csproj
+++ b/src/ServiceStack.OrmLite.SqlServer.Data/ServiceStack.OrmLite.SqlServer.Data.Core.csproj
@@ -22,4 +22,70 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\Converters\SqlServerBoolConverter.cs">
+      <Link>Converters\SqlServerBoolConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\Converters\SqlServerByteArrayConverter.cs">
+      <Link>Converters\SqlServerByteArrayConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\Converters\SqlServerDateTime2Converter.cs">
+      <Link>Converters\SqlServerDateTime2Converter.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\Converters\SqlServerDateTimeConverter.cs">
+      <Link>Converters\SqlServerDateTimeConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\Converters\SqlServerFloatConverters.cs">
+      <Link>Converters\SqlServerFloatConverters.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\Converters\SqlServerGuidConverter.cs">
+      <Link>Converters\SqlServerGuidConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\Converters\SqlServerIntegerConverters.cs">
+      <Link>Converters\SqlServerIntegerConverters.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\Converters\SqlServerJsonStringConverters.cs">
+      <Link>Converters\SqlServerJsonStringConverters.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\Converters\SqlServerSpecialConverters.cs">
+      <Link>Converters\SqlServerSpecialConverters.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\Converters\SqlServerStringConverters.cs">
+      <Link>Converters\SqlServerStringConverters.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\Converters\SqlServerTimeConverter.cs">
+      <Link>Converters\SqlServerTimeConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\SqlServer2008OrmLiteDialectProvider.cs">
+      <Link>SqlServer2008OrmLiteDialectProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\SqlServer2012OrmLiteDialectProvider.cs">
+      <Link>SqlServer2012OrmLiteDialectProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\SqlServer2014OrmLiteDialectProvider.cs">
+      <Link>SqlServer2014OrmLiteDialectProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\SqlServer2016Expression.cs">
+      <Link>SqlServer2016Expression.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\SqlServer2016OrmLiteDialectProvider.cs">
+      <Link>SqlServer2016OrmLiteDialectProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\SqlServer2017OrmLiteDialectProvider.cs">
+      <Link>SqlServer2017OrmLiteDialectProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\SqlServerDialect.cs">
+      <Link>SqlServerDialect.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\SqlServerExpression.cs">
+      <Link>SqlServerExpression.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\SqlServerOrmLiteDialectProvider.cs">
+      <Link>SqlServerOrmLiteDialectProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\ServiceStack.OrmLite.SqlServer\SqlServerTableHint.cs">
+      <Link>SqlServerTableHint.cs</Link>
+    </Compile>
+  </ItemGroup>  
+
 </Project>

--- a/src/ServiceStack.OrmLite.SqlServer.Data/ServiceStack.OrmLite.SqlServer.Data.csproj
+++ b/src/ServiceStack.OrmLite.SqlServer.Data/ServiceStack.OrmLite.SqlServer.Data.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <PackageId>ServiceStack.OrmLite.SqlServer.Data</PackageId>
-    <AssemblyName>ServiceStack.OrmLite.SqlServer</AssemblyName>
-    <RootNamespace>ServiceStack.OrmLite.SqlServer</RootNamespace>
+    <AssemblyName>ServiceStack.OrmLite.SqlServer.Data</AssemblyName>
+    <RootNamespace>ServiceStack.OrmLite.SqlServer.Data</RootNamespace>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Title>OrmLite.SqlServer - Fast, code-first, config-free POCO ORM</Title>
     <PackageDescription>


### PR DESCRIPTION
See twitter discussion https://twitter.com/danielmarbach/status/1224952168563838976

When referencing ServiceStack.OrmLite.SqlServer.Data to get access to Microsoft.Data.SqlClient the full framework target does not properly resolve the dependencies, It only ships netstandard2.0 but its dependencies have net45;netstandard2.0. This causes dependency issues. When you reference that package on net462 the package brings in netstandard but the dependencies go for net45 assemblies which then causes build errors like the following

![image](https://user-images.githubusercontent.com/174258/73835655-1064b980-480e-11ea-9aca-65e23171af1a.png)
![image](https://user-images.githubusercontent.com/174258/73835662-12c71380-480e-11ea-9ac8-4a6a97c9c4f4.png)

It was then recommended to use ServiceStack.OrmLite.SqlServer.Data.Core which is netstandard only. Unfortunately if I pull this in I'm not able to set

```
OrmLiteConfig.DialectProvider = SqlServerDialect.Provider;
```

With a custom build containing the PR I can now properly use the SqlServerDialect