### PR TITLE
Enhance CustomJoin

### DIFF
--- a/src/ServiceStack.OrmLite/Expressions/SqlExpression.Join.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpression.Join.cs
@@ -31,6 +31,20 @@ namespace ServiceStack.OrmLite
             return allTableDefs;
         }
 
+        public SqlExpression<T> AddReferenceTableIfNotExists<Target>()
+        {
+            var tableDef = typeof(Target).GetModelDefinition();
+            if (!tableDefs.Contains(tableDef))
+                tableDefs.Add(tableDef);
+            return this;
+        }
+
+        public SqlExpression<T> CustomJoin<Target>(string joinString)
+        {
+            AddReferenceTableIfNotExists<Target>();
+            return CustomJoin(joinString);
+        }
+
         public bool IsJoinedTable(Type type)
         {
             return tableDefs.FirstOrDefault(x => x.ModelType == type) != null;


### PR DESCRIPTION
When using ``CustomJoin`` to build complex queries, ``SqlExpression<T>`` will lose the ``Entity`` information it depends on in SQL.

example:
```C#
  public class Result {
     public string From{get;set;}
  }
  public class AssetInfo
    {
        public string DeviceId { get; set; }
    }
  public class Region
    {
		public string Code { get; set; }
    }

```
And
```C#
var q=db.From<Result>()
.LeftJoin<AssetInfo>((x,y)=>x.From==y.DeviceId)
.CustomJoin("LEFT JOIN `Region` ON `AssetInfo`.`DeviceId` LIKE CONCAT(`Region`.`Code`,'%')")
.Where<Result,Region>((x,y)=>y.Code.StartsWith("some_code"));
q.ToMergedParamsSelectStatement(); 
```
The code will throw an exception in  ``SqlExpression.cs``.``private object EvaluateExpression(Expression m)``.
The reason is trying to calculate the result of the expression here, but the ``Region`` .``Code`` field  is null at this time.
By analyzing the call stack, it is found that the expression makes the IsJoinedTable function return false, which causes the code path to enter here.But it is obvious that the way of directly writing SQL cannot make ``Expression<T>`` perceive that additional entities are referenced. 

This PR solves this problem by adding a ``CustomJoin<T>`` overload and adding a ``AddReferenceTableIfNotExists`` function.

```C#
var q=db.From<Result>()
.LeftJoin<AssetInfo>((x,y)=>x.From==y.DeviceId)
.CustomJoin<Region>("LEFT JOIN `Region` ON `AssetInfo`.`DeviceId` LIKE CONCAT(`Region`.`Code`,'%')")
.Where<Result,Region>((x,y)=>y.Code.StartsWith("some_code"));
q.ToMergedParamsSelectStatement();  //work fine
```

PS:
The reason why we use ``CustomJoin`` here is because we found that ``LeftJoin`` does not support advanced operations, such as ``StartsWith``.
```C#
var q=db.From<Result>()
.LeftJoin<AssetInfo>((x,y)=>x.From==y.DeviceId)
.LeftJoin<AssetInfo,Region>((x, y) => x.DeviceId.StartsWith(y.Code))//Here should be a reference to ``Region.Code``, not the field as a constant value 
.Where<Result,Region>((x,y)=>y.Code.StartsWith("some_code"));
q.ToMergedParamsSelectStatement(); 
```
