### PR TITLE
Fix NullRefrenceException.

### DIFF
--- a/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
@@ -926,7 +926,7 @@ namespace ServiceStack.OrmLite
             foreach (var field in fields)
             {
                 var tableDef = GetModelDefinition(field);
-                var qualifiedName = modelDef != null
+                var qualifiedName = tableDef != null
                     ? GetQuotedColumnName(tableDef, field.Name)
                     : DialectProvider.GetQuotedColumnName(field);
 


### PR DESCRIPTION
In multi thread environment, run AutoQuery.CreateQuery method with the same From Type will cause null reference.