### PR TITLE
Fix in InsertOnly for param greater than default length

### DIFF
--- a/src/ServiceStack.OrmLite.Firebird/FirebirdOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.Firebird/FirebirdOrmLiteDialectProvider.cs
@@ -161,8 +161,7 @@ namespace ServiceStack.OrmLite.Firebird
                     sbColumnNames.Append(GetQuotedColumnName(fieldDef.FieldName));
                     sbColumnValues.Append(this.GetParam(SanitizeFieldNameForParamName(fieldDef.FieldName)));
 
-                    var p = AddParameter(cmd, fieldDef);
-                    p.Value = GetFieldValue(fieldDef, fieldDef.GetValue(objWithProperties)) ?? DBNull.Value;
+                    AddParameter(cmd, fieldDef);
                 }
                 catch (Exception ex)
                 {

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerOrmLiteDialectProvider.cs
@@ -323,8 +323,7 @@ namespace ServiceStack.OrmLite.SqlServer
                     sbColumnNames.Append(GetQuotedColumnName(fieldDef.FieldName));
                     sbColumnValues.Append(this.GetParam(SanitizeFieldNameForParamName(fieldDef.FieldName)));
 
-                    var p = AddParameter(cmd, fieldDef);
-                    p.Value = GetFieldValue(fieldDef, fieldDef.GetValue(objWithProperties)) ?? DBNull.Value;
+                    AddParameter(cmd, fieldDef);
                 }
                 catch (Exception ex)
                 {

--- a/src/ServiceStack.OrmLite/Async/WriteExpressionCommandExtensionsAsync.cs
+++ b/src/ServiceStack.OrmLite/Async/WriteExpressionCommandExtensionsAsync.cs
@@ -138,7 +138,11 @@ namespace ServiceStack.OrmLite
         {
             OrmLiteConfig.InsertFilter?.Invoke(dbCmd, obj);
 
-            var sql = dbCmd.GetDialectProvider().ToInsertRowStatement(dbCmd, obj, onlyFields);
+            var dialectProvider = dbCmd.GetDialectProvider();
+            var sql = dialectProvider.ToInsertRowStatement(dbCmd, obj, onlyFields);
+
+            dialectProvider.SetParameterValues<T>(dbCmd, obj);
+
             return dbCmd.ExecuteSqlAsync(sql, token);
         }
 

--- a/src/ServiceStack.OrmLite/Expressions/WriteExpressionCommandExtensions.cs
+++ b/src/ServiceStack.OrmLite/Expressions/WriteExpressionCommandExtensions.cs
@@ -230,6 +230,8 @@ namespace ServiceStack.OrmLite
             var dialectProvider = dbCmd.GetDialectProvider();
             var sql = dialectProvider.ToInsertRowStatement(dbCmd, obj, onlyFields);
 
+            dialectProvider.SetParameterValues<T>(dbCmd, obj);
+
             if (selectIdentity)
                 return dbCmd.ExecLongScalar(sql + dialectProvider.GetLastInsertIdSqlSuffix<T>());
 

--- a/src/ServiceStack.OrmLite/Legacy/WriteExpressionCommandExtensionsAsyncLegacy.cs
+++ b/src/ServiceStack.OrmLite/Legacy/WriteExpressionCommandExtensionsAsyncLegacy.cs
@@ -55,7 +55,11 @@ namespace ServiceStack.OrmLite.Legacy
             if (OrmLiteConfig.InsertFilter != null)
                 OrmLiteConfig.InsertFilter(dbCmd, obj);
 
-            var sql = dbCmd.GetDialectProvider().ToInsertRowStatement(dbCmd, obj, onlyFields.InsertFields);
+            var dialectProvider = dbCmd.GetDialectProvider();
+            var sql = dialectProvider.ToInsertRowStatement(dbCmd, obj, onlyFields.InsertFields);
+
+            dialectProvider.SetParameterValues<T>(dbCmd, obj);
+            
             return dbCmd.ExecuteSqlAsync(sql, token);
         }
     }

--- a/src/ServiceStack.OrmLite/Legacy/WriteExpressionCommandExtensionsLegacy.cs
+++ b/src/ServiceStack.OrmLite/Legacy/WriteExpressionCommandExtensionsLegacy.cs
@@ -97,7 +97,11 @@ namespace ServiceStack.OrmLite.Legacy
             if (OrmLiteConfig.InsertFilter != null)
                 OrmLiteConfig.InsertFilter(dbCmd, obj);
 
-            var sql = dbCmd.GetDialectProvider().ToInsertRowStatement(dbCmd, obj, onlyFields.InsertFields);
+            var dialectProvider = dbCmd.GetDialectProvider();
+            var sql = dialectProvider.ToInsertRowStatement(dbCmd, obj, onlyFields.InsertFields);
+            
+            dialectProvider.SetParameterValues<T>(dbCmd, obj);
+
             dbCmd.ExecuteSql(sql);
         }
     }

--- a/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
+++ b/src/ServiceStack.OrmLite/OrmLiteDialectProviderBase.cs
@@ -614,8 +614,7 @@ namespace ServiceStack.OrmLite
                     sbColumnNames.Append(GetQuotedColumnName(fieldDef.FieldName));
                     sbColumnValues.Append(this.GetParam(SanitizeFieldNameForParamName(fieldDef.FieldName)));
 
-                    var p = AddParameter(cmd, fieldDef);
-                    p.Value = GetFieldValue(fieldDef, fieldDef.GetValue(objWithProperties)) ?? DBNull.Value;
+                    AddParameter(cmd, fieldDef);
                 }
                 catch (Exception ex)
                 {

--- a/tests/ServiceStack.OrmLite.SqlServer.Tests/Issues/StringLengthParamTests.cs
+++ b/tests/ServiceStack.OrmLite.SqlServer.Tests/Issues/StringLengthParamTests.cs
@@ -40,5 +40,30 @@ namespace ServiceStack.OrmLite.SqlServerTests.Issues
 
             OrmLiteConfig.DialectProvider.GetStringConverter().UseUnicode = hold;
         }
+
+        [Test]
+        public void Can_insert_only_param_greater_than_default_length()
+        {
+            var hold = OrmLiteConfig.DialectProvider.GetStringConverter().UseUnicode;
+            OrmLiteConfig.DialectProvider.GetStringConverter().UseUnicode = true;
+
+            using (var db = OpenDbConnection())
+            {
+                db.DropAndCreateTable<StringLengthParamTest>();
+
+                var name = "a" + new string('b', 8000) + "c";
+
+                db.InsertOnly(new StringLengthParamTest
+                {
+                    Name = name
+                }, s => s.Name);
+
+                var people = db.Select<StringLengthParamTest>(p => p.Name == name);
+
+                Assert.That(people.Count, Is.EqualTo(1));
+            }
+
+            OrmLiteConfig.DialectProvider.GetStringConverter().UseUnicode = hold;
+        }
     }
 }


### PR DESCRIPTION
``InsertOnly`` had different logic than the ``Insert`` method when handling parameter values. Now ``InsertOnly`` also uses ``dialectProvider.SetParameterValues``.