### PR TITLE
Update MySqlConnector to 1.0

### DIFF
--- a/src/ServiceStack.OrmLite.MySqlConnector/MySqlConnectorDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.MySqlConnector/MySqlConnectorDialectProvider.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using ServiceStack.OrmLite.MySql.Converters;
 
 namespace ServiceStack.OrmLite.MySql

--- a/src/ServiceStack.OrmLite.MySqlConnector/ServiceStack.OrmLite.MySqlConnector.csproj
+++ b/src/ServiceStack.OrmLite.MySqlConnector/ServiceStack.OrmLite.MySqlConnector.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServiceStack.OrmLite\ServiceStack.OrmLite.csproj" />
-    <PackageReference Include="MySqlConnector" Version="0.64.1" />
+    <PackageReference Include="MySqlConnector" Version="1.0.0" />
     <PackageReference Include="ServiceStack.Common" Version="$(Version)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">


### PR DESCRIPTION
MySqlConnector 1.0 changes the primary namespace to `MySqlConnector`: mysql-net/MySqlConnector#824; this updates all relevant code.

This starts the discussion around updating MySqlConnector to 1.0, but doesn't need to be merged until it's out of beta.