### PR TITLE
Npgsql is not compatible with version 7 and can result in runtime error

### DIFF
--- a/src/ServiceStack.OrmLite.PostgreSQL/ServiceStack.OrmLite.PostgreSQL.Core.csproj
+++ b/src/ServiceStack.OrmLite.PostgreSQL/ServiceStack.OrmLite.PostgreSQL.Core.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ServiceStack.OrmLite\ServiceStack.OrmLite.Core.csproj" />
     <PackageReference Include="ServiceStack.Common.Core" Version="$(Version)" />
-    <PackageReference Include="Npgsql" Version="5.0.10" />
+    <PackageReference Include="Npgsql" Version="[5.0.10,7.0.0)" /> <!-- Not compatible with version 7 and results in runtime error -->
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Resolves the following exception by limiting version of Npgsql:

> System.TypeLoadException: Could not load type 'NpgsqlTypes.NpgsqlDate' from assembly 'Npgsql,

This range should be included in the package reference.
