### PR TITLE
To insert statement dbnull check

### DIFF
--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -1614,7 +1614,7 @@ namespace ServiceStack.OrmLite
 
         public virtual string GetQuotedValue(object value, Type fieldType)
         {
-            if (value == null) 
+            if (value == null || value == DBNull.Value) 
                 return "NULL";
 
             var converter = value.GetType().IsEnum

--- a/tests/ServiceStack.OrmLite.Tests/Shared/Person.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Shared/Person.cs
@@ -1,4 +1,5 @@
-﻿using ServiceStack.DataAnnotations;
+﻿using System;
+using ServiceStack.DataAnnotations;
 
 namespace ServiceStack.OrmLite.Tests.Shared
 {
@@ -153,6 +154,51 @@ namespace ServiceStack.OrmLite.Tests.Shared
                 hashCode = (hashCode * 397) ^ (FirstName != null ? FirstName.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (LastName != null ? LastName.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (BestFriend != null ? BestFriend.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+    }
+    
+    public class TestProduct
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public DateTime? Modified { get; set; }
+
+        public static TestProduct[] TestValues =
+        {
+            new TestProduct
+            {
+                Id = "1",
+                Modified = null,
+                Name = "Testing"
+            }
+        };
+        
+        protected bool Equals(TestProduct other)
+        {
+            return Id == other.Id &&
+                   string.Equals(Name, other.Name) &&
+                   Modified.Equals(other.Modified);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TestProduct)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (Id != null ? Id.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Name != null ? Name.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Modified != null ? Modified.GetHashCode() : 0);
                 return hashCode;
             }
         }

--- a/tests/ServiceStack.OrmLite.Tests/Shared/Person.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Shared/Person.cs
@@ -119,6 +119,13 @@ namespace ServiceStack.OrmLite.Tests.Shared
                 FirstName = "Test",
                 LastName = "McTest",
                 Id = 1
+            },
+            new PersonWithReferenceType
+            {
+                FirstName = "John",
+                LastName = "Doe",
+                Id = 2,
+                BestFriend = new Person(1,"Jane","Doe",33)
             }
         };
         

--- a/tests/ServiceStack.OrmLite.Tests/Shared/Person.cs
+++ b/tests/ServiceStack.OrmLite.Tests/Shared/Person.cs
@@ -105,4 +105,49 @@ namespace ServiceStack.OrmLite.Tests.Shared
         Male
     }
 
+    public class PersonWithReferenceType
+    {
+        public int Id { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public Person BestFriend { get; set; }
+
+        public static PersonWithReferenceType[] TestValues = new[]
+        {
+            new PersonWithReferenceType
+            {
+                FirstName = "Test",
+                LastName = "McTest",
+                Id = 1
+            }
+        };
+        
+        protected bool Equals(PersonWithReferenceType other)
+        {
+            return Id == other.Id &&
+                   string.Equals(FirstName, other.FirstName) &&
+                   string.Equals(LastName, other.LastName) &&
+                   ((BestFriend == null && other.BestFriend == null) || (BestFriend != null && BestFriend.Equals(other.BestFriend))) ;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((PersonWithReferenceType)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Id;
+                hashCode = (hashCode * 397) ^ (FirstName != null ? FirstName.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (LastName != null ? LastName.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (BestFriend != null ? BestFriend.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+    }
 }

--- a/tests/ServiceStack.OrmLite.Tests/ToInsertAndUpdateStatementTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/ToInsertAndUpdateStatementTests.cs
@@ -62,5 +62,22 @@ namespace ServiceStack.OrmLite.Tests
                 Assert.That(insertedRow.Equals(row));
             }
         }
+        
+        [Test]
+        public void Correct_Ref_in_ToInsertStatement()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<PersonWithReferenceType>();
+                var row = PersonWithReferenceType.TestValues[1];
+
+                var sql = db.ToInsertStatement(row);
+                sql.Print();
+                db.ExecuteSql(sql);
+
+                var insertedRow = db.SingleById<PersonWithReferenceType>(row.Id);
+                Assert.That(insertedRow.Equals(row));
+            }
+        }
     }
 }

--- a/tests/ServiceStack.OrmLite.Tests/ToInsertAndUpdateStatementTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/ToInsertAndUpdateStatementTests.cs
@@ -79,5 +79,22 @@ namespace ServiceStack.OrmLite.Tests
                 Assert.That(insertedRow.Equals(row));
             }
         }
+        
+        [Test]
+        public void Correct_nullable_in_ToInsertStatement()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<TestProduct>();
+                var row = TestProduct.TestValues[0];
+
+                var sql = db.ToInsertStatement(row);
+                sql.Print();
+                db.ExecuteSql(sql);
+
+                var insertedRow = db.SingleById<TestProduct>(row.Id);
+                Assert.AreEqual(insertedRow, row);
+            }
+        }
     }
 }

--- a/tests/ServiceStack.OrmLite.Tests/ToInsertAndUpdateStatementTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/ToInsertAndUpdateStatementTests.cs
@@ -45,5 +45,22 @@ namespace ServiceStack.OrmLite.Tests
                 Assert.That(insertedRow.Equals(row));
             }
         }
+
+        [Test]
+        public void Correct_DbNull_in_ToInsertStatement()
+        {
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<PersonWithReferenceType>();
+                var row = PersonWithReferenceType.TestValues[0];
+
+                var sql = db.ToInsertStatement(row);
+                sql.Print();
+                db.ExecuteSql(sql);
+
+                var insertedRow = db.SingleById<PersonWithReferenceType>(row.Id);
+                Assert.That(insertedRow.Equals(row));
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix for when table class has reference type (treated as TEXT or JSON column) and is provided null. Previously generated `{}` for null values with if inserted and then retrieved results in different instance values.

Added 2 tests.