### PR TITLE
add ToString format paramater support for MySql DateTime

### DIFF
--- a/src/ServiceStack.OrmLite.MySql/MySqlExpression.cs
+++ b/src/ServiceStack.OrmLite.MySql/MySqlExpression.cs
@@ -1,9 +1,12 @@
 ﻿namespace ServiceStack.OrmLite.MySql
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq.Expressions;
     public class MySqlExpression<T> : SqlExpression<T>
     {
         public MySqlExpression(IOrmLiteDialectProvider dialectProvider)
-            : base(dialectProvider) {}
+            : base(dialectProvider) { }
 
         protected override string ToCast(string quotedColName)
         {
@@ -15,6 +18,24 @@
             return base.tableDefs.Count > 1
                 ? $"DELETE {DialectProvider.GetQuotedTableName(modelDef)} {FromExpression} {WhereExpression}"
                 : base.ToDeleteRowStatement();
+        }
+
+        protected override object VisitColumnAccessMethod(MethodCallExpression m)
+        {
+            if (m.Method.Name == nameof(ToString) && m.Object?.Type == typeof(DateTime))
+            {
+                List<object> args = this.VisitExpressionList(m.Arguments);
+                var quotedColName = Visit(m.Object);
+                if (!IsSqlClass(quotedColName))
+                    quotedColName = ConvertToParam(quotedColName);
+
+                var statement = "";
+                var arg = args.Count > 0 ? args[0] : null;
+                if (arg == null) statement = ToCast(quotedColName.ToString());
+                else statement = $"DATE_FORMAT({quotedColName.ToString()},'{arg.ToString()}')";
+                return new PartialSqlString(statement);
+            }
+            return base.VisitColumnAccessMethod(m);
         }
 
         protected override string CreateInSubQuerySql(object quotedColName, string subSelect)

--- a/tests/ServiceStack.OrmLite.MySql.Tests/DateTimeColumnTest.cs
+++ b/tests/ServiceStack.OrmLite.MySql.Tests/DateTimeColumnTest.cs
@@ -101,6 +101,109 @@ namespace ServiceStack.OrmLite.MySql.Tests
             results.PrintDump();
         }
 
+        [Test]
+        public void Can_query_DateTime_column_in_select_without_any_format_parameter()
+        {
+            using var db = OpenDbConnection();
+            db.CreateTable<Analyze>(true);
+            var obj = new Analyze
+            {
+                Id = 1,
+                Date = DateTime.Now,
+                Url = "http://www.google.com"
+            };
+            db.Save(obj);
+
+            var q=db.From<Analyze>().Select(i => i.Date);
+            var sql = q.ToMergedParamsSelectStatement();
+           var val= db.Select<DateTime>(q).First();
+           Assert.That(obj.Date,Is.EqualTo(val).Within(TimeSpan.FromSeconds(1)));
+        }
+
+        [Test]
+        public void Can_query_DateTime_column_in_select_with_format_parameter()
+        {
+            using var db = OpenDbConnection();
+            db.CreateTable<Analyze>(true);
+            var obj = new Analyze
+            {
+                Id = 1,
+                Date = DateTime.Now,
+                Url = "http://www.google.com"
+            };
+            db.Save(obj);
+            var q = db.From<Analyze>().Select(i => i.Date.ToString("%Y-%m-%d %H:%i:%s"));
+            var sql = q.ToMergedParamsSelectStatement();
+            var val = db.Select<string>(q).First();
+            Assert.That(obj.Date, Is.EqualTo(DateTime.Parse(val)).Within(TimeSpan.FromSeconds(1)));
+        }
+
+        [Test]
+        public void Can_query_DateTime_column_in_where_with_format_parameter()
+        {
+            using var db = OpenDbConnection();
+            db.CreateTable<Analyze>(true);
+            var obj = new Analyze
+            {
+                Id = 1,
+                Date = DateTime.Now,
+                Url = "http://www.google.com"
+            };
+            var yesterdayString = obj.Date.AddDays(-1).ToString("yyyy-MM-dd");
+            var todayString = obj.Date.ToString("yyyy-MM-dd");
+            db.Save(obj);
+            var q = db.From<Analyze>().Where(i=>i.Date.ToString("%Y-%m-%d")== yesterdayString);
+            var results = db.Select<Analyze>(q);
+            var sql = q.ToMergedParamsSelectStatement();
+            Assert.That(results.Count, Is.EqualTo(0));
+
+            q = db.From<Analyze>().Where(i => i.Date.ToString("%Y-%m-%d") == todayString);
+            results = db.Select<Analyze>(q);
+            sql = q.ToMergedParamsSelectStatement();
+            Assert.That(results.Count, Is.EqualTo(1));
+
+            var id = (int)db.LastInsertId();
+            var target = db.SingleById<Analyze>(id);
+            Assert.That(target, Is.Not.Null);
+            Assert.That(target.Id, Is.EqualTo(id));
+            Assert.That(target.Date, Is.EqualTo(obj.Date).Within(TimeSpan.FromSeconds(1)));
+            Assert.That(target.Url, Is.EqualTo(obj.Url));
+        }
+
+        [Test]
+        public void Can_query_DateTime_column_in_select_and_where_with_format_parameter()
+        {
+            using var db = OpenDbConnection();
+            db.CreateTable<Analyze>(true);
+            var obj = new Analyze
+            {
+                Id = 1,
+                Date = DateTime.Now,
+                Url = "http://www.google.com"
+            };
+            var yesterdayString = DateTime.Now.AddDays(-1).ToString("yyyy-MM-dd");
+            var todayString = DateTime.Now.ToString("yyyy-MM-dd");
+            db.Save(obj);
+            var q = db.From<Analyze>().Where(i => i.Date.ToString("%Y-%m-%d") == yesterdayString).Select(i=>i.Date.ToString("%Y-%m-%d"));
+            var results = db.Select<string>(q);
+            var sql = q.ToMergedParamsSelectStatement();
+            Assert.That(results.Count, Is.EqualTo(0));
+
+            q = db.From<Analyze>().Where(i => i.Date.ToString() == yesterdayString).Select(i => i.Date.ToString("%Y-%m-%d"));
+            results = db.Select<string>(q);
+            sql = q.ToMergedParamsSelectStatement();
+            Assert.That(results.Count, Is.EqualTo(0));
+
+            q = db.From<Analyze>().Where(i => i.Date.ToString("%Y-%m-%d") == todayString).Select(i => i.Date.ToString("%Y-%m-%d"));
+            results = db.Select<string>(q);
+            sql = q.ToMergedParamsSelectStatement();
+            Assert.That(results.Count, Is.EqualTo(1));
+
+            var target = results.First();
+            Assert.That(target, Is.Not.Null);
+            Assert.That(target, Is.EqualTo(todayString));
+        }
+
         /// <summary>
         /// Provided by RyogoNA in issue #38 https://github.com/ServiceStack/ServiceStack.OrmLite/issues/38#issuecomment-4625178
         /// </summary>


### PR DESCRIPTION
currently, ```ToString``` on ```DateTime``` will ignore any format parameters and always convert to ```cast({quotedColName} as char(1000))```,but most developers (at least in our opinion) want to convert according to the specified format and use it in ```Where``` or ```Select```.

this commit achieves this goal by passing the ```ToString``` parameter as it is to the ```DateFormat``` function of Mysql.